### PR TITLE
BET-1405: ROI self-report + Tonight's-budget card

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -40,6 +40,12 @@ import {
   nowCostLabel,
   decisionCards,
   executeSuggestionOption,
+  tonightBudgetMode,
+  nightGauge,
+  providerWindowNotes,
+  forecastAccuracyRows,
+  bindingReserveFrac,
+  budgetTodayUsd,
   type BlockerCard,
   type CtoState,
   type CtoHealthStat,
@@ -102,7 +108,16 @@ type CtoSettingsConfig = {
   ctoTier?: "low" | "medium" | "high";
   ctoAmbientCap?: number;
   ctoDigestPush?: boolean;
+  // BET-1405: the Overnight switch + night pool live in the Behavior card
+  // (shipped with the §11 overnight wiring). The Tonight's-budget card reads
+  // both — the full render is gated on High + Overnight on (§10.5 card 3).
+  ctoOvernight?: boolean;
+  ctoNightCapUsd?: number;
 };
+
+// §11.2 defaults — the same constants ctoBudget.mjs enforces server-side.
+const DEFAULT_AMBIENT_CAP_USD = 2.5;
+const DEFAULT_NIGHT_CAP_USD = 5;
 
 export function CtoPanel({
   state,
@@ -549,16 +564,36 @@ function SettingsView({
   const [capText, setCapText] = useState("");
   const [health, setHealth] = useState<CtoHealthStat[]>([]);
   const [busyPause, setBusyPause] = useState(false);
+  // BET-1405 (§10.5 card 3): budget payload (day buckets + quota cache) and
+  // usage snapshots (provider window notes), read once on settings-open.
+  const [budget, setBudget] = useState<{ days?: Record<string, { usd?: number } | undefined>; quota?: Record<string, { provider?: string; mode?: string | null; reserve?: number | null; mape14?: number | null } | undefined> } | null>(null);
+  const [usageSnaps, setUsageSnaps] = useState<{ provider?: string; windows?: { kind?: string; label?: string; resetsAt?: number | null }[] | null }[]>([]);
 
   useEffect(() => {
     let alive = true;
     void window.api.configGet().then((c) => {
       if (!alive) return;
-      setConfig({ ctoEnabled: !!c?.ctoEnabled, ctoTier: c?.ctoTier, ctoAmbientCap: c?.ctoAmbientCap, ctoDigestPush: !!c?.ctoDigestPush });
-      setCapText(String(c?.ctoAmbientCap ?? 2.5));
+      setConfig({
+        ctoEnabled: !!c?.ctoEnabled,
+        ctoTier: c?.ctoTier,
+        ctoAmbientCap: c?.ctoAmbientCap,
+        ctoDigestPush: !!c?.ctoDigestPush,
+        ctoOvernight: !!c?.ctoOvernight,
+        ctoNightCapUsd: c?.ctoNightCapUsd,
+      });
+      setCapText(String(c?.ctoAmbientCap ?? DEFAULT_AMBIENT_CAP_USD));
     });
     void window.api.ctoHealthGet().then((h) => {
       if (alive) setHealth(h.stats);
+    });
+    // BET-1405 (§10.5 card 3): the persisted budget payload (day buckets +
+    // quota cache) and the usage snapshots (provider window notes) — one read
+    // on settings-open, never polled. Rejections degrade to absent data.
+    void window.api.ctoQuotaRead().then((b) => {
+      if (alive) setBudget(b ?? null);
+    });
+    void window.api.usageList().then((snaps) => {
+      if (alive) setUsageSnaps(Array.isArray(snaps) ? snaps : []);
     });
     return () => {
       alive = false;
@@ -766,7 +801,7 @@ function SettingsView({
             </div>
           </section>
 
-          {/* ---------- Health card (§10.5 card 2, P1 rows) ---------- */}
+          {/* ---------- Health card (§10.5 card 2) ---------- */}
           <section className="rounded-lg border border-border-subtle p-4">
             <h3 className="text-sm font-semibold text-text">Health</h3>
             <ul className="mt-3 divide-y divide-border-subtle">
@@ -780,7 +815,15 @@ function SettingsView({
                       ? "Digest opens · 7d"
                       : id === "pipelineLag"
                       ? "Pipeline lag (close → summary)"
-                      : "Suggestion acceptance · 30d",
+                      : id === "suggestionAcceptance"
+                      ? "Suggestion acceptance · 30d"
+                      : id === "forecastAccuracy"
+                      ? "Forecast accuracy · MAPE 14d"
+                      : id === "capHitsCaused"
+                      ? "Cap-hits caused · 30d"
+                      : id === "reserveFractile"
+                      ? "Reserve fractile"
+                      : "ROI · self-report",
                   value: null,
                   n: 0,
                   min: 1,
@@ -797,6 +840,16 @@ function SettingsView({
               })}
             </ul>
           </section>
+
+          {/* ---------- Tonight's budget (§10.5 card 3, BET-1405) ---------- */}
+          <TonightBudgetCard
+            tier={config?.ctoTier ?? "low"}
+            overnightOn={!!config?.ctoOvernight}
+            ambientCapUsd={config?.ctoAmbientCap ?? DEFAULT_AMBIENT_CAP_USD}
+            nightCapUsd={config?.ctoNightCapUsd ?? DEFAULT_NIGHT_CAP_USD}
+            budget={budget}
+            usageSnaps={usageSnaps}
+          />
 
           {/* ---------- Internals: Profile & rhythm + Activity ledger ---------- */}
           <section className="rounded-lg border border-border-subtle p-4">
@@ -834,7 +887,161 @@ function SettingsView({
   );
 }
 
-const HEALTH_ROW_ORDER = ["ambientSpendToday", "digestOpens", "pipelineLag", "suggestionAcceptance"] as const;
+// §10.5 card 2 render order. BET-1400's forecast/cap-hit/reserve rows and
+// BET-1405's ROI row (last — the self-report closes the list).
+const HEALTH_ROW_ORDER = [
+  "ambientSpendToday",
+  "digestOpens",
+  "pipelineLag",
+  "suggestionAcceptance",
+  "forecastAccuracy",
+  "capHitsCaused",
+  "reserveFractile",
+  "roi",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Tonight's-budget card (§10.5 card 3, BET-1405)
+// ---------------------------------------------------------------------------
+type TonightBudgetProps = {
+  tier: "low" | "medium" | "high";
+  overnightOn: boolean;
+  ambientCapUsd: number;
+  nightCapUsd: number;
+  budget: { days?: Record<string, { usd?: number } | undefined>; quota?: Record<string, { provider?: string; mode?: string | null; reserve?: number | null; mape14?: number | null } | undefined> } | null;
+  usageSnaps: { provider?: string; windows?: { kind?: string; label?: string; resetsAt?: number | null }[] | null }[];
+};
+
+function formatResetNote(resetsAt: number | null): string {
+  if (resetsAt == null) return "";
+  const diff = resetsAt - Date.now();
+  if (diff <= 0) return "resetting…";
+  const mins = Math.round(diff / 60_000);
+  if (mins < 60) return `resets in ${mins}m`;
+  const hours = Math.round(mins / 60);
+  return `resets in ${hours}h`;
+}
+
+function TonightBudgetCard({ tier, overnightOn, ambientCapUsd, nightCapUsd, budget, usageSnaps }: TonightBudgetProps) {
+  const mode = tonightBudgetMode({ tier, overnightOn });
+  const usedTodayUsd = budgetTodayUsd(budget ?? null);
+  const notes = providerWindowNotes(usageSnaps);
+  const accuracy = forecastAccuracyRows(budget?.quota ?? null);
+
+  if (mode === "ambient") {
+    return (
+      <section className="rounded-lg border border-border-subtle p-4">
+        <h3 className="text-sm font-semibold text-text">Tonight&apos;s budget</h3>
+        <div className="mt-3 flex items-baseline justify-between gap-3">
+          <span className="text-sm text-text-muted">Ambient spend today</span>
+          <span className="font-mono text-sm text-text">
+            ${usedTodayUsd.toFixed(2)} of ${Number(ambientCapUsd).toFixed(2)} cap
+          </span>
+        </div>
+        <p className="mt-2 text-xs text-text-faint">
+          Overnight work is {overnightOn ? "below the High tier" : "off"} — there is no night pool to gauge.
+        </p>
+        <p className="mt-2 text-xs text-text-faint">Plan editing lives in the tonight drill-down.</p>
+      </section>
+    );
+  }
+
+  // Full render (High + Overnight on): the night-pool gauge with used /
+  // planned segments + the reserve line, legend, window notes, accuracy.
+  const plannedTonightUsd: number | null = null; // §10.4 plan portfolio — wired when the tonight plan lands
+  const reserveFrac = bindingReserveFrac(budget?.quota ?? null);
+  const gauge = nightGauge({ nightCapUsd, usedTodayUsd, plannedTonightUsd, reserveFrac });
+  const usedPct = gauge.poolUsd > 0 ? (gauge.usedUsd / gauge.poolUsd) * 100 : 0;
+  const plannedPct = gauge.poolUsd > 0 ? (gauge.plannedUsd / gauge.poolUsd) * 100 : 0;
+  const reservePct = gauge.reserveLineUsd != null && gauge.poolUsd > 0 ? (gauge.reserveLineUsd / gauge.poolUsd) * 100 : null;
+
+  return (
+    <section className="rounded-lg border border-border-subtle p-4">
+      <h3 className="text-sm font-semibold text-text">Tonight&apos;s budget</h3>
+
+      <div className="mt-3">
+        <div className="relative h-4 w-full overflow-hidden rounded-full bg-fill-active">
+          <div className="absolute inset-y-0 left-0 bg-accent/25" style={{ width: `${Math.min(100, usedPct)}%` }} />
+          <div
+            className="absolute inset-y-0 bg-accent/60"
+            style={{ left: `${Math.min(100, usedPct)}%`, width: `${Math.min(100 - Math.min(100, usedPct), plannedPct)}%` }}
+          />
+          {reservePct != null && (
+            <div
+              className="absolute inset-y-0 w-0.5 bg-warn"
+              style={{ left: `${Math.min(100, reservePct)}%` }}
+              aria-hidden="true"
+            />
+          )}
+        </div>
+        <div className="mt-2 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 text-xs text-text-muted">
+          <span>
+            Used today <span className="font-mono text-text">${gauge.usedUsd.toFixed(2)}</span>
+          </span>
+          <span>
+            Planned tonight{" "}
+            <span className="font-mono text-text">
+              {plannedTonightUsd != null ? `$${gauge.plannedUsd.toFixed(2)}` : "no plan queued"}
+            </span>
+          </span>
+          <span>
+            Night pool <span className="font-mono text-text">${gauge.poolUsd.toFixed(2)}</span>
+            {gauge.overflow ? " · over pool" : ""}
+          </span>
+        </div>
+      </div>
+
+      {/* Legend (§10.5 card 3) */}
+      <ul className="mt-3 space-y-1 text-xs text-text-faint">
+        <li>
+          <span className="mr-1 inline-block h-2 w-4 rounded-sm bg-accent/25 align-middle" /> used today — ambient +
+          overnight spend metered into the same daily buckets
+        </li>
+        <li>
+          <span className="mr-1 inline-block h-2 w-4 rounded-sm bg-accent/60 align-middle" /> planned tonight — the
+          queued plan&apos;s spend estimate
+        </li>
+        <li>
+          <span className="mr-1 inline-block h-2 w-0.5 bg-warn align-middle" /> reserve line — the pool share held
+          back at the active fractile{reserveFrac != null ? ` (P${Math.round(reserveFrac * 100)})` : " (no windowed reserve)"}
+        </li>
+      </ul>
+
+      {/* Provider window notes (§11.2 adapters, via the usage poller) */}
+      {notes.length > 0 && (
+        <div className="mt-3">
+          <div className="text-xs font-medium text-text-muted">Provider windows</div>
+          <ul className="mt-1 space-y-0.5 text-xs text-text-faint">
+            {notes.map((n, i) => (
+              <li key={`${n.provider}-${i}`}>
+                <span className="text-text-muted">{n.provider}</span> · {n.label || "window"}
+                {n.resetsAt != null ? ` · ${formatResetNote(n.resetsAt)}` : ""}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Forecast accuracy (§14.5 cache) */}
+      <div className="mt-3">
+        <div className="text-xs font-medium text-text-muted">Forecast accuracy · MAPE 14d</div>
+        {accuracy.length === 0 ? (
+          <div className="mt-1 text-xs text-text-faint">collecting — no provider forecast history yet</div>
+        ) : (
+          <ul className="mt-1 space-y-0.5 text-xs text-text-faint">
+            {accuracy.map((a) => (
+              <li key={a.provider}>
+                <span className="text-text-muted">{a.provider}</span> · {Math.round(a.mape14 * 100)}%
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <p className="mt-3 text-xs text-text-faint">Read-only — plan editing lives in the tonight drill-down.</p>
+    </section>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Activity ledger drill-down (A12)

--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -1011,7 +1011,7 @@ function TonightBudgetCard({ tier, overnightOn, ambientCapUsd, nightCapUsd, budg
       {notes.length > 0 && (
         <div className="mt-3">
           <div className="text-xs font-medium text-text-muted">Provider windows</div>
-          <ul className="mt-1 space-y-0.5 text-xs text-text-faint">
+          <ul className="mt-1 space-y-1 text-xs text-text-faint">
             {notes.map((n, i) => (
               <li key={`${n.provider}-${i}`}>
                 <span className="text-text-muted">{n.provider}</span> · {n.label || "window"}
@@ -1028,7 +1028,7 @@ function TonightBudgetCard({ tier, overnightOn, ambientCapUsd, nightCapUsd, budg
         {accuracy.length === 0 ? (
           <div className="mt-1 text-xs text-text-faint">collecting — no provider forecast history yet</div>
         ) : (
-          <ul className="mt-1 space-y-0.5 text-xs text-text-faint">
+          <ul className="mt-1 space-y-1 text-xs text-text-faint">
             {accuracy.map((a) => (
               <li key={a.provider}>
                 <span className="text-text-muted">{a.provider}</span> · {Math.round(a.mape14 * 100)}%

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -60,6 +60,7 @@ export const DEMO_UNIMPLEMENTED = [
   "ctoProfileEdit",
   "ctoProfileGet",
   "ctoProfileSuppress",
+  "ctoQuotaRead",
   "ctoResume",
   "ctoStateGet",
   "ctoVerdict",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1573,8 +1573,25 @@ export const httpApi: Api = {
     if (res.status === 401) throw new AuthRequiredError();
     if (!res.ok) return { stats: [] };
     let json: { stats?: CtoHealthStat[] } = {};
-    try { json = (await res.json()) as typeof json; } catch { /* non-JSON */ }
+    try { json = await res.json() as typeof json; } catch { /* non-JSON */ }
     return { stats: Array.isArray(json?.stats) ? json.stats : [] };
+  },
+
+  // RPC `quota:read` (BET-1405) — the persisted budget payload (day buckets +
+  // §11.3 quota cache) for the Tonight's-budget card (§10.5 card 3).
+  ctoQuotaRead: async (): Promise<{
+    days?: Record<string, { usd?: number; calls?: number } | undefined>;
+    quota?: Record<
+      string,
+      { provider?: string; mode?: string | null; reserve?: number | null; spendable?: number | null; mape14?: number | null } | undefined
+    >;
+  } | null> => {
+    try {
+      return await rpc("quota:read");
+    } catch (e) {
+      if (e instanceof AuthRequiredError) throw e;
+      return null;
+    }
   },
 
   // GET /api/cto/ledger (A12) — reverse-chron Activity-ledger page, cursor-

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -441,3 +441,106 @@ it("executeSuggestionOption: failure is reported (not swallowed)", async () => {
   expect(r.ok).toBe(false);
   expect(r.error ?? "").toMatch(/boom/);
 });
+
+// --- BET-1405: Tonight's-budget card selectors (§10.5 card 3) --------------
+
+import {
+  tonightBudgetMode,
+  nightGauge,
+  budgetTodayUsd,
+  bindingReserveFrac,
+  providerWindowNotes,
+  forecastAccuracyRows,
+} from "./ctoView";
+
+describe("tonightBudgetMode", () => {
+  it("is full only at High with Overnight on", () => {
+    expect(tonightBudgetMode({ tier: "high", overnightOn: true })).toBe("full");
+    expect(tonightBudgetMode({ tier: "high", overnightOn: false })).toBe("ambient");
+    expect(tonightBudgetMode({ tier: "medium", overnightOn: true })).toBe("ambient");
+    expect(tonightBudgetMode({ tier: "low", overnightOn: true })).toBe("ambient");
+    expect(tonightBudgetMode(null)).toBe("ambient");
+    expect(tonightBudgetMode({ tier: null, overnightOn: true })).toBe("ambient");
+  });
+});
+
+describe("nightGauge", () => {
+  it("clamps segments into the pool and places the reserve line", () => {
+    const g = nightGauge({ nightCapUsd: 5, usedTodayUsd: 1.5, plannedTonightUsd: 2, reserveFrac: 0.95 });
+    expect(g.poolUsd).toBe(5);
+    expect(g.usedUsd).toBe(1.5);
+    expect(g.plannedUsd).toBe(2);
+    expect(g.reserveLineUsd).toBeCloseTo(4.75);
+    expect(g.overflow).toBe(false);
+  });
+
+  it("flags overflow instead of silently truncating", () => {
+    const g = nightGauge({ nightCapUsd: 5, usedTodayUsd: 4.5, plannedTonightUsd: 2, reserveFrac: null });
+    expect(g.overflow).toBe(true);
+    expect(g.usedUsd).toBe(4.5);
+    expect(g.plannedUsd).toBe(0.5); // clamped to what remains
+  });
+
+  it("handles a zero pool and absent inputs honestly", () => {
+    const g = nightGauge({ nightCapUsd: 0, usedTodayUsd: 3, plannedTonightUsd: null, reserveFrac: null });
+    expect(g.poolUsd).toBe(0);
+    expect(g.usedUsd).toBe(0);
+    expect(g.reserveLineUsd).toBe(null);
+    expect(g.overflow).toBe(true);
+  });
+});
+
+describe("budgetTodayUsd", () => {
+  it("reads today's local-midnight bucket", () => {
+    const d = new Date(2026, 7, 28, 15, 30);
+    const key = String(new Date(2026, 7, 28).getTime());
+    expect(
+      budgetTodayUsd({ days: { [key]: { usd: 1.25 } } }, d.getTime()),
+    ).toBe(1.25);
+    expect(budgetTodayUsd({ days: {} }, d.getTime())).toBe(0);
+    expect(budgetTodayUsd(null, d.getTime())).toBe(0);
+  });
+});
+
+describe("bindingReserveFrac", () => {
+  it("takes the largest windowed reserve and ignores windowless rows", () => {
+    expect(
+      bindingReserveFrac({
+        a: { provider: "a", mode: "forecast", reserve: 0.9 },
+        b: { provider: "b", mode: "forecast", reserve: 0.99 },
+        c: { provider: "c", mode: "windowless", reserve: 1.5 },
+      }),
+    ).toBe(0.99);
+    expect(bindingReserveFrac({ c: { provider: "c", mode: "windowless", reserve: 1.5 } })).toBe(null);
+    expect(bindingReserveFrac(null)).toBe(null);
+  });
+});
+
+describe("providerWindowNotes", () => {
+  it("flattens windows with labels and resets, capped", () => {
+    const notes = providerWindowNotes(
+      [
+        { provider: "claude", windows: [{ kind: "session", label: "5h", resetsAt: 123 }, { kind: "weekly", label: "7d" }] },
+        { provider: "kimi", windows: null },
+        { provider: "", windows: [{ label: "x" }] },
+      ],
+      2,
+    );
+    expect(notes).toHaveLength(2);
+    expect(notes[0]).toEqual({ provider: "claude", label: "5h", resetsAt: 123 });
+    expect(notes[1]).toEqual({ provider: "claude", label: "7d", resetsAt: null });
+  });
+});
+
+describe("forecastAccuracyRows", () => {
+  it("emits only providers with a numeric MAPE", () => {
+    expect(
+      forecastAccuracyRows({
+        a: { provider: "a", mape14: 0.23 },
+        b: { provider: "b", mape14: null },
+        c: { provider: "c" },
+      }),
+    ).toEqual([{ provider: "a", mape14: 0.23 }]);
+    expect(forecastAccuracyRows(null)).toEqual([]);
+  });
+});

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -208,9 +208,10 @@ export function forecastAccuracyRows(
   const rows: ForecastAccuracyRow[] = [];
   for (const q of Object.values(quotaRows)) {
     if (!q || typeof q.provider !== "string" || !q.provider) continue;
-    const mape = Number(q.mape14);
-    if (!Number.isFinite(mape)) continue;
-    rows.push({ provider: q.provider, mape14: mape });
+    // typeof guard, not Number(): Number(null) === 0 would render an absent
+    // forecast as a perfect 0% MAPE.
+    if (typeof q.mape14 !== "number" || !Number.isFinite(q.mape14)) continue;
+    rows.push({ provider: q.provider, mape14: q.mape14 });
   }
   return rows;
 }

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -43,21 +43,37 @@ export const idleBackfill: BackfillState = {
 // shows `collecting (n/k)` and never the number — a stat never displays noise
 // as signal.
 export type CtoHealthStat = {
-  id: "ambientSpendToday" | "digestOpens" | "pipelineLag" | "suggestionAcceptance";
+  id:
+    | "ambientSpendToday"
+    | "digestOpens"
+    | "pipelineLag"
+    | "suggestionAcceptance"
+    // BET-1400 rows (rendered since their server stats landed):
+    | "forecastAccuracy"
+    | "capHitsCaused"
+    | "reserveFractile"
+    // BET-1405 (§12.4): the monthly ROI self-report roll.
+    | "roi";
   label: string;
   value: string | null;
   n: number;
   min: number;
+  // BET-1405: when a not-ready row needs a specific collecting sentence
+  // (e.g. the ROI row's `collecting — first report <date>`), the server
+  // supplies it verbatim; otherwise the generic `collecting (n / min)` renders.
+  collectingText?: string;
 };
 
 // Pure stat-display selector (§10.5): when a stat has not reached its minimum
-// sample size, render `collecting (n / min)` instead of the (possibly noisy)
-// value. Returns the ready flag so the caller can de-emphasize collecting rows.
+// sample size, render `collecting (n / min)` — or the stat's own
+// `collectingText` when the server supplied one — instead of the (possibly
+// noisy) value. Returns the ready flag so the caller can de-emphasize
+// collecting rows.
 export function statDisplay(stat: CtoHealthStat): { text: string; ready: boolean } {
   const ready = stat?.n >= stat?.min && typeof stat?.value === "string" && stat.value !== "";
   if (!ready) {
     return {
-      text: `collecting (${stat?.n ?? 0} / ${stat?.min ?? 0})`,
+      text: stat?.collectingText ?? `collecting (${stat?.n ?? 0} / ${stat?.min ?? 0})`,
       ready: false,
     };
   }
@@ -71,6 +87,132 @@ export function statDisplay(stat: CtoHealthStat): { text: string; ready: boolean
 // epoch-ms the kill switch was thrown, for the banner's "paused at" line.
 export function showPausedBanner(state: CtoState | null): boolean {
   return state?.dot === "paused";
+}
+
+// ---------------------------------------------------------------------------
+// Tonight's-budget card (§10.5 card 3) — BET-1405. Pure selectors over the
+// config + budget payload + usage snapshots; the card component renders them.
+// ---------------------------------------------------------------------------
+
+export type TonightBudgetMode = "full" | "ambient";
+
+export type TonightBudgetGate = {
+  tier?: "low" | "medium" | "high" | null;
+  overnightOn?: boolean | null;
+};
+
+// Render-mode selection (§10.5 card 3): the full gauge (night pool, planned
+// tonight, reserve line) renders ONLY at High with Overnight on. Below that,
+// the card shows ambient spend vs cap only — never a gauge for a pool that
+// cannot run (overnight is off, there is no pool to spend).
+export function tonightBudgetMode(gate: TonightBudgetGate | null): TonightBudgetMode {
+  return gate?.tier === "high" && gate?.overnightOn === true ? "full" : "ambient";
+}
+
+export type NightGaugeInput = {
+  nightCapUsd: number;
+  usedTodayUsd: number;
+  plannedTonightUsd: number | null;
+  reserveFrac: number | null;
+};
+
+export type NightGauge = {
+  poolUsd: number;
+  usedUsd: number;
+  plannedUsd: number;
+  reserveLineUsd: number | null;
+  overflow: boolean;
+};
+
+/**
+ * The night-pool gauge (§10.5 card 3): axis $0 → `ctoNightCapUsd`; segments
+ * [used today][planned tonight] and the reserve line at the fractile — the
+ * pool share held back at the binding provider's active reserve (null when no
+ * windowed reserve exists). All inputs clamp into the pool; `overflow` flags
+ * a used+planned that exceeds it (the gauge never silently truncates).
+ */
+export function nightGauge(input: NightGaugeInput): NightGauge {
+  const pool = Math.max(0, Number(input?.nightCapUsd) || 0);
+  const used = Math.max(0, Number(input?.usedTodayUsd) || 0);
+  const planned = input?.plannedTonightUsd != null ? Math.max(0, Number(input.plannedTonightUsd) || 0) : 0;
+  const overflow = used + planned > pool + 1e-9;
+  const usedClamped = Math.min(used, pool);
+  const plannedClamped = Math.min(planned, Math.max(0, pool - usedClamped));
+  const reserveRaw = Number(input?.reserveFrac);
+  const reserveLineUsd =
+    input?.reserveFrac != null && Number.isFinite(reserveRaw) ? Math.max(0, Math.min(1, reserveRaw)) * pool : null;
+  return { poolUsd: pool, usedUsd: usedClamped, plannedUsd: plannedClamped, reserveLineUsd, overflow };
+}
+
+/** Today's spend from the budget payload (the same day buckets the server
+ *  meters into; day rolls at the viewer's local midnight). */
+export function budgetTodayUsd(
+  payload: { days?: Record<string, { usd?: number } | undefined> } | null | undefined,
+  now = Date.now(),
+): number {
+  const d = new Date(now);
+  const key = String(new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime());
+  const usd = Number(payload?.days?.[key]?.usd);
+  return Number.isFinite(usd) && usd > 0 ? usd : 0;
+}
+
+/** The binding windowed reserve (fraction) — the largest reserve among the
+ *  persisted quota rows with an active reserve; null when none (windowless
+ *  providers hold no reserve — no line renders). */
+export function bindingReserveFrac(
+  quotaRows: Record<string, { provider?: string; mode?: string | null; reserve?: number | null } | undefined> | null | undefined,
+): number | null {
+  if (!quotaRows || typeof quotaRows !== "object") return null;
+  let best: number | null = null;
+  for (const q of Object.values(quotaRows)) {
+    if (!q || q.mode === "windowless") continue;
+    const r = Number(q.reserve);
+    if (!Number.isFinite(r)) continue;
+    if (best == null || r > best) best = r;
+  }
+  return best;
+}
+
+export type ProviderWindowNote = { provider: string; label: string; resetsAt: number | null };
+export type UsageWindowLike = { kind?: string; label?: string; resetsAt?: number | null };
+export type UsageSnapshotLike = { provider?: string; windows?: UsageWindowLike[] | null };
+
+/** Per-provider plan-window notes for the card's legend (§10.5 card 3):
+ *  window label + reset instant from the usage poller's snapshots. Capped at
+ *  `max` notes to keep the card a card. */
+export function providerWindowNotes(snapshots: UsageSnapshotLike[] | null | undefined, max = 6): ProviderWindowNote[] {
+  const snaps = Array.isArray(snapshots) ? snapshots : [];
+  const notes: ProviderWindowNote[] = [];
+  for (const s of snaps) {
+    const provider = typeof s?.provider === "string" && s.provider ? s.provider : null;
+    if (!provider) continue;
+    const windows = Array.isArray(s?.windows) ? s.windows : [];
+    for (const w of windows) {
+      if (!w) continue;
+      const label = typeof w.label === "string" && w.label ? w.label : typeof w.kind === "string" ? w.kind : "";
+      notes.push({ provider, label, resetsAt: typeof w.resetsAt === "number" ? w.resetsAt : null });
+    }
+  }
+  return notes.slice(0, Math.max(0, max));
+}
+
+export type ForecastAccuracyRow = { provider: string; mape14: number };
+
+/** Forecast-accuracy rows (§14.5 cache) from the persisted quota state — only
+ *  providers with a numeric 14-day MAPE speak; the rest are absent (never
+ *  rendered as 0%). */
+export function forecastAccuracyRows(
+  quotaRows: Record<string, { provider?: string; mape14?: number | null } | undefined> | null | undefined,
+): ForecastAccuracyRow[] {
+  if (!quotaRows || typeof quotaRows !== "object") return [];
+  const rows: ForecastAccuracyRow[] = [];
+  for (const q of Object.values(quotaRows)) {
+    if (!q || typeof q.provider !== "string" || !q.provider) continue;
+    const mape = Number(q.mape14);
+    if (!Number.isFinite(mape)) continue;
+    rows.push({ provider: q.provider, mape14: mape });
+  }
+  return rows;
 }
 
 // State-dot tone (§10.1): active/disabled/thrifty/paused → ok/tx4/warn/danger.

--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -60,6 +60,7 @@
 import { budgetStore } from "./ctoStores.mjs";
 import { startOfDay } from "./ctoRollups.mjs";
 import { blendedPrice } from "../shared/blendedPrice.mjs";
+import { effectsForVerdict } from "./ctoVerdicts.mjs";
 import {
   forecastNextDayFraction,
   forecastMape,
@@ -415,6 +416,172 @@ export function planReserve({
 }
 
 // ---------------------------------------------------------------------------
+// ROI self-report (§12.4) — BET-1405
+// ---------------------------------------------------------------------------
+//
+// A MONTHLY ledger roll: total CTO spend vs counted outcomes (accepted
+// suggestions, merged CTO branches, incidents where a blocker surfaced before
+// the user hit them) + a tier recommendation. Copy-only — the recommendation
+// never writes the dial; the Health row renders it and the user decides.
+//
+// Data durability drives the shape. The three outcome counters differ:
+//   - spend: budget.json day buckets (durable, indefinite),
+//   - accepted suggestions + incidents: verdicts.json (180d) and the §14.5
+//     ledger (180d) — recomputable for any month inside retention,
+//   - merged branches: delegate jobs are swept after 7 days, so the month's
+//     job list cannot be re-read at month end. Instead every terminal CTO job
+//     is SAMPLED into `budget.roi.pending` (branch + project dir + finish ts)
+//     while the record is fresh; each later refresh probes the project repo
+//     (the existing git read of the project) and counts the merge. A merge
+//     discovered late (the branch was cleaned up days later) still lands on
+//     its finish month.
+//
+// Recommendation rules (deterministic, documented — the roll is labeled
+// self-reported and imperfect counts are acceptable):
+//   - no spend and no outcomes           → stay ("nothing to judge yet")
+//   - spend ≥ $1 and zero outcomes       → lower (money without results)
+//   - outcomes ≥ ROI_MIN_OUTCOMES_RAISE  → raise (earning its keep)
+//   - otherwise                          → stay (hold the current tier)
+
+export const ROI_MIN_OUTCOMES_RAISE = 5;
+export const ROI_MIN_SPEND_USD_LOWER = 1;
+
+export function roiMonthKey(t) {
+  const ts = typeof t === "number" && Number.isFinite(t) ? t : Date.now();
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/** "YYYY-MM" → { startTs, endTs } in local time; endTs exclusive. Bad keys → null. */
+export function monthWindow(key) {
+  const m = /^(\d{4})-(\d{2})$/.exec(String(key ?? ""));
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month0 = Number(m[2]) - 1;
+  if (month0 < 0 || month0 > 11) return null;
+  const startTs = new Date(year, month0, 1, 0, 0, 0, 0).getTime();
+  const endTs = new Date(year, month0 + 1, 1, 0, 0, 0, 0).getTime();
+  return { startTs, endTs };
+}
+
+/** Sum of the day buckets inside a month window (the month's total CTO spend —
+ *  ambient and overnight both meter into the same buckets). */
+export function monthSpendUsd(payload, window) {
+  const startTs = window?.startTs;
+  const endTs = window?.endTs;
+  if (!Number.isFinite(startTs) || !Number.isFinite(endTs)) return 0;
+  const days = normalizeBudget(payload).days;
+  let total = 0;
+  for (const key of Object.keys(days)) {
+    const ts = Number(key);
+    if (!Number.isFinite(ts) || ts < startTs || ts >= endTs) continue;
+    total += dollar(days[key]?.usd);
+  }
+  return dollar(total);
+}
+
+/** Accepted suggestions in a window — the SAME single mapping table the §9.5
+ *  router and the Health acceptance row read, so the roll can never drift
+ *  from what the rest of the system calls "accepted". */
+export function acceptedSuggestions(verdictRows, window) {
+  const startTs = window?.startTs;
+  const endTs = window?.endTs;
+  if (!Number.isFinite(startTs) || !Number.isFinite(endTs)) return 0;
+  const rows = Array.isArray(verdictRows) ? verdictRows : [];
+  return rows.filter((v) => {
+    const ts = typeof v?.ts === "number" && Number.isFinite(v.ts) ? v.ts : NaN;
+    if (!Number.isFinite(ts) || ts < startTs || ts >= endTs) return false;
+    const fx = effectsForVerdict(v.verdict, v.never === true);
+    return fx.success === true && fx.rejection !== true;
+  }).length;
+}
+
+/**
+ * Incidents surfaced before the user hit them (§12.4) — deterministic over
+ * the ledger + segments: a resolved blocker card counts when its card's
+ * source event predates ANY user prompt on the owning session (the segments
+ * store's 30-day retention is the observation horizon). Cards without a
+ * sessionID (health watchdog escalations) cannot be evaluated — excluded,
+ * a documented limitation of this self-reported counter.
+ */
+export function preSurfacedIncidents({ resolvedRows, createdTsByCardId, promptTsBySession, window } = {}) {
+  const startTs = window?.startTs;
+  const endTs = window?.endTs;
+  if (!Number.isFinite(startTs) || !Number.isFinite(endTs)) return 0;
+  const rows = Array.isArray(resolvedRows) ? resolvedRows : [];
+  let count = 0;
+  for (const r of rows) {
+    const ts = typeof r?.ts === "number" && Number.isFinite(r.ts) ? r.ts : NaN;
+    if (!Number.isFinite(ts) || ts < startTs || ts >= endTs) continue;
+    if (r?.kind !== "card.resolved" || r?.variant !== "blocker") continue;
+    const sessionID = typeof r?.sessionID === "string" && r.sessionID ? r.sessionID : null;
+    if (!sessionID) continue;
+    const createdTs = createdTsByCardId?.[r.cardId];
+    const sourceTs = typeof createdTs === "number" && Number.isFinite(createdTs) ? createdTs : ts;
+    const prompts = promptTsBySession?.get?.(sessionID) ?? [];
+    const anyPrior = prompts.some((p) => typeof p === "number" && Number.isFinite(p) && p < sourceTs);
+    if (!anyPrior) count += 1;
+  }
+  return count;
+}
+
+/**
+ * A delegate record's branch merged — pure predicate over the injected git
+ * probe of the project repo:
+ *   - branch gone (`exists === false`) → merged: the cleanup path deletes
+ *     with `git branch -d`, which only succeeds on merged branches — the
+ *     deletion is the merge's fingerprint;
+ *   - branch present and `merge-base --is-ancestor` true → merged locally;
+ *   - otherwise (including a probe failure) → not merged.
+ */
+export function isJobMerged(probe) {
+  if (!probe || typeof probe !== "object") return false;
+  if (probe.exists === false) return true;
+  return probe.isAncestor === true;
+}
+
+/** The monthly recommendation. Copy-only; the dial is never written. */
+export function roiRecommendation({ spendUsd, accepted, merged, incidents } = {}) {
+  const spend = dollar(spendUsd);
+  const outcomes =
+    Math.max(0, Math.trunc(Number(accepted) || 0)) +
+    Math.max(0, Math.trunc(Number(merged) || 0)) +
+    Math.max(0, Math.trunc(Number(incidents) || 0));
+  if (outcomes <= 0 && spend <= 0) return { tier: "stay", reason: "no spend and no counted outcomes yet" };
+  if (outcomes <= 0) return { tier: "lower", reason: `$${spend.toFixed(2)} spent with no counted outcomes` };
+  if (outcomes >= ROI_MIN_OUTCOMES_RAISE) return { tier: "raise", reason: `${outcomes} counted outcomes this month` };
+  return {
+    tier: "stay",
+    reason: `${outcomes} outcome${outcomes === 1 ? "" : "s"} for $${spend.toFixed(2)} — holding`,
+  };
+}
+
+function normalizeRoi(payload) {
+  const p = normalizeQuota(payload);
+  const roi = p.roi && typeof p.roi === "object" ? p.roi : {};
+  const months = roi.months && typeof roi.months === "object" ? roi.months : {};
+  const pending = Array.isArray(roi.pending) ? roi.pending.filter((j) => j && typeof j === "object") : [];
+  return { ...p, roi: { months, pending } };
+}
+
+function monthAccumulator(months, key) {
+  const prev = months[key] && typeof months[key] === "object" ? months[key] : {};
+  return {
+    month: key,
+    spendUsd: dollar(prev.spendUsd),
+    accepted: Math.max(0, Math.trunc(Number(prev.accepted) || 0)),
+    merged: Math.max(0, Math.trunc(Number(prev.merged) || 0)),
+    incidents: Math.max(0, Math.trunc(Number(prev.incidents) || 0)),
+    computedAt: typeof prev.computedAt === "number" && Number.isFinite(prev.computedAt) ? prev.computedAt : 0,
+    frozen: prev.frozen === true,
+  };
+}
+
+// Pending rows older than this are dropped (bounded growth; a merge that
+// surfaced 60 days late is beyond the report's honest horizon).
+export const ROI_PENDING_RETENTION_MS = 60 * 24 * HOUR_MS;
+
+// ---------------------------------------------------------------------------
 // The I/O accessor the engine consumes (injected store + seams).
 // ---------------------------------------------------------------------------
 
@@ -431,6 +598,13 @@ export function createCtoBudget({
   mapeFn = forecastMape,
   cfg = () => ({}), // () => config object (ctoNightCapUsd read here)
   ledger = null, // optional { append(row) } — the §14.5 activity ledger
+  // BET-1405 ROI seams (§12.4 — all injectable; index.mjs wires the real
+  // delegate jobs, the project's git read, verdicts, segments and ledger):
+  jobsRead = async () => [], // () => [{id, actor, status, branch, cwd, finishedAt}]
+  gitProbe = async () => ({ exists: false, isAncestor: false }), // ({cwd, branch}) => {exists, isAncestor}
+  verdictsRead = async () => [], // () => [{verdict, never, ts}]
+  segmentsRead = async () => [], // () => [{sessionID, events: [{t, kind}]}]
+  ledgerRead = async () => [], // () => ledger rows [{kind, ts, ...}]
 } = {}) {
   async function load() {
     try {
@@ -590,6 +764,200 @@ export function createCtoBudget({
     return { ok: true };
   }
 
+  // --- ROI self-report (§12.4, BET-1405) ---------------------------------
+
+  // Per-session user prompt timestamps from the segments store (30d horizon —
+  // the observation window the incidents heuristic is honest about).
+  async function promptTsBySession() {
+    let segments = [];
+    try {
+      segments = (await segmentsRead()) ?? [];
+    } catch {
+      segments = [];
+    }
+    const bySession = new Map();
+    for (const s of segments) {
+      if (!s || typeof s.sessionID !== "string" || !s.sessionID) continue;
+      const events = Array.isArray(s.events) ? s.events : [];
+      const list = bySession.get(s.sessionID) ?? [];
+      for (const ev of events) {
+        if (ev?.kind !== "prompt") continue;
+        const t = typeof ev.t === "number" && Number.isFinite(ev.t) ? ev.t : NaN;
+        if (Number.isFinite(t)) list.push(t);
+      }
+      bySession.set(s.sessionID, list);
+    }
+    return bySession;
+  }
+
+  // Recompute one month's store-derived counters (spend/accepted/incidents)
+  // and attach the accumulated merged count + the copy-only recommendation.
+  async function computeMonth(acc, t) {
+    const window = monthWindow(acc.month);
+    if (!window) return acc;
+    let payload = null;
+    try {
+      payload = await load();
+    } catch {
+      payload = normalizeQuota(defaultBudgetPayload());
+    }
+    let verdicts = [];
+    try {
+      verdicts = (await verdictsRead()) ?? [];
+    } catch {
+      verdicts = [];
+    }
+    let ledgerRows = [];
+    try {
+      ledgerRows = (await ledgerRead()) ?? [];
+    } catch {
+      ledgerRows = [];
+    }
+    const createdTsByCardId = {};
+    for (const r of ledgerRows) {
+      if (r?.kind === "card.created" && typeof r?.cardId === "string" && typeof r?.ts === "number" && Number.isFinite(r.ts)) {
+        const prev = createdTsByCardId[r.cardId];
+        createdTsByCardId[r.cardId] = typeof prev === "number" ? Math.min(prev, r.ts) : r.ts;
+      }
+    }
+    const prompts = await promptTsBySession();
+    const resolved = ledgerRows.filter((r) => r?.kind === "card.resolved");
+    const spend = monthSpendUsd(payload, window);
+    const accepted = acceptedSuggestions(verdicts, window);
+    const incidents = preSurfacedIncidents({
+      resolvedRows: resolved,
+      createdTsByCardId,
+      promptTsBySession: prompts,
+      window,
+    });
+    const merged = acc.merged;
+    return {
+      ...acc,
+      spendUsd: spend,
+      accepted,
+      incidents,
+      merged,
+      recommendation: roiRecommendation({ spendUsd: spend, accepted, merged, incidents }),
+      computedAt: t,
+    };
+  }
+
+  /**
+   * Advance the monthly roll (§12.4). Idempotent per refresh; safe to call on
+   * every health read. Samples fresh terminal CTO jobs into `roi.pending`
+   * (the jobs store sweeps after 7 days — the branch names are the durable
+   * record), probes pending branches against the project repo, and recomputes
+   * the store-derived counters: the current month on every refresh, the
+   * previous month once after it closes (frozen thereafter). Persisted
+   * best-effort — a store failure degrades the report, never the caller.
+   */
+  async function refreshRoi() {
+    const t = typeof now === "function" ? now() : Date.now();
+    let payload;
+    try {
+      payload = normalizeRoi(await store.load());
+    } catch {
+      payload = normalizeRoi(defaultBudgetPayload());
+    }
+    const months = { ...payload.roi.months };
+    const pending = payload.roi.pending.map((j) => ({ ...j }));
+
+    // 1. Sample terminal CTO-actor jobs not yet snapshotted.
+    let jobs = [];
+    try {
+      jobs = (await jobsRead()) ?? [];
+    } catch {
+      jobs = [];
+    }
+    const known = new Set(pending.filter((j) => j.counted !== true).map((j) => j.id));
+    for (const j of jobs) {
+      if (!j || j.actor !== "cto" || j.status !== "done") continue;
+      if (typeof j.branch !== "string" || !j.branch) continue;
+      if (typeof j.id !== "string" || !j.id || known.has(j.id)) continue;
+      pending.push({
+        id: j.id,
+        branch: j.branch,
+        cwd: typeof j.cwd === "string" ? j.cwd : "",
+        finishedAt: typeof j.finishedAt === "number" && Number.isFinite(j.finishedAt) ? j.finishedAt : null,
+        counted: false,
+      });
+    }
+
+    // 2. Probe pending branches (merged = branch deleted-on-merge, or present
+    //    and an ancestor of the project's HEAD). Probe failures leave the row
+    //    uncounted for a later refresh.
+    for (const row of pending) {
+      if (row.counted === true) continue;
+      let probe = { exists: false, isAncestor: false };
+      try {
+        probe = (await gitProbe({ cwd: row.cwd, branch: row.branch })) ?? probe;
+      } catch {
+        probe = { exists: false, isAncestor: false };
+      }
+      if (isJobMerged(probe)) {
+        const key = roiMonthKey(typeof row.finishedAt === "number" ? row.finishedAt : t);
+        const acc = monthAccumulator(months, key);
+        acc.merged += 1;
+        months[key] = acc;
+        row.counted = true;
+      }
+    }
+
+    // 3. Recompute the store-derived counters: current month every refresh;
+    //    the previous month once after it closes, then frozen.
+    const currentKey = roiMonthKey(t);
+    const currentWindow = monthWindow(currentKey);
+    const prevKey = currentWindow ? roiMonthKey(currentWindow.startTs - 1) : null;
+    const toCompute = [currentKey];
+    if (prevKey && months[prevKey]?.frozen !== true) toCompute.push(prevKey);
+    for (const key of toCompute) {
+      const acc = monthAccumulator(months, key);
+      const isCurrent = key === currentKey;
+      months[key] = await computeMonth({ ...acc, frozen: !isCurrent }, t);
+    }
+
+    // 4. Hygiene: drop stale pending rows.
+    const cutoff = t - ROI_PENDING_RETENTION_MS;
+    const kept = pending.filter((j) => j.counted === true ? (typeof j.finishedAt === "number" ? j.finishedAt >= cutoff : true) : true);
+    const trimmed = kept.slice(-200);
+
+    try {
+      await save({ ...payload, roi: { months, pending: trimmed } });
+    } catch {
+      /* ROI persistence is best-effort */
+    }
+    return { months, pending: trimmed };
+  }
+
+  /** The render model for the Health ROI row (§12.4): the most recent CLOSED
+   *  month's roll, or `collecting — first report <date>` until the first
+   *  monthly roll lands (the end of the month of first recorded spend). */
+  async function roiSnapshot() {
+    const t = typeof now === "function" ? now() : Date.now();
+    let payload;
+    try {
+      payload = normalizeRoi(await store.load());
+    } catch {
+      payload = normalizeRoi(defaultBudgetPayload());
+    }
+    const months = payload.roi.months;
+    const dayKeys = Object.keys(payload.days)
+      .map((k) => Number(k))
+      .filter((n) => Number.isFinite(n))
+      .sort((a, b) => a - b);
+    const firstActivityTs = dayKeys.length ? dayKeys[0] : null;
+    const currentKey = roiMonthKey(t);
+    const currentWindow = monthWindow(currentKey);
+    const prevKey = currentWindow ? roiMonthKey(currentWindow.startTs - 1) : null;
+    const roll = prevKey ? (months[prevKey] ?? null) : null;
+    return {
+      month: roll ? prevKey : null,
+      roll,
+      collectingUntil:
+        firstActivityTs != null ? (monthWindow(roiMonthKey(firstActivityTs))?.endTs ?? null) : null,
+    };
+  }
+
   return {
     record,
     payload: load,
@@ -600,5 +968,7 @@ export function createCtoBudget({
     didDayRoll: async () => didDayRoll(await load(), now()),
     computeSpendable,
     recordCapHit,
+    refreshRoi,
+    roiSnapshot,
   };
 }

--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -548,7 +548,9 @@ export function roiRecommendation({ spendUsd, accepted, merged, incidents } = {}
     Math.max(0, Math.trunc(Number(merged) || 0)) +
     Math.max(0, Math.trunc(Number(incidents) || 0));
   if (outcomes <= 0 && spend <= 0) return { tier: "stay", reason: "no spend and no counted outcomes yet" };
-  if (outcomes <= 0) return { tier: "lower", reason: `$${spend.toFixed(2)} spent with no counted outcomes` };
+  if (outcomes <= 0 && spend >= ROI_MIN_SPEND_USD_LOWER) {
+    return { tier: "lower", reason: `$${spend.toFixed(2)} spent with no counted outcomes` };
+  }
   if (outcomes >= ROI_MIN_OUTCOMES_RAISE) return { tier: "raise", reason: `${outcomes} counted outcomes this month` };
   return {
     tier: "stay",
@@ -792,27 +794,36 @@ export function createCtoBudget({
 
   // Recompute one month's store-derived counters (spend/accepted/incidents)
   // and attach the accumulated merged count + the copy-only recommendation.
+  // Returns null when ANY source read failed — a month whose sources could
+  // not be read must never persist as frozen zeros (noise as signal).
   async function computeMonth(acc, t) {
     const window = monthWindow(acc.month);
-    if (!window) return acc;
+    if (!window) return null;
     let payload = null;
+    let verdicts = null;
+    let ledgerRows = null;
+    let prompts = null;
     try {
       payload = await load();
     } catch {
-      payload = normalizeQuota(defaultBudgetPayload());
+      payload = null;
     }
-    let verdicts = [];
     try {
       verdicts = (await verdictsRead()) ?? [];
     } catch {
-      verdicts = [];
+      verdicts = null;
     }
-    let ledgerRows = [];
     try {
       ledgerRows = (await ledgerRead()) ?? [];
     } catch {
-      ledgerRows = [];
+      ledgerRows = null;
     }
+    try {
+      prompts = await promptTsBySession();
+    } catch {
+      prompts = null;
+    }
+    if (!payload || verdicts == null || ledgerRows == null || prompts == null) return null;
     const createdTsByCardId = {};
     for (const r of ledgerRows) {
       if (r?.kind === "card.created" && typeof r?.cardId === "string" && typeof r?.ts === "number" && Number.isFinite(r.ts)) {
@@ -820,7 +831,6 @@ export function createCtoBudget({
         createdTsByCardId[r.cardId] = typeof prev === "number" ? Math.min(prev, r.ts) : r.ts;
       }
     }
-    const prompts = await promptTsBySession();
     const resolved = ledgerRows.filter((r) => r?.kind === "card.resolved");
     const spend = monthSpendUsd(payload, window);
     const accepted = acceptedSuggestions(verdicts, window);
@@ -869,7 +879,9 @@ export function createCtoBudget({
     } catch {
       jobs = [];
     }
-    const known = new Set(pending.filter((j) => j.counted !== true).map((j) => j.id));
+    // Every pending id — counted or not — is a dedupe fingerprint: a job
+    // already snapshotted (and probed) must never re-sample.
+    const known = new Set(pending.map((j) => j.id));
     for (const j of jobs) {
       if (!j || j.actor !== "cto" || j.status !== "done") continue;
       if (typeof j.branch !== "string" || !j.branch) continue;
@@ -913,7 +925,8 @@ export function createCtoBudget({
     for (const key of toCompute) {
       const acc = monthAccumulator(months, key);
       const isCurrent = key === currentKey;
-      months[key] = await computeMonth({ ...acc, frozen: !isCurrent }, t);
+      const computed = await computeMonth({ ...acc, frozen: !isCurrent }, t);
+      if (computed) months[key] = computed;
     }
 
     // 4. Hygiene: drop stale pending rows.

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -405,3 +405,269 @@ test("recordCapHit writes a cto.cap_hit ledger row", async () => {
   assert.equal(ledgerRows[0].provider, "claude");
   assert.equal(ledgerRows[0].pct, 100);
 });
+
+// ---------------------------------------------------------------------------
+// BET-1405 — ROI monthly roll (§12.4)
+// ---------------------------------------------------------------------------
+
+import {
+  ROI_MIN_OUTCOMES_RAISE,
+  ROI_MIN_SPEND_USD_LOWER,
+  ROI_PENDING_RETENTION_MS,
+  roiMonthKey,
+  monthWindow,
+  monthSpendUsd,
+  acceptedSuggestions,
+  preSurfacedIncidents,
+  isJobMerged,
+  roiRecommendation,
+} from "./ctoBudget.mjs";
+
+const AUG_KEY = roiMonthKey(MIDNIGHT); // 2026-08 local
+const JUL_KEY = "2026-07";
+
+test("roiMonthKey + monthWindow are local-month consistent", () => {
+  assert.equal(AUG_KEY, "2026-08");
+  const w = monthWindow(AUG_KEY);
+  assert.equal(w.startTs, new Date(2026, 7, 1).getTime()); // Aug 1, local
+  assert.equal(w.endTs, monthWindow("2026-09").startTs); // Aug has 31 days
+  assert.equal(monthWindow("nope"), null);
+  assert.equal(monthWindow("2026-13"), null);
+  assert.equal(monthWindow(undefined), null);
+});
+
+test("monthSpendUsd sums only the buckets inside the month window", () => {
+  let p = defaultBudgetPayload();
+  p = recordSpend(p, { now: MIDNIGHT + 3_600_000, usd: 1.25 }); // Aug 28
+  p = recordSpend(p, { now: dayStart(-5) + 3_600_000, usd: 0.75 }); // Aug 23
+  p = recordSpend(p, { now: dayStart(-40) + 3_600_000, usd: 9.99 }); // July
+  assert.equal(monthSpendUsd(p, monthWindow(AUG_KEY)), 2.0);
+  assert.equal(monthSpendUsd(p, monthWindow(JUL_KEY)), 9.99);
+  assert.equal(monthSpendUsd(p, null), 0);
+});
+
+test("acceptedSuggestions reuses the §9.5 verdict mapping (never-flag ≠ accept)", () => {
+  const w = monthWindow(AUG_KEY);
+  const rows = [
+    { verdict: "accept", ts: MIDNIGHT + 1_000 },
+    { verdict: "edit", ts: MIDNIGHT + 2_000 },
+    { verdict: "dismiss", ts: MIDNIGHT + 3_000 },
+    { verdict: "accept", never: true, ts: MIDNIGHT + 4_000 },
+    { verdict: "accept", ts: dayStart(-40) }, // outside window
+    { verdict: "accept", ts: undefined },
+  ];
+  assert.equal(acceptedSuggestions(rows, w), 2);
+  assert.equal(acceptedSuggestions([], w), 0);
+  assert.equal(acceptedSuggestions(rows, null), 0);
+});
+
+test("preSurfacedIncidents: resolved blocker whose source event predates any user prompt on the session counts", () => {
+  const w = monthWindow(AUG_KEY);
+  const resolvedRows = [
+    { kind: "card.resolved", variant: "blocker", cardId: "c1", sessionID: "s1", ts: MIDNIGHT + 2 * 86_400_000 },
+    { kind: "card.resolved", variant: "blocker", cardId: "c2", sessionID: "s2", ts: MIDNIGHT + 2 * 86_400_000 },
+    { kind: "card.resolved", variant: "blocker", cardId: "c3", sessionID: null, ts: MIDNIGHT + 2 * 86_400_000 }, // health — no sessionID, excluded
+    { kind: "card.resolved", variant: "question", cardId: "c4", sessionID: "s4", ts: MIDNIGHT + 2 * 86_400_000 }, // not a blocker
+    { kind: "card.resolved", variant: "blocker", cardId: "c5", sessionID: "s5", ts: dayStart(-40) }, // outside window
+  ];
+  const createdTsByCardId = { c1: MIDNIGHT + 1 * 86_400_000, c2: MIDNIGHT - 10 * 86_400_000, c5: dayStart(-40) };
+  const promptTsBySession = new Map([
+    // s1: no prompt before the card existed → counts
+    // s2: user was already on the session 12 days before the card → does NOT count
+    ["s2", [MIDNIGHT - 12 * 86_400_000]],
+  ]);
+  assert.equal(
+    preSurfacedIncidents({ resolvedRows, createdTsByCardId, promptTsBySession, window: w }),
+    1,
+  );
+});
+
+test("preSurfacedIncidents: missing creation row falls back to the resolution ts", () => {
+  const w = monthWindow(AUG_KEY);
+  const count = preSurfacedIncidents({
+    resolvedRows: [{ kind: "card.resolved", variant: "blocker", cardId: "cx", sessionID: "sx", ts: MIDNIGHT + 86_400_000 }],
+    createdTsByCardId: {},
+    promptTsBySession: new Map([["sx", [MIDNIGHT + 86_400_000 - 1]]]),
+    window: w,
+  });
+  assert.equal(count, 0); // a prompt one ms before the fallback source ts disqualifies
+});
+
+test("isJobMerged: branch gone counts as merged; present needs merge-base ancestry", () => {
+  assert.equal(isJobMerged({ exists: false, isAncestor: false }), true);
+  assert.equal(isJobMerged({ exists: true, isAncestor: true }), true);
+  assert.equal(isJobMerged({ exists: true, isAncestor: false }), false);
+  assert.equal(isJobMerged({ exists: true }), false);
+  assert.equal(isJobMerged(null), false);
+  assert.equal(isJobMerged(undefined), false);
+});
+
+test("roiRecommendation rules: stay / lower / raise / hold", () => {
+  assert.deepEqual(roiRecommendation({ spendUsd: 0, accepted: 0, merged: 0, incidents: 0 }), {
+    tier: "stay",
+    reason: "no spend and no counted outcomes yet",
+  });
+  assert.deepEqual(roiRecommendation({ spendUsd: 1.5, accepted: 0, merged: 0, incidents: 0 }), {
+    tier: "lower",
+    reason: "$1.50 spent with no counted outcomes",
+  });
+  assert.deepEqual(roiRecommendation({ spendUsd: 0.2, accepted: 0, merged: 0, incidents: 0 }), {
+    tier: "stay",
+    reason: "0 outcomes for $0.20 — holding",
+  });
+  assert.equal(
+    roiRecommendation({ spendUsd: 3, accepted: ROI_MIN_OUTCOMES_RAISE - 1, merged: 1, incidents: 0 }).tier,
+    "raise",
+  );
+  assert.equal(
+    roiRecommendation({ spendUsd: 3, accepted: 2, merged: 0, incidents: 0 }).tier,
+    "stay",
+  );
+  assert.equal(ROI_MIN_SPEND_USD_LOWER, 1);
+});
+
+test("refreshRoi: samples terminal CTO jobs, probes merges, persists months + pending", async () => {
+  let payload = recordSpend(defaultBudgetPayload(), { now: dayStart(-40), usd: 0.5 }); // July activity
+  const store = {
+    load: async () => payload,
+    save: async (p) => {
+      payload = p;
+    },
+  };
+  const jobs = [
+    { id: "j1", actor: "cto", status: "done", branch: "cto/j1", cwd: "/proj", finishedAt: MIDNIGHT + 86_400_000 },
+    { id: "j2", actor: "cto", status: "done", branch: "cto/j2", cwd: "/proj", finishedAt: MIDNIGHT + 86_400_000 },
+    { id: "j3", actor: "user", status: "done", branch: "u/j3", cwd: "/proj", finishedAt: MIDNIGHT + 86_400_000 }, // not CTO
+    { id: "j4", actor: "cto", status: "running", branch: "cto/j4", cwd: "/proj", finishedAt: null }, // not terminal
+    { id: "j5", actor: "cto", status: "done", branch: null, finishedAt: MIDNIGHT + 86_400_000 }, // no branch
+  ];
+  const probes = {
+    "cto/j1": { exists: false, isAncestor: false }, // deleted-on-merge
+    "cto/j2": { exists: true, isAncestor: false }, // not merged (yet)
+  };
+  const budget = createCtoBudget({
+    store,
+    jobsRead: async () => jobs,
+    gitProbe: async ({ branch }) => probes[branch] ?? { exists: true, isAncestor: false },
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now: () => MIDNIGHT + 2 * 86_400_000,
+  });
+  const r1 = await budget.refreshRoi();
+  assert.equal(r1.pending.length, 2); // j1, j2 sampled
+  assert.equal(r1.months[AUG_KEY].merged, 1); // j1 merged
+  const r2 = await budget.refreshRoi();
+  assert.equal(r2.pending.length, 2);
+  assert.equal(r2.months[AUG_KEY].merged, 1); // idempotent — j1 not double-counted
+  // The Health row renders the latest CLOSED month (July — its spend only),
+  // while August's accumulator keeps the merged count for its own roll.
+  const snap = await budget.roiSnapshot();
+  assert.equal(snap.month, JUL_KEY);
+  assert.equal(snap.roll.merged, 0);
+  assert.equal(snap.roll.spendUsd, 0.5);
+  assert.equal(snap.roll.recommendation.tier, "stay"); // $0.50 with no outcomes — below the $1 lower bar
+  assert.equal(snap.collectingUntil, monthWindow(JUL_KEY).endTs); // first report passed
+});
+
+test("refreshRoi: recomputes the previous month once after it closes, then freezes", async () => {
+  let payload = defaultBudgetPayload();
+  const store = {
+    load: async () => payload,
+    save: async (p) => {
+      payload = p;
+    },
+  };
+  let ledger = [
+    { kind: "card.created", cardId: "c9", ts: dayStart(-40) + 1_000 },
+    { kind: "card.resolved", variant: "blocker", cardId: "c9", sessionID: "s9", ts: dayStart(-40) + 2_000 },
+  ];
+  const budget = createCtoBudget({
+    store,
+    ledgerRead: async () => ledger,
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    jobsRead: async () => [],
+    gitProbe: async () => ({ exists: false, isAncestor: false }),
+    now: () => MIDNIGHT, // Aug 28 — July is closed
+  });
+  await budget.refreshRoi();
+  const july1 = payload.roi.months[JUL_KEY];
+  assert.equal(july1.incidents, 1);
+  assert.equal(july1.frozen, true);
+
+  // A later data change must NOT rewrite a frozen month.
+  ledger = [];
+  await budget.refreshRoi();
+  const july2 = payload.roi.months[JUL_KEY];
+  assert.equal(july2.incidents, 1);
+  assert.equal(july2.frozen, true);
+
+  // The current (open) month recomputes every refresh.
+  const aug = payload.roi.months[AUG_KEY];
+  assert.equal(aug.frozen, false);
+});
+
+test("refreshRoi: store and probe failures degrade without throwing (no frozen zeros)", async () => {
+  const budget = createCtoBudget({
+    store: { load: async () => { throw new Error("disk"); }, save: async () => { throw new Error("disk"); } },
+    jobsRead: async () => { throw new Error("jobs"); },
+    gitProbe: async () => { throw new Error("git"); },
+    ledgerRead: async () => { throw new Error("ledger"); },
+    verdictsRead: async () => { throw new Error("verdicts"); },
+    segmentsRead: async () => { throw new Error("segments"); },
+    now: () => MIDNIGHT,
+  });
+  const r = await budget.refreshRoi();
+  assert.deepEqual(r.months, {}); // failed months are never persisted as zeros
+  const snap = await budget.roiSnapshot();
+  assert.equal(snap.roll, null);
+  assert.equal(snap.collectingUntil, null);
+});
+
+test("roiSnapshot: collectingUntil is the first month's end from the day buckets", async () => {
+  let payload = recordSpend(defaultBudgetPayload(), { now: dayStart(-40), usd: 0.5 });
+  const store = { load: async () => payload, save: async (p) => (payload = p) };
+  const budget = createCtoBudget({
+    store,
+    jobsRead: async () => [],
+    gitProbe: async () => ({ exists: false, isAncestor: false }),
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now: () => MIDNIGHT,
+  });
+  const snap = await budget.roiSnapshot();
+  assert.equal(snap.roll, null); // no refresh ran → no roll stored
+  assert.equal(snap.collectingUntil, monthWindow(JUL_KEY).endTs);
+});
+
+test("pending rows past the retention horizon are dropped", async () => {
+  let payload = defaultBudgetPayload();
+  const store = { load: async () => payload, save: async (p) => (payload = p) };
+  // A stateful jobs reader: the job exists only on the first refresh (the
+  // jobs store sweeps terminal records after 7 days — long before the 60d
+  // pending-retention horizon drops a counted row, so a counted job can
+  // never be re-sampled in reality).
+  let jobsVisible = true;
+  const budget = createCtoBudget({
+    store,
+    jobsRead: async () => {
+      if (!jobsVisible) return [];
+      jobsVisible = false;
+      return [{ id: "old", actor: "cto", status: "done", branch: "cto/old", cwd: "/p", finishedAt: MIDNIGHT - ROI_PENDING_RETENTION_MS - 1 }];
+    },
+    gitProbe: async () => ({ exists: true, isAncestor: false }), // never merges
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now: () => MIDNIGHT,
+  });
+  await budget.refreshRoi();
+  await budget.refreshRoi();
+  assert.equal(payload.roi.pending.length, 1); // uncounted row is kept for later probes
+  payload.roi.pending[0].counted = true;
+  await store.save(payload);
+  await budget.refreshRoi();
+  assert.equal(payload.roi.pending.length, 0); // counted stale row swept
+});

--- a/src/server/ctoHealth.mjs
+++ b/src/server/ctoHealth.mjs
@@ -9,16 +9,16 @@
 // rendered here.
 
 import { effectsForVerdict } from "./ctoVerdicts.mjs";
+import { todaySpend, roiMonthKey } from "./ctoBudget.mjs";
 
 const DAY_MS = 86_400_000;
 
 // Minimum sample sizes (samples, not days). Chosen so a median is meaningful:
 // a week of observed opens for the digest median, a week of summarized
 // segments for the pipeline-lag median, and at least one budget meter reading
-// for the ambient-spend row (the B1 metering that feeds it lands in a later
-// economics issue — until then this row honestly reports `collecting (0/1)`).
-// Suggestion acceptance needs ≥ 10 acceptance-deciding verdicts (BET-1391) so
-// a thumb of a few verdicts never reads as signal.
+// for the ambient-spend row. Suggestion acceptance needs ≥ 10
+// acceptance-deciding verdicts (BET-1391) so a thumb of a few verdicts never
+// reads as signal.
 export const HEALTH_STAT_MIN = Object.freeze({
   ambientSpendToday: 1,
   digestOpens: 7,
@@ -27,7 +27,23 @@ export const HEALTH_STAT_MIN = Object.freeze({
   forecastAccuracy: 1,
   capHitsCaused: 1,
   reserveFractile: 1,
+  roi: 1,
 });
+
+// EN month labels for ROI row copy — deterministic (server locale must not
+// leak into stat text the desktop + mobile render identically).
+const MONTH_LABELS = Object.freeze([
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+]);
+
+/** "2026-07" → "Jul 2026"; anything else → the key unchanged. */
+export function roiMonthLabel(key) {
+  const m = /^(\d{4})-(\d{2})$/.exec(String(key ?? ""));
+  if (!m) return String(key ?? "");
+  const idx = Number(m[2]) - 1;
+  return idx >= 0 && idx < 12 ? `${MONTH_LABELS[idx]} ${m[1]}` : String(key);
+}
 
 function medianOf(values) {
   if (!values.length) return null;
@@ -68,6 +84,9 @@ export async function computeHealthStats({
   listSegments = async () => [],
   verdictsRead = async () => [],
   ctoAmbientCap = 2.5,
+  // BET-1405 (§12.4): async () => { month, roll, collectingUntil } — the
+  // monthly ROI roll; the endpoint refreshes it before this read.
+  roiRead = async () => null,
 } = {}) {
   const t = now();
   const stats = [];
@@ -79,15 +98,19 @@ export async function computeHealthStats({
   } catch {
     budget = null;
   }
-  const todaySpend = budget?.today?.spend;
-  const hasSpend = typeof todaySpend === "number" && Number.isFinite(todaySpend);
+  // The meter is live when the budget store holds any recorded activity —
+  // a quiet today then honestly reads "$0.00 of $2.50 / day".
+  const todaySpent = budget ? todaySpend(budget, t) : 0;
+  const budgetLive =
+    budget != null &&
+    (budget.updatedMs != null || Object.keys(budget.days ?? {}).length > 0);
   stats.push({
     id: "ambientSpendToday",
     label: "Ambient spend today",
     min: HEALTH_STAT_MIN.ambientSpendToday,
-    n: hasSpend ? 1 : 0,
-    value: hasSpend
-      ? `$${todaySpend.toFixed(2)} of $${Number(ctoAmbientCap).toFixed(2)} / day`
+    n: budgetLive ? 1 : 0,
+    value: budgetLive
+      ? `$${todaySpent.toFixed(2)} of $${Number(ctoAmbientCap).toFixed(2)} / day`
       : null,
   });
 
@@ -237,6 +260,44 @@ export async function computeHealthStats({
     n: withFractile ? 1 : 0,
     value: withFractile && fractileLabel ? `${fractileLabel} · ${withFractile.provider ?? "provider"}` : null,
   });
+
+  // 8. ROI self-report (§12.4, BET-1405) — the monthly roll: total CTO spend
+  //    vs counted outcomes + a copy-only tier recommendation. Until the first
+  //    monthly boundary passes the row renders `collecting — first report
+  //    <date>`; the recommendation NEVER writes the dial.
+  let roi = null;
+  try {
+    roi = (await roiRead()) ?? null;
+  } catch {
+    roi = null;
+  }
+  if (roi && roi.roll) {
+    const r = roi.roll;
+    const rec = r.recommendation ?? { tier: "stay", reason: "" };
+    stats.push({
+      id: "roi",
+      label: `ROI · ${roiMonthLabel(roi.month ?? r.month)}`,
+      min: HEALTH_STAT_MIN.roi,
+      n: 1,
+      value: `$${Number(r.spendUsd ?? 0).toFixed(2)} · ${r.accepted ?? 0} accepted · ${r.merged ?? 0} merged · ${r.incidents ?? 0} pre-surfaced — recommend ${rec.tier}: ${rec.reason}`,
+    });
+  } else {
+    const firstReport =
+      roi?.collectingUntil != null
+        ? new Date(roi.collectingUntil)
+        : null;
+    const firstReportText = firstReport
+      ? `${MONTH_LABELS[firstReport.getMonth()]} ${firstReport.getDate()}`
+      : null;
+    stats.push({
+      id: "roi",
+      label: "ROI · self-report",
+      min: HEALTH_STAT_MIN.roi,
+      n: 0,
+      value: null,
+      collectingText: firstReportText ? `collecting — first report ${firstReportText}` : "collecting",
+    });
+  }
 
   return { stats, generatedAt: t };
 }

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -59,14 +59,34 @@ test("ambient spend: budget absent or unpopulated → collecting (0/1)", async (
   assert.equal(s.value, null);
 });
 
+// The budget payload's real shape: day buckets keyed by local-midnight ms
+// (BET-1405 fixed the read — it used to look for a `today` key that never
+// existed, so the row rendered `collecting` forever).
+function localDayKey(ts) {
+  const d = new Date(ts);
+  return String(new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime());
+}
+
 test("ambient spend: with a reading, value renders spend vs cap", async () => {
   const { stats } = await computeHealthStats({
+    now: () => NOW,
     ctoAmbientCap: 2.5,
-    budgetRead: async () => ({ today: { spend: 0.42 } }),
+    budgetRead: async () => ({ days: { [localDayKey(NOW)]: { usd: 0.42, calls: 2 } }, updatedMs: NOW }),
   });
   const s = stats.find((x) => x.id === "ambientSpendToday");
   assert.equal(s.n, 1);
   assert.equal(s.value, "$0.42 of $2.50 / day");
+});
+
+test("ambient spend: live meter with a quiet today renders $0.00", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    ctoAmbientCap: 2.5,
+    budgetRead: async () => ({ days: { [localDayKey(NOW - 3 * DAY)]: { usd: 1.1, calls: 4 } }, updatedMs: NOW - 3 * DAY }),
+  });
+  const s = stats.find((x) => x.id === "ambientSpendToday");
+  assert.equal(s.n, 1);
+  assert.equal(s.value, "$0.00 of $2.50 / day");
 });
 
 test("pipeline lag: collecting until summarized segments accrue", async () => {
@@ -252,4 +272,65 @@ test("BET-1417: windowed row behavior unchanged (mode not surfaced in the value)
     const r = stats.find((s) => s.id === "reserveFractile");
     assert.equal(r.value, "P90 · claude");
   }
+});
+
+// --- BET-1405: the ROI self-report row (§12.4) -----------------------------
+
+test("ROI row: collecting — first report <date> until the first monthly roll", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    roiRead: async () => ({ month: null, roll: null, collectingUntil: NOW + 9 * DAY }),
+  });
+  const r = stats.find((s) => s.id === "roi");
+  assert.equal(r.n, 0);
+  assert.equal(r.min, 1);
+  assert.equal(r.value, null);
+  assert.match(r.collectingText, /^collecting — first report \w+ \d+$/);
+});
+
+test("ROI row: no activity yet → plain collecting (no fabricated date)", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    roiRead: async () => ({ month: null, roll: null, collectingUntil: null }),
+  });
+  const r = stats.find((s) => s.id === "roi");
+  assert.equal(r.value, null);
+  assert.equal(r.collectingText, "collecting");
+});
+
+test("ROI row: renders the month roll with spend, outcomes and recommendation", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    roiRead: async () => ({
+      month: "2026-07",
+      roll: {
+        month: "2026-07",
+        spendUsd: 4.12,
+        accepted: 2,
+        merged: 1,
+        incidents: 0,
+        recommendation: { tier: "stay", reason: "3 outcomes for $4.12 — holding" },
+      },
+      collectingUntil: null,
+    }),
+  });
+  const r = stats.find((s) => s.id === "roi");
+  assert.equal(r.n, 1);
+  assert.equal(r.label, "ROI · Jul 2026");
+  assert.equal(
+    r.value,
+    "$4.12 · 2 accepted · 1 merged · 0 pre-surfaced — recommend stay: 3 outcomes for $4.12 — holding",
+  );
+});
+
+test("ROI row: roiRead failure degrades to collecting, never throws", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    roiRead: async () => {
+      throw new Error("store down");
+    },
+  });
+  const r = stats.find((s) => s.id === "roi");
+  assert.equal(r.value, null);
+  assert.equal(r.collectingText, "collecting");
 });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -7,6 +7,8 @@
 // one less auth surface.
 
 import { createServer } from "node:http";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { readFile, stat, mkdir, rm, readdir } from "node:fs/promises";
 import { createWriteStream, createReadStream } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -2072,6 +2074,52 @@ const adaptiveCtoBudget = ctoBudget.createCtoBudget({
       return {};
     }
   },
+  // BET-1405 ROI roll seams (§12.4): terminal delegate jobs (sampled into
+  // budget.roi.pending before the 7-day jobs sweep), the project repo's git
+  // read (merged-branch detection), verdicts, segments (user-prompt history
+  // for the incidents heuristic) and the §14.5 ledger.
+  jobsRead: async () => {
+    try {
+      const { jobs = [] } = await delegateEngine.listJobs();
+      return jobs;
+    } catch {
+      return [];
+    }
+  },
+  gitProbe: async ({ cwd, branch }) => {
+    const dir = typeof cwd === "string" && cwd ? cwd : null;
+    if (!dir || typeof branch !== "string" || !branch) return { exists: false, isAncestor: false };
+    const runGit = async (args) => {
+      const { stdout } = await promisify(execFile)("git", ["-C", dir, ...args], { timeout: 5000 });
+      return stdout;
+    };
+    try {
+      await runGit(["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`]);
+    } catch {
+      return { exists: false, isAncestor: false };
+    }
+    try {
+      await runGit(["merge-base", "--is-ancestor", branch, "HEAD"]);
+      return { exists: true, isAncestor: true };
+    } catch {
+      return { exists: true, isAncestor: false };
+    }
+  },
+  verdictsRead: async () => (await verdictsStore.load())?.entries ?? [],
+  segmentsRead: async () => {
+    const rows = [];
+    try {
+      for (const name of await readdir(segmentsStore.dir)) {
+        if (!name.endsWith(".json")) continue;
+        const seg = await segmentsStore.load(name.replace(/\.json$/, ""));
+        if (seg && typeof seg === "object") rows.push(seg);
+      }
+    } catch {
+      /* segments dir absent → no prompt history */
+    }
+    return rows;
+  },
+  ledgerRead: () => ledgerStore.read(),
 });
 const adaptiveCtoWatchdog = ctoEngine.createWatchdog({
   engine: adaptiveCto,
@@ -4057,6 +4105,14 @@ const handleRequest = async (req, res) => {
         return rows;
       },
       verdictsRead: async () => (await verdictsStore.load())?.entries ?? [],
+      roiRead: async () => {
+        try {
+          await adaptiveCtoBudget.refreshRoi();
+        } catch {
+          /* the roll degrades to collecting — never fail the health read */
+        }
+        return adaptiveCtoBudget.roiSnapshot();
+      },
         });
         respondJson(res, 200, result);
         return;

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -284,14 +284,23 @@ export type CtoDigest = {
 
 // A single Health-card row (§10.5 card 2, P1 only). `n` is samples seen so
 // far, `min` the minimum sample size before the value may be trusted. While
-// `n < min` the renderer shows `collecting (n/min)` and never the number — a
-// stat never displays noise as signal.
+// `n < min` the renderer shows `collecting (n/min)` — or the row's own
+// `collectingText` when the server supplies one — and never the number.
 export type CtoHealthStat = {
-  id: "ambientSpendToday" | "digestOpens" | "pipelineLag" | "suggestionAcceptance";
+  id:
+    | "ambientSpendToday"
+    | "digestOpens"
+    | "pipelineLag"
+    | "suggestionAcceptance"
+    | "forecastAccuracy"
+    | "capHitsCaused"
+    | "reserveFractile"
+    | "roi";
   label: string;
   value: string | null;
   n: number;
   min: number;
+  collectingText?: string;
 };
 
 // A raw Activity-ledger row (A12 drill-down). Append-only; reverse-chron view.
@@ -1129,6 +1138,16 @@ export interface Api {
   // GET /api/cto/health — the §10.5 Health-card P1 stats (composed by the
   // engine from the ledger + budget + segment stores). Read on settings-open.
   ctoHealthGet(): Promise<{ stats: CtoHealthStat[] }>;
+  // RPC `quota:read` — the persisted budget payload (day buckets + §11.3
+  // per-provider quota cache). Read-only; feeds the Tonight's-budget card
+  // (§10.5 card 3, BET-1405).
+  ctoQuotaRead(): Promise<{
+    days?: Record<string, { usd?: number; calls?: number } | undefined>;
+    quota?: Record<
+      string,
+      { provider?: string; mode?: string | null; reserve?: number | null; spendable?: number | null; mape14?: number | null } | undefined
+    >;
+  } | null>;
   // GET /api/cto/ledger — reverse-chron Activity-ledger drill-down (A12),
   // cursor-paginated with `before` (exclusive ts) and filterable by actor/kind.
   ctoLedgerGet(opts?: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -311,6 +311,14 @@ export type AppConfig = {
   // Adaptive CTO (BET-1386): push the pre-generated digest to the phone (§5.5
   // notify). Off by default.
   ctoDigestPush?: boolean;
+  // Adaptive CTO (BET-1405): the §11 Overnight-work switch — gates the entire
+  // overnight pool; only visible/effective at High (§10.5 card 1). Default off.
+  // NOTE: the Behavior-card control ships with the §11 overnight wiring
+  // (BET-1419); the config key + the Tonight's-budget card's read of it land
+  // here first so both runs converge on the same key.
+  ctoOvernight?: boolean;
+  // Adaptive CTO (BET-1400): the windowless/night $ pool (§11.2). Default 5.
+  ctoNightCapUsd?: number;
   // ----- Manta Optimizer (BET-1342 / Phase 2) -----
   // Master switch for the optimizer. DEFAULT FALSE. Opt-in: with it OFF the
   // optimizer changes nothing. It does NOT gate Automatic Manta Routing —


### PR DESCRIPTION
## BET-1405 — ROI self-report + Tonight's-budget card (§12.4, §10.5 card 3)

Closes the economics-deliverable pair of the Adaptive CTO epic: a monthly ROI roll surfaced as a Health row, and the ⚙ page's Tonight's-budget card.

**Base: origin/main @ 6fc3b53a**

### What's here

**1. Monthly ROI roll (`src/server/ctoBudget.mjs`)**
- Pure helpers: `roiMonthKey`, `monthWindow`, `monthSpendUsd`, `acceptedSuggestions` (reuses the §9.5 `effectsForVerdict` mapping — one source of truth), `preSurfacedIncidents`, `isJobMerged`, `roiRecommendation`.
- `refreshRoi()` on the budget accessor + `roiSnapshot()` for the render model. Roll state persists in `budget.json` under `roi` (a §13.1-listed store — no new store file).
- Retention-aware by design: delegate jobs sweep after 7 days, so terminal CTO-actor jobs are SAMPLED into `budget.roi.pending` (id, branch, cwd, finishedAt) while fresh; each later refresh probes the project repo's git (branch deleted-on-merge, or `merge-base --is-ancestor`) and counts the merge onto its finish month. Months close once (previous month frozen after its post-boundary recompute); a month whose source reads fail is never persisted as frozen zeros.
- Recommendation rules (deterministic, documented, **copy-only — never writes the dial**): 0 outcomes + 0 spend → stay ("nothing to judge"); ≥$1 with 0 outcomes → lower; ≥5 outcomes → raise; else stay.

**2. Health ROI row (`ctoHealth.mjs` + endpoint wiring in `index.mjs`)**
- Renders the last closed month: `$X · A accepted · B merged · C pre-surfaced — recommend <tier>: <reason>`, labeled `ROI · <Month>`.
- Before the first monthly boundary: `collecting — first report <date>` (via a new per-stat `collectingText`; first report = end of the month of first recorded spend). `roiRead` failure degrades to collecting.
- **Bug fix (same row family):** the ambient-spend row read `budget?.today?.spend` — a shape that never exists in the payload — so it rendered `collecting (0/1)` forever. Now reads the real day bucket (`todaySpend`), with a live-meter `$0.00` quiet-day render.

**3. Tonight's-budget card (`CtoPanel.tsx` + `ctoView.ts` selectors)**
- Render-mode selector (pure, tested): **full gauge only at High + Overnight on**; otherwise ambient spend vs cap only — never a gauge for a pool that cannot run (§10.5 card 3).
- Full render: night-pool gauge ($0 → `ctoNightCapUsd`) with used-today / planned-tonight segments + reserve line at the binding fractile, overflow flagged; legend; per-provider window notes (label + reset countdown from the usage poller's snapshots); forecast accuracy (MAPE 14d from the persisted quota cache). Read-only, with the "plan editing lives in the tonight drill-down" caption.
- Config surface: `ctoOvernight` (new, default off) + `ctoNightCapUsd` added to `AppConfig`/`CtoSettingsConfig` and read via a new `ctoQuotaRead` Api method (RPC `quota:read`).

### Cross-cutting / coordination notes
- **`ctoOvernight` config key (BET-1419)**: the Overnight switch itself is BET-1419's control. This PR defines the config key the budget card's render gate consumes (`ctoOvernight`, boolean, default false) and consumes it defensively — until the switch ships, the card renders ambient-only, which is the honest state (no overnight pool can run). BET-1419 should persist its switch into this key.
- **`plannedTonightUsd` seam**: the tonight plan portfolio is BET-1419's; until it lands the gauge renders "no plan queued" (the segment is omitted — never fabricated).
- Health renderer rows `forecastAccuracy` / `capHitsCaused` / `reserveFractile` (BET-1400) were emitted server-side but missing from the renderer row order — added to the union + `HEALTH_ROW_ORDER` so the ROI row's ordering is total.
- Batch availability notes: no usage adapter exposes batch support today, so the card renders reset-time notes only (honest absence, documented).

### Incidents heuristic (documented, self-reported)
A resolved blocker card counts when its card's source event predates ANY user prompt on the owning session (segments' 30-day retention is the horizon). Cards without a sessionID (health watchdog escalations) cannot be evaluated — excluded, a documented limitation.

### Verification results

**Files changed:** 12 files (see diff-stat below)

```
src/renderer/CtoPanel.tsx            | 236 ++++++-
src/renderer/api/demoCoverage.test.ts|   1 +
src/renderer/api/httpApi.ts          |  19 +-
src/renderer/ctoView.test.ts         | 103 +++++
src/renderer/ctoView.ts              | 151 ++++++-
src/server/ctoBudget.mjs             | 383 +++++++
src/server/ctoBudget.test.mjs        | 266 +++++++
src/server/ctoHealth.mjs             |  79 ++-
src/server/ctoHealth.test.mjs        |  83 ++-
src/server/index.mjs                 |  56 ++
src/shared/api.ts                    |  25 +-
src/shared/types.ts                  |   8 +
```

**Verification results:**
- PR branch (`multica/BET-1405-roi-budget-card` @ `7f179fb5`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`. vitest: `198` files, `3846` pass / `0` fail / `7` skip; node --test: `3422` pass / `0` fail. Failures: none. log sha256: `9314c3c485c953d5e12d64fd8e80e92d42f5c319065c3931900a30ee0cd6222e`
- Base (`main` @ `6fc3b53a`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`. vitest: `198` files, `3838` pass / `0` fail / `7` skip; node --test: `3405` pass / `0` fail. Failures: none. log sha256: `2b8cd095d97d8c687efc7e1c006e4bb273037416bd7d284c16bdb6294c904a49`
- **Conclusion:** 0 pre-existing failures, 0 new failures caused by this PR; 25 new tests (17 node --test + 8 vitest).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
