### PR TITLE
BET-1421: engine reads ctoAmbientCap — cap edits now reach the enforcement gate

### DIFF
--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -6,7 +6,7 @@
 // What lives here:
 //   - Per-day ambient spend accumulation into budget.json (day rolls at local
 //     midnight — same local-midnight clock as the rollups layer, reused below).
-//   - The independent HARD CAP (`ctoAmbientCapUsd`, default $2.50 / day): a
+//   - The independent HARD CAP (`ctoAmbientCap`, default $2.50 / day): a
 //     ceiling on ambient spend that the engine consults BEFORE every ambient
 //     model call, at every tier, regardless of the A12 tier dial.
 //   - THRIFTY mode (§10.6-6 / §12.2): a numbered capability-shed ladder the
@@ -132,10 +132,16 @@ export function todaySpend(payload, now) {
 }
 
 // The configured per-day ambient cap; falls back to the default when absent or
-// malformed. `ctoAmbientCapUsd` is the config key (§12.1).
+// malformed. `ctoAmbientCap` is the config key (§12.1) — the same key the UI
+// writes. `ctoAmbientCapUsd` is a retired spelling kept as a one-release
+// fallback for stale configs; the canonical key wins when both are present.
 export function ambientCapUsd(cfg) {
-  const c = cfg && typeof cfg === "object" ? cfg.ctoAmbientCapUsd : undefined;
-  return typeof c === "number" && Number.isFinite(c) && c >= 0 ? c : DEFAULT_AMBIENT_CAP_USD;
+  const c = cfg && typeof cfg === "object" ? cfg.ctoAmbientCap : undefined;
+  if (typeof c === "number" && Number.isFinite(c) && c >= 0) return c;
+  const legacy = cfg && typeof cfg === "object" ? cfg.ctoAmbientCapUsd : undefined;
+  return typeof legacy === "number" && Number.isFinite(legacy) && legacy >= 0
+    ? legacy
+    : DEFAULT_AMBIENT_CAP_USD;
 }
 
 // True once today's spend reaches the cap. Boundary: spends == cap counts as a

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -38,12 +38,19 @@ function dayStart(offsetDays = 0) {
 const MIDNIGHT = dayStart(0);
 const NOON = MIDNIGHT + 12 * 3_600_000;
 
-test("cap defaults to $2.50 and honors ctoAmbientCapUsd", () => {
+test("cap defaults to $2.50 and honors ctoAmbientCap", () => {
   assert.equal(ambientCapUsd({}), DEFAULT_AMBIENT_CAP_USD);
+  assert.equal(ambientCapUsd({ ctoAmbientCap: 1.25 }), 1.25);
+  assert.equal(ambientCapUsd({ ctoAmbientCap: 0 }), 0);
+  assert.equal(ambientCapUsd({ ctoAmbientCap: -3 }), DEFAULT_AMBIENT_CAP_USD);
+  assert.equal(ambientCapUsd({ ctoAmbientCap: "x" }), DEFAULT_AMBIENT_CAP_USD);
+  // Retired spelling kept as a one-release fallback for stale configs.
   assert.equal(ambientCapUsd({ ctoAmbientCapUsd: 1.25 }), 1.25);
-  assert.equal(ambientCapUsd({ ctoAmbientCapUsd: 0 }), 0);
-  assert.equal(ambientCapUsd({ ctoAmbientCapUsd: -3 }), DEFAULT_AMBIENT_CAP_USD);
-  assert.equal(ambientCapUsd({ ctoAmbientCapUsd: "x" }), DEFAULT_AMBIENT_CAP_USD);
+  // Canonical key wins when both spellings are present.
+  assert.equal(ambientCapUsd({ ctoAmbientCap: 5, ctoAmbientCapUsd: 1.25 }), 5);
+  // Malformed canonical falls through to a well-formed legacy alias, then default.
+  assert.equal(ambientCapUsd({ ctoAmbientCap: "x", ctoAmbientCapUsd: 1.25 }), 1.25);
+  assert.equal(ambientCapUsd({ ctoAmbientCap: -3, ctoAmbientCapUsd: 1.25 }), 1.25);
 });
 
 test("day rolls at local midnight (spend lands in separate day buckets)", () => {


### PR DESCRIPTION
## Summary

BET-1421 — the §12.1 ambient-cap config key drifted: the enforcement point (`ambientCapUsd()` in `src/server/ctoBudget.mjs`) read `ctoAmbientCapUsd`, a key **nothing writes**, while the Behavior-card editor, `local.mjs` DEFAULT_CONFIG, and the `/api/cto/health` endpoint all write `ctoAmbientCap`. The engine therefore silently ran on the $2.50 default forever; a user raising the cap to $10 still got shed/blocked at $2.50, and the Health row displayed the UI value the enforcement never honored.

**Fix — `ctoAmbientCap` is the single key:**
- `ambientCapUsd()` now reads `ctoAmbientCap` first.
- The retired `ctoAmbientCapUsd` spelling is kept as a one-release fallback alias for stale configs; the canonical key wins when both are present, and a malformed canonical value falls through to a well-formed alias.
- Cap test rewritten: canonical key (valid / 0 / negative / malformed), legacy alias, both-present precedence, malformed-canonical→alias fallthrough.
- Repo-wide grep: the only remaining `ctoAmbientCapUsd` references are the alias itself and its tests — no other readers existed. Writers (`local.mjs`, `index.mjs` health endpoint, `CtoPanel.tsx`, `ctoHealth.mjs`, `types.ts`) already use `ctoAmbientCap`; no docs reference either spelling.

Follow-up filed: BET-1423 (remove the alias after the grace release).

Base: origin/main @ 2cbdad6b

## Verification results

- PR branch (`multica/BET-1421-ambient-cap-key` @ `a6884dd7`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3422` pass / `0` fail / `0` skip. Failures: none. log sha256: `7770b565d96eec937957b33ce5d40e333b3f8f202fd616cabb1b52397e7c5bf1`
- Base (`main` @ `2cbdad6b`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3422` pass / `0` fail / `0` skip. Failures: none. log sha256: `2f530bb758e647607570dc82746ab2df6a2f2986641a34c149f5165da2bde108`
- **Conclusion:** 0 new failures, 0 pre-existing — both branches fully green.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.