### PR TITLE
Adaptive CTO: trust promotion ladder + act-and-report (BET-1403)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -364,7 +364,10 @@ export function CtoPanel({
   const handleVetoCancel = useCallback(
     (card: VetoCardRow) => {
       void window.api
-        ?.ctoVerdict?.({ subject: { type: "veto-window", id: card.id, class: "overnight" }, verdict: "veto" })
+        // BET-1403: the class stamp is the canonical §9.3 action class the
+        // veto window guards (queue-tonight) — it must agree with the trust
+        // record's consumer, not name the feature.
+        ?.ctoVerdict?.({ subject: { type: "veto-window", id: card.id, class: "queue-tonight" }, verdict: "veto" })
         .then((r) => {
           if (!r?.ok) pushToast({ id: `veto-${Date.now()}`, message: `Couldn't cancel tonight: ${r?.error ?? "unknown"}` });
         })

--- a/src/server/ctoDigest.mjs
+++ b/src/server/ctoDigest.mjs
@@ -271,7 +271,7 @@ export function nextDigestMs({
 // Context assembly — the `digest-compose` model input (≤12k ctx, §12.3)
 // ---------------------------------------------------------------------------
 
-export function buildDigestContext({ granularity, window, slice, needsYou, factsChanged, probes, gMinutes, audience } = {}) {
+export function buildDigestContext({ granularity, window, slice, needsYou, factsChanged, probes, gMinutes, audience, reports } = {}) {
   const [ws, we] = window;
   const blocks = [];
 
@@ -297,6 +297,18 @@ export function buildDigestContext({ granularity, window, slice, needsYou, facts
       `When a change OVERTURNS a previously-held fact, phrase it as a subordinate clause on the owning item ` +
       `(e.g. a "sub" like "this overturns the earlier priority"), NEVER as a separate section or item.`,
   });
+  if (Array.isArray(reports) && reports.length) {
+    // BET-1403 (§9.2 invariant 1): actions the CTO executed on its own are
+    // injected into the digest input — the model must report each as a
+    // progress item; the deterministic aside below guarantees appearance.
+    blocks.push({
+      priority: "high",
+      text:
+        `The CTO executed the following actions on its own since the last digest ` +
+        `(each MUST appear as a progress-tier item, phrased as a factual report of what was done):\n` +
+        reports.map((r) => `- ${typeof r === "string" ? r : r.text}`).join("\n"),
+    });
+  }
   if (needsYou && needsYou.length) {
     blocks.push({
       priority: "medium",
@@ -487,6 +499,7 @@ export function createCtoDigest(deps = {}) {
     getInferredTz = async () => null, // {utcOffsetHours, confidence} | null
     getAudience = async () => null, // §8.4 async ({topics}) => audience block | null
     getDeviations = async () => [], // §8.4 deviation-from-baseline asides (user-only)
+    trust = null, // BET-1403: trust engine — act-and-report lines (mandatory report, §9.2) + tier changes, announced as progress asides
     getHeldSuggestionCount = async () => 0, // §14.3 silence audit: held suggestion rows (default none)
     getEnabled = async () => false, // top-level ctoEnabled gate for the scheduler
     digestPushEnabled = async () => false, // §10.5 toggle (ships A12) — off by default
@@ -604,7 +617,13 @@ export function createCtoDigest(deps = {}) {
     const topics = [...new Set((slice || []).map((it) => it.project).filter(Boolean))];
     const audience = await safe(getAudience, { topics });
 
-    const context = buildDigestContext({ granularity, window, slice: slice || [], needsYou, factsChanged: fChanged, probes, gMinutes, audience });
+    // BET-1403: pending trust announcements — act-and-report lines (the
+    // mandatory report, §9.2 invariant 1) + tier changes (§9.4). Acts are
+    // also injected into the digest input; every row is deterministically
+    // appended as a progress aside below so appearance is guaranteed.
+    const trustAsides = trust ? ((await safe(trust.listAnnouncements)) ?? []) : [];
+
+    const context = buildDigestContext({ granularity, window, slice: slice || [], needsYou, factsChanged: fChanged, probes, gMinutes, audience, reports: trustAsides.filter((a) => a?.kind === "act") });
 
     let digest = null;
     if (runEphemeral) {
@@ -653,6 +672,26 @@ export function createCtoDigest(deps = {}) {
       }
     }
 
+    // BET-1403: trust asides — act-and-report lines (the mandatory report,
+    // §9.2 invariant 1) + trust-tier changes (§9.4) appended as progress-tier
+    // items, same treatment as the §8.4 deviations. Marked announced only
+    // after the digest is persisted, so a failed save re-announces next time.
+    const announcedIds = [];
+    if (validateDigest(digest) && trustAsides.length) {
+      const extant = new Set(digest.items.map((i) => `${i.tier || ""}:${i.text || ""}`));
+      for (const a of trustAsides) {
+        if (!a || !a.text || !a.id) continue;
+        if (extant.has(`progress:${a.text}`)) {
+          announcedIds.push(a.id); // already reported (model picked it up)
+          continue;
+        }
+        digest.items.push({ tier: "progress", text: a.text, ...(Array.isArray(a.refs) && a.refs.length ? { refs: a.refs } : {}) });
+        extant.add(`progress:${a.text}`);
+        announcedIds.push(a.id);
+      }
+      digest.refs = collectDigestRefs(digest.items);
+    }
+
     const id = String(t);
     try {
       // §14.3 silence audit: the digest carries how many suggestions the CTO
@@ -664,6 +703,7 @@ export function createCtoDigest(deps = {}) {
     } catch {
       /* best-effort */
     }
+    if (trust && announcedIds.length) await safe(trust.markAnnounced, announcedIds);
     lastGenerated = t;
     lastDigestId = id;
 

--- a/src/server/ctoDigest.mjs
+++ b/src/server/ctoDigest.mjs
@@ -693,6 +693,7 @@ export function createCtoDigest(deps = {}) {
     }
 
     const id = String(t);
+    let persisted = false;
     try {
       // §14.3 silence audit: the digest carries how many suggestions the CTO
       // held back, so the DigestSection can render the "I held back N — review"
@@ -700,10 +701,13 @@ export function createCtoDigest(deps = {}) {
       const held = await safe(getHeldSuggestionCount);
       if (typeof held === "number" && held > 0) digest.heldSuggestions = held;
       await digests.save(id, digest);
+      persisted = true;
     } catch {
-      /* best-effort */
+      /* best-effort — but the trust queue below is NOT consumed on a failed
+         save: an announcement consumed without its digest persisting would
+         lose the mandatory act report (§9.2 invariant 1) forever. */
     }
-    if (trust && announcedIds.length) await safe(trust.markAnnounced, announcedIds);
+    if (persisted && trust && announcedIds.length) await safe(trust.markAnnounced, announcedIds);
     lastGenerated = t;
     lastDigestId = id;
 

--- a/src/server/ctoDigest.test.mjs
+++ b/src/server/ctoDigest.test.mjs
@@ -646,3 +646,25 @@ test("generateDigest: trust asides survive a degraded digest (MUST appear, even 
   const digest = await engine.generateDigest({ reason: "manual" });
   assert.ok(digest.items.some((i) => i.tier === "progress" && i.text === "Acted on my own (record-decision): Adopt pact"));
 });
+
+test("generateDigest: a failed save does NOT consume the trust queue — the mandatory act report re-announces (§9.2 invariant 1)", async () => {
+  const marked = [];
+  const trust = {
+    listAnnouncements: async () => [{ id: "a1", ts: 900, kind: "act", text: "Acted on my own (record-decision): Adopt pact", refs: [] }],
+    markAnnounced: async (ids) => marked.push(...ids),
+  };
+  // First generation: the digest composes (with the report appended) but the
+  // save throws — the announcement queue must stay intact.
+  const failing = { ...makeDigestStore(), save: async () => { throw new Error("disk full"); } };
+  const { engine } = makeEngine({ runEphemeral: async () => ({ text: JSON.stringify({ items: [{ tier: "progress", text: "shipped", refs: [] }] }) }), trust, digests: failing });
+  const failed = await engine.generateDigest({ reason: "manual" });
+  assert.ok(failed.items.some((i) => i.tier === "progress" && i.text === "Acted on my own (record-decision): Adopt pact"));
+  assert.deepEqual(marked, [], "a failed save must not consume the announcements");
+
+  // Next generation (save works again): the same report re-announces and is
+  // then consumed exactly once.
+  const { engine: engine2 } = makeEngine({ runEphemeral: async () => ({ text: JSON.stringify({ items: [{ tier: "progress", text: "shipped", refs: [] }] }) }), trust });
+  const next = await engine2.generateDigest({ reason: "manual" });
+  assert.equal(next.items.filter((i) => i.text === "Acted on my own (record-decision): Adopt pact").length, 1);
+  assert.deepEqual(marked, ["a1"]);
+});

--- a/src/server/ctoDigest.test.mjs
+++ b/src/server/ctoDigest.test.mjs
@@ -570,3 +570,79 @@ test("generateDigest: zero held suggestions → no heldSuggestions field (no asi
   const digest = await engine.generateDigest({ reason: "manual" });
   assert.equal(digest.heldSuggestions, undefined, "no held count → no aside field");
 });
+
+// ---------------------------------------------------------------------------
+// BET-1403 — trust asides: act-and-report lines + tier changes (§9.2/§9.4)
+// ---------------------------------------------------------------------------
+
+test("buildDigestContext: trust reports are injected as a high-priority input block", () => {
+  const g = selectGranularity(2 * DAY_MS, { gMinutes: G });
+  const plain = buildDigestContext({ granularity: g, window: [1, 200], slice: [] });
+  const withReports = buildDigestContext({
+    granularity: g,
+    window: [1, 200],
+    slice: [],
+    reports: [{ kind: "act", text: "Acted on my own (record-decision): Adopt pact", refs: ["msg:1"] }],
+  });
+  assert.equal(withReports.length, plain.length + 1);
+  const block = withReports[withReports.length - 1];
+  assert.equal(block.priority, "high");
+  assert.match(block.text, /MUST appear as a progress-tier item/);
+  assert.match(block.text, /Acted on my own/);
+});
+
+test("generateDigest: act reports reach the model input AND land as deterministic progress asides; announced exactly once", async () => {
+  let sawContext = null;
+  const model = async ({ context } = {}) => {
+    sawContext = context;
+    return { text: JSON.stringify({ items: [{ tier: "progress", text: "shipped", refs: [] }] }) };
+  };
+  const marked = [];
+  const trust = {
+    listAnnouncements: async () => [
+      { id: "a1", ts: 900, kind: "act", text: "Acted on my own (record-decision): Adopt pact", refs: ["msg:1"] },
+      { id: "a2", ts: 950, kind: "promoted", text: 'Trust promoted: the "start-job" class may now use the veto-window verb.', refs: [] },
+    ],
+    markAnnounced: async (ids) => {
+      marked.push(...ids);
+    },
+  };
+  const { engine, store } = makeEngine({ runEphemeral: model, trust });
+  const digest = await engine.generateDigest({ reason: "manual" });
+  const texts = digest.items.map((i) => `${i.tier}:${i.text}`);
+  // Both announcements deterministically present as progress items.
+  assert.ok(texts.includes("progress:Acted on my own (record-decision): Adopt pact"));
+  assert.ok(texts.some((t) => t.startsWith("progress:Trust promoted:")));
+  // The act line was injected into the model input too (the mandatory report).
+  const inputBlock = (Array.isArray(sawContext) ? sawContext : (sawContext?.blocks ?? [])).find((b) => /Acted on my own/.test(b.text || ""));
+  assert.ok(inputBlock, "act report injected into the digest input");
+  // Consumed exactly once — not re-announced on the next generation.
+  assert.deepEqual(marked.sort(), ["a1", "a2"]);
+  assert.equal(store.map.get(String(digest.generated)).items.length, digest.items.length);
+});
+
+test("generateDigest: a model item already reporting the act is not duplicated by the aside", async () => {
+  const model = async () => ({
+    text: JSON.stringify({ items: [{ tier: "progress", text: "Acted on my own (record-decision): Adopt pact", refs: ["msg:1"] }] }),
+  });
+  const marked = [];
+  const trust = {
+    listAnnouncements: async () => [{ id: "a1", ts: 900, kind: "act", text: "Acted on my own (record-decision): Adopt pact", refs: ["msg:1"] }],
+    markAnnounced: async (ids) => marked.push(...ids),
+  };
+  const { engine } = makeEngine({ runEphemeral: model, trust });
+  const digest = await engine.generateDigest({ reason: "manual" });
+  const matches = digest.items.filter((i) => i.text === "Acted on my own (record-decision): Adopt pact");
+  assert.equal(matches.length, 1); // deduped — the model's item wins
+  assert.deepEqual(marked, ["a1"]); // still consumed
+});
+
+test("generateDigest: trust asides survive a degraded digest (MUST appear, even when the model fails)", async () => {
+  const trust = {
+    listAnnouncements: async () => [{ id: "a1", ts: 900, kind: "act", text: "Acted on my own (record-decision): Adopt pact", refs: [] }],
+    markAnnounced: async () => {},
+  };
+  const { engine } = makeEngine({ runEphemeral: null, trust }); // no model → degraded path
+  const digest = await engine.generateDigest({ reason: "manual" });
+  assert.ok(digest.items.some((i) => i.tier === "progress" && i.text === "Acted on my own (record-decision): Adopt pact"));
+});

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -57,6 +57,10 @@ import {
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
 import { createVerdictEngine } from "./ctoVerdicts.mjs";
+// BET-1403: the earned-trust ladder (§9.3/§9.4). Its per-class Beta counters
+// ride the §9.5 verdict sink registry below; the digest announces acts and
+// tier changes through the same engine.
+import { createCtoTrust } from "./ctoTrust.mjs";
 import { createCtoBackfill } from "./ctoBackfill.mjs";
 import { startPoller } from "./startPoller.mjs";
 import { createSeenIdFilter } from "./seenIds.mjs";
@@ -381,6 +385,7 @@ export function createCtoEngine(deps = {}) {
   let builtInBackfill = null;
   let profileDecayHandle = null;
   let verdictsEngine = null;
+  let trustEngine = null;
   let watcherEngine = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
@@ -950,6 +955,14 @@ export function createCtoEngine(deps = {}) {
     verdictsEngine = createVerdictEngine({ verdicts, now });
     verdictsEngine.registerCounterSink(factsCounterSink);
     verdictsEngine.registerCounterSink(tonightCounterSink);
+    // BET-1403 (§9.4): the trust counters ride the same §9.5 sink registry —
+    // per-action-class Beta counters over class-attributed suggestion
+    // verdicts. Best-effort like every sink: a failure never breaks verdict
+    // recording.
+    const t = getTrust();
+    verdictsEngine.registerCounterSink((effects, entry) => {
+      void t.noteVerdictEffects(effects, entry).catch(() => {});
+    });
     return verdictsEngine;
   }
 
@@ -965,6 +978,16 @@ export function createCtoEngine(deps = {}) {
     void overnight
       .foldCounters({ category: "queue-tonight", verdict: entry?.verdict, never: entry?.never === true })
       .catch(() => {});
+  }
+
+  // BET-1403: the earned-trust engine over the shared stores (engine state
+  // persists `es.trust`). One instance per engine; the suggest module keeps
+  // its own over the same stores — both are stateless facades whose every
+  // op loads fresh, mutates, and saves.
+  function getTrust() {
+    if (trustEngine) return trustEngine;
+    trustEngine = createCtoTrust({ engineState, ledger, verdicts, now });
+    return trustEngine;
   }
 
   // BET-1398 standing-query watchers (§4.3/§13.4): lazy single instance over
@@ -1997,6 +2020,9 @@ export function createCtoEngine(deps = {}) {
     // all reach one path through these).
     recordVerdict: (input) => getVerdictsEngine().recordVerdict(input),
     listVerdicts: () => getVerdictsEngine().listVerdicts(),
+    // BET-1403: trust engine — consult tiers, act-and-report bookkeeping, and
+    // the digest announcement queue (index.mjs wires the digest seam to it).
+    trust: getTrust(),
     get rateTracker() {
       return track;
     },

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -47,6 +47,7 @@ import {
   ctoPath,
   ledgerStore,
   engineStateStore,
+  trustStore,
   cardsStore,
   segmentsStore,
   rollupsStore,
@@ -275,6 +276,9 @@ export function createCtoEngine(deps = {}) {
     configGet = async () => ({}), // → { ctoEnabled?: boolean }
     ledger = ledgerStore, // A1 ledger writer { append }
     engineState = engineStateStore, // { load, save } (engine-state.json)
+    // BET-1403: the trust ladder's own file — isolated from engine-state
+    // writers so no snapshot-spread save can revert tiers/counters/pending.
+    trustStore: trustStoreDep = trustStore,
     killSwitch = createKillSwitch(),
     publish = () => {}, // (evt: {kind:"ctoState", payload}) => void
     now = () => Date.now(),
@@ -980,13 +984,14 @@ export function createCtoEngine(deps = {}) {
       .catch(() => {});
   }
 
-  // BET-1403: the earned-trust engine over the shared stores (engine state
-  // persists `es.trust`). One instance per engine; the suggest module keeps
+  // BET-1403: the earned-trust engine over its own store file (trust.json —
+  // a legacy `es.trust` payload migrates on first load). One instance per
+  // engine; the suggest module keeps
   // its own over the same stores — both are stateless facades whose every
   // op loads fresh, mutates, and saves.
   function getTrust() {
     if (trustEngine) return trustEngine;
-    trustEngine = createCtoTrust({ engineState, ledger, verdicts, now });
+    trustEngine = createCtoTrust({ store: trustStoreDep, legacy: engineState, ledger, verdicts, now });
     return trustEngine;
   }
 

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1373,6 +1373,12 @@ export function createCtoEngine(deps = {}) {
       if (stale) {
         const fulfilled = win.state === "open" && win.countdown == null;
         await cards.resolveById(stale.id, { reason: fulfilled ? "window opened" : "countdown elapsed unmet" }).catch(() => {});
+        if (fulfilled) {
+          // BET-1403 §9.4: the announced window elapsed UNcancelled and the
+          // overnight run opened — the veto-window record's acceptance, feeding
+          // the veto→act promotion bar under the canonical action class.
+          void getTrust().noteVetoOutcome("queue-tonight", { accepted: true }).catch(() => {});
+        }
       }
     }
   }
@@ -1565,9 +1571,16 @@ export function createCtoEngine(deps = {}) {
     const stale = open.find((c) => c?.id === VETO_CARD_ID && c?.variant === "veto");
     if (stale) await cards.resolveById(stale.id, { reason: "canceled by user" }).catch(() => {});
     await ledgerLog({ kind: "cto.overnight.veto", ts: now() });
+    // BET-1403 §9.4: a cancel IS the veto-window record's rejection. The
+    // canonical action class is "queue-tonight" (the §9.3 eligibility map's
+    // class — the overnight veto window guards tonight's queued tasks); the
+    // UI's veto-verdict subject carries the same stamp. Single writer: the
+    // trust sink ignores veto-window subjects, so the record is fed exactly
+    // once per resolved window (cancel here, executed-open in the veto card).
     void getVerdictsEngine()
-      .recordVerdict({ subject: { type: "veto-window", id: VETO_CARD_ID, class: "overnight" }, verdict: "veto" })
+      .recordVerdict({ subject: { type: "veto-window", id: VETO_CARD_ID, class: "queue-tonight" }, verdict: "veto" })
       .catch(() => {});
+    void getTrust().noteVetoOutcome("queue-tonight", { accepted: false }).catch(() => {});
     await syncState().catch(() => {});
     return { ok: true };
   }

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -18,6 +18,7 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
   const ledgerRows = [];
   const engineStateObj = { v: 1, pendingBlockers: [], tonightQueue: JSON.parse(JSON.stringify(queue)) };
   const overnightStoreObj = { v: 1, window: null };
+  const verdictsObj = { v: 1, entries: [] };
   const published = [];
   const startedJobs = [];
   const pausedJobs = [];
@@ -43,6 +44,14 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
     configGet: async () => ({ ...config }),
     tierGet: async () => config.ctoTier,
     now,
+    // §9.5 verdict ledger, in-memory so tests never share the sandboxed file.
+    verdicts: {
+      load: async () => JSON.parse(JSON.stringify(verdictsObj)),
+      save: async (payload) => {
+        verdictsObj.v = payload?.v ?? 1;
+        verdictsObj.entries = Array.isArray(payload?.entries) ? JSON.parse(JSON.stringify(payload.entries)) : [];
+      },
+    },
     ledger: {
       append: async (row) => ledgerRows.push(row),
       read: async () => [...ledgerRows],
@@ -55,6 +64,9 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
         if (payload?.rollupCursor) engineStateObj.rollupCursor = payload.rollupCursor;
         if (payload?.backfillProgress) engineStateObj.backfillProgress = payload.backfillProgress;
         if (payload?.backfillStartInstant !== undefined) engineStateObj.backfillStartInstant = payload.backfillStartInstant;
+        // BET-1403: the trust ladder persists under `es.trust` — keep it so
+        // the veto-record feed accumulates across loads like production.
+        if (payload?.trust) engineStateObj.trust = payload.trust;
       },
     },
     killSwitch: {
@@ -266,6 +278,16 @@ test("overnight: veto card arms 30 min before the trough, cancels on the veto ve
   assert.equal(h.vetoCards.length, 0, "the veto card resolved on cancel");
   assert.ok(h.ledgerRows.some((row) => row.kind === "cto.overnight.veto"));
 
+  // BET-1403 §9.4: the cancel verdict is stamped with the canonical action
+  // class the veto window guards (queue-tonight — the §9.3 eligibility map's
+  // class), and the veto-window record's rejection advanced exactly once.
+  const verdicts = (await h.engine.listVerdicts()).filter((v) => v?.subject?.type === "veto-window");
+  assert.equal(verdicts.length, 1);
+  assert.equal(verdicts[0].subject.class, "queue-tonight", "the veto verdict carries the canonical action class");
+  const trustAfterCancel = await h.engine.trust.getState();
+  assert.equal(trustAfterCancel.stats["queue-tonight"]?.vb, 1, "a cancel feeds the veto record's rejection");
+  assert.equal(trustAfterCancel.stats["queue-tonight"]?.va ?? 0, 0);
+
   // Still in the pre-window: the veto suppresses BOTH the card re-arm and the
   // countdown — a cancel is not a countdown reset (§9.2).
   h.advance(5 * 60_000);
@@ -294,6 +316,51 @@ test("overnight: veto card arms 30 min before the trough, cancels on the veto ve
   await h.engine.tick();
   assert.equal(h.overnightStoreObj.window?.state, "open", "the fresh trough opens normally (absent, in trough)");
   assert.equal(h.vetoCards.length, 0);
+
+  // BET-1403 §9.4: that resolution was the EXECUTED path — the announced
+  // window elapsed uncancelled and the run opened, so the veto record's
+  // acceptance advanced (the va side of the veto→act bar). Both sides of the
+  // record are now fed by the same machinery, exactly once per window.
+  const trustAfterOpen = await h.engine.trust.getState();
+  assert.equal(trustAfterOpen.stats["queue-tonight"]?.va, 1, "the executed window feeds the veto record's acceptance");
+  assert.equal(trustAfterOpen.stats["queue-tonight"]?.vb, 1, "the earlier cancel is still on the record");
+});
+
+test("overnight: an executed window feeds the veto record's acceptance (BET-1403 §9.4 veto→act bar)", async () => {
+  const due = h0().startMs;
+  const h = makeHarness({ trough: { startMs: due, endMs: due + 6 * HOUR }, queue: [QUEUE_TASK], projects: [] });
+
+  // Arm the veto card in the pre-window (no cancel this time).
+  h.clock.ms = due - 20 * 60_000;
+  await h.engine.tick();
+  assert.equal(h.vetoCards.length, 1);
+
+  // The clock enters the trough while the user is absent: the window opens
+  // (the machine's open path fulfils the countdown) and the next tick resolves
+  // the lingering veto card as fulfilled.
+  h.advance(25 * 60_000);
+  await h.engine.tick();
+  await h.engine.tick();
+  assert.equal(h.overnightStoreObj.window?.state, "open", "the unannounced-veto window opened");
+  assert.equal(h.vetoCards.length, 0, "the veto card resolved once the window opened");
+
+  // The veto-window record's acceptance advanced under the canonical class —
+  // the va/vb pair the veto→act promotion bar (§9.4) reads.
+  const st = await h.engine.trust.getState();
+  assert.equal(st.stats["queue-tonight"]?.va, 1, "an executed window feeds the veto record's acceptance");
+  assert.equal(st.stats["queue-tonight"]?.vb ?? 0, 0);
+
+  // And a cancel on a LATER night demotes the rolling pressure the same way —
+  // both sides of the record are fed by the same machinery.
+  const nextDue = due + 24 * HOUR;
+  h.setTrough({ startMs: nextDue, endMs: nextDue + 6 * HOUR });
+  h.advance(24 * HOUR - 25 * 60_000);
+  await h.engine.tick(); // arm tomorrow's card
+  assert.equal(h.vetoCards.length, 1, "the next night arms a fresh veto card");
+  await h.engine.tonightCancel();
+  const st2 = await h.engine.trust.getState();
+  assert.equal(st2.stats["queue-tonight"]?.va, 1);
+  assert.equal(st2.stats["queue-tonight"]?.vb, 1, "the later cancel feeds the rejection side too");
 });
 
 test("overnight: run-now opens the window outside the trough and dispatches", async () => {
@@ -332,9 +399,14 @@ test("tonight verbs: add gates on the switch, caps at 12, remove + reorder pin t
   assert.equal(pinned.ok, true);
   assert.equal(h.overnightStoreObj.window?.pinnedOrder?.length, 12);
 
-  // Remove drops the entry AND its pinned slot.
+  // Remove drops the entry AND its pinned slot. Drain first: the remove's
+  // §9.5 verdict fires its counter sinks fire-and-forget, and a best-effort
+  // engine-state write from an in-flight sink must settle before the store is
+  // read (a stale full-state snapshot would otherwise clobber the queue row).
   const removed = await h.engine.tonightRemove(h.engineStateObj.tonightQueue[0].id);
   assert.equal(removed.ok, true);
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
   assert.equal(h.engineStateObj.tonightQueue.length, 11);
 });
 

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -19,11 +19,24 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
   const engineStateObj = { v: 1, pendingBlockers: [], tonightQueue: JSON.parse(JSON.stringify(queue)) };
   const overnightStoreObj = { v: 1, window: null };
   const verdictsObj = { v: 1, entries: [] };
+  const trustObj = { v: 1, tiers: {}, stats: {}, pending: [] };
   const published = [];
   const startedJobs = [];
   const pausedJobs = [];
   const listedJobs = [];
   const vetoCards = [];
+
+  // Raw engine-state writer (the shared shape of the production writers).
+  // BET-1403 (cycle 4): a `trust` key in the payload is IGNORED — the trust
+  // ladder persists to its own store, so a stale snapshot-spread save can no
+  // longer carry trust state in or out of this file.
+  function saveEngineStateRaw(payload = {}) {
+    if (Array.isArray(payload?.tonightQueue)) engineStateObj.tonightQueue = payload.tonightQueue;
+    if (payload?.pendingBlockers) engineStateObj.pendingBlockers = payload.pendingBlockers;
+    if (payload?.rollupCursor) engineStateObj.rollupCursor = payload.rollupCursor;
+    if (payload?.backfillProgress) engineStateObj.backfillProgress = payload.backfillProgress;
+    if (payload?.backfillStartInstant !== undefined) engineStateObj.backfillStartInstant = payload.backfillStartInstant;
+  }
   const config = { ctoEnabled: true, ctoTier: tier, ctoOvernight: overnightEnabled };
   let curTrough = trough;
 
@@ -52,22 +65,25 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
         verdictsObj.entries = Array.isArray(payload?.entries) ? JSON.parse(JSON.stringify(payload.entries)) : [];
       },
     },
+    // BET-1403: the trust ladder's own store (in-memory, isolated from
+    // engine-state writers).
+    trustStore: {
+      load: async () => JSON.parse(JSON.stringify(trustObj)),
+      save: async (payload) => {
+        const copy = JSON.parse(JSON.stringify(payload ?? {}));
+        trustObj.v = copy.v ?? 1;
+        trustObj.tiers = copy.tiers ?? {};
+        trustObj.stats = copy.stats ?? {};
+        trustObj.pending = Array.isArray(copy.pending) ? copy.pending : [];
+      },
+    },
     ledger: {
       append: async (row) => ledgerRows.push(row),
       read: async () => [...ledgerRows],
     },
     engineState: {
       load: async () => JSON.parse(JSON.stringify(engineStateObj)),
-      save: async (payload) => {
-        if (Array.isArray(payload?.tonightQueue)) engineStateObj.tonightQueue = payload.tonightQueue;
-        if (payload?.pendingBlockers) engineStateObj.pendingBlockers = payload.pendingBlockers;
-        if (payload?.rollupCursor) engineStateObj.rollupCursor = payload.rollupCursor;
-        if (payload?.backfillProgress) engineStateObj.backfillProgress = payload.backfillProgress;
-        if (payload?.backfillStartInstant !== undefined) engineStateObj.backfillStartInstant = payload.backfillStartInstant;
-        // BET-1403: the trust ladder persists under `es.trust` — keep it so
-        // the veto-record feed accumulates across loads like production.
-        if (payload?.trust) engineStateObj.trust = payload.trust;
-      },
+      save: saveEngineStateRaw,
     },
     killSwitch: {
       isPaused: async () => false,
@@ -136,6 +152,9 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
     setTrough(t) {
       curTrough = t;
     },
+    // Test seam: a raw engine-state write (the hostile snapshot-spread shape
+    // from the pre-cycle-4 writers).
+    engineStateSave: saveEngineStateRaw,
     advance(ms) {
       clock.ms += ms;
     },
@@ -416,6 +435,34 @@ test("overnight: queue-tonight verdicts fold into the overnight Thompson counter
   await new Promise((r) => setImmediate(r));
   const counters = await h.overnight.readCounters();
   assert.equal(counters?.["queue-tonight"]?.alpha, 1, "accept folds a success counter");
+});
+
+test("durability: a trust fold survives a queue-edit save landing after it (mirrored-order regression, BET-1403 cycle 4)", async () => {
+  const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [] });
+
+  // The trust fold lands first (a verdict's fire-and-forget sink writes the
+  // trust ladder's own store).
+  await h.engine.recordVerdict({ subject: { type: "suggestion", id: "card-2", class: "queue-tonight" }, verdict: "accept" });
+  await new Promise((r) => setImmediate(r));
+  const afterFold = await h.engine.trust.getState();
+  assert.equal(afterFold.stats["queue-tonight"]?.a, 1);
+
+  // Then a queue edit lands — AND the hostile old writer shape runs: a whole
+  // engine-state save spreading a STALE pre-fold snapshot that still carries
+  // an `es.trust` fossil key. When trust lived under es.trust this reverted
+  // the fold; with the dedicated store the tier/counter change survives and
+  // the queue edit lands normally.
+  const removed = await h.engine.tonightRemove(h.engineStateObj.tonightQueue[0].id);
+  assert.equal(removed.ok, true);
+  await h.engineStateSave({ v: 1, trust: { tiers: {}, stats: {} }, tonightQueue: [{ id: "tq:stale" }] });
+  await new Promise((r) => setImmediate(r));
+
+  const after = await h.engine.trust.getState();
+  // Two folds landed: the accept verdict (a=1) and the remove's own edit
+  // verdict (a=2) — BOTH survived the hostile stale engine-state save, which
+  // under es.trust would have reverted the record to the pre-fold snapshot.
+  assert.equal(after.stats["queue-tonight"]?.a, 2, "the trust folds survived the stale engine-state save");
+  assert.deepEqual(h.engineStateObj.tonightQueue, [{ id: "tq:stale" }], "the queue edit landed");
 });
 
 // Fixed trough helper for the veto-card test (a window that starts "now").

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -151,6 +151,12 @@ export const budgetStore = createCtoJsonStore("budget", ctoPath("budget.json"));
 // created, lastHit, hits, retired? }] }`. Owned by ctoWatchers.mjs.
 export const watchersStore = createCtoJsonStore("watchers", ctoPath("watchers.json"));
 export const engineStateStore = createCtoJsonStore("engine-state", ctoPath("engine-state.json"));
+// BET-1403 (review cycle 4): the trust ladder's own store. Trust state lived
+// under `es.trust` until the durability review showed ANY snapshot-spreading
+// engine-state writer could silently revert tiers/counters/announcements —
+// so it moved to a dedicated file no other writer touches. ctoTrust.mjs
+// migrates a legacy `es.trust` payload on first load.
+export const trustStore = createCtoJsonStore("trust", ctoPath("trust.json"));
 
 // ---------------------------------------------------------------------------
 // Single-level directory JSON stores: one file per id, e.g. `facts/<project>.json`

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -156,6 +156,19 @@ export const engineStateStore = createCtoJsonStore("engine-state", ctoPath("engi
 // Single-level directory JSON stores: one file per id, e.g. `facts/<project>.json`
 // ---------------------------------------------------------------------------
 
+// Best-effort A1 ledger append shared by the cto engines (extracted for
+// BET-1403 — see the duplication-gate report): observability must never take
+// the caller down, so a ledger failure is swallowed, not thrown. Returns true
+// when the row landed. `ts` is an epoch-ms number.
+export async function appendLedgerBestEffort(ledger, ts, entry) {
+  try {
+    await ledger.append({ actor: "cto", ts, ...entry });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function createDirJsonStore(name, dirPart) {
   const filePath = (id) => ctoPath(dirPart, `${id}.json`);
   return {

--- a/src/server/ctoSuggest.mjs
+++ b/src/server/ctoSuggest.mjs
@@ -36,6 +36,7 @@ import {
   appendLedgerBestEffort,
   ledgerStore,
   engineStateStore,
+  trustStore,
   verdictsStore,
   digestsStore,
   factsStore,
@@ -364,6 +365,7 @@ export function createCtoSuggest(deps = {}) {
     publish = () => {},
     ledger = ledgerStore,
     engineState = engineStateStore,
+    trustStore: trustStoreDep = trustStore, // BET-1403: the trust ladder's own file (isolated from engine-state writers)
     verdicts = verdictsStore,
     digests = digestsStore,
     facts = factsStore,
@@ -382,10 +384,11 @@ export function createCtoSuggest(deps = {}) {
   } = deps;
 
   const priors = { ...DEFAULT_CLASS_PRIORS, ...classPriors };
-  // BET-1403: the earned-trust engine over the same injected stores (engine
-  // state persists `es.trust` — tiers, Beta counters, rolling windows, and
-  // the pending digest-announcement queue).
-  const trust = createCtoTrust({ engineState, ledger, verdicts, now });
+  // BET-1403: the earned-trust engine over its own store file (tiers, Beta
+  // counters, rolling windows, and the pending digest-announcement queue) —
+  // isolated from engine-state writers; a legacy `es.trust` payload migrates
+  // on first load.
+  const trust = createCtoTrust({ store: trustStoreDep, legacy: engineState, ledger, verdicts, now });
 
   // Trust consult for one candidate class — never throws, defaults to ask.
   async function trustConsult(cls, coldStart) {

--- a/src/server/ctoSuggest.mjs
+++ b/src/server/ctoSuggest.mjs
@@ -33,6 +33,7 @@
 
 import { createHash } from "node:crypto";
 import {
+  appendLedgerBestEffort,
   ledgerStore,
   engineStateStore,
   verdictsStore,
@@ -396,11 +397,7 @@ export function createCtoSuggest(deps = {}) {
   }
 
   async function ledgerAppend(entry) {
-    try {
-      await ledger.append({ actor: "cto", ts: now(), ...entry });
-    } catch {
-      /* best-effort — a ledger failure never takes suggestions down */
-    }
+    return appendLedgerBestEffort(ledger, now(), entry);
   }
 
   async function loadState() {

--- a/src/server/ctoSuggest.mjs
+++ b/src/server/ctoSuggest.mjs
@@ -40,6 +40,9 @@ import {
   factsStore,
 } from "./ctoStores.mjs";
 import { collectWatcherHitsFromLedger } from "./ctoWatchers.mjs";
+// BET-1403: the earned-trust ladder (§9.3/§9.4) consults per-class tiers for
+// verb selection; VERDICT_MIN (the §10.6-4 cold-start gate) is owned here.
+import { createCtoTrust, VERDICT_MIN as TRUST_VERDICT_MIN } from "./ctoTrust.mjs";
 
 export const SUGGEST_VERSION = 1;
 
@@ -70,7 +73,8 @@ export const DEFAULT_CLASS_PRIORS = Object.freeze({
 });
 
 // Cold-start: below this many verdicts every candidate is capped at ask verbs.
-export const VERDICT_MIN = 15;
+// Owned by ctoTrust (§10.6-4) since BET-1403 — re-exported for callers.
+export const VERDICT_MIN = TRUST_VERDICT_MIN;
 
 // §9.1 default gate thresholds (engine-state overrides).
 export function defaultThresholds() {
@@ -123,11 +127,16 @@ export function worthinessProbability(score, prior = 0.5, senderReliability = 0.
   return Math.min(1, s * p * r);
 }
 
-// §9.1 surface-verb selection for one candidate. NOTHING acts in P2.
+// §9.1/§9.2 surface-verb selection for one candidate.
 //   - coldStart (`verdicts < VERDICT_MIN`): capped at the ask verb regardless
-//     of score — the act branch is simply never considered.
-//   - p >= p_act (outside cold-start): the act branch is reached → throw
-//     (the guard that nothing acts in P2; unreachable by a correct pipeline).
+//     of score or trust tier — the §10.6-4 global gate dominates (§9.4).
+//   - The class's trust tier raises the ceiling (§9.4): at the veto-window
+//     tier the veto-window verb is reachable; at the act tier the act verb
+//     becomes reachable once p >= p_act (below it the class still surfaces
+//     the veto-window verb). Eligibility (§9.3) gates the climb — an
+//     ask-capped class never leaves the ask verbs whatever its counters say.
+//   - p >= p_act on an un-promoted (ask-tier) class: the act branch is
+//     reached without trust → throw (the guard that nothing acts unearned).
 //   - p >= p_ask: DECISION card; `notify` true when the decay rule matches.
 //   - else: SILENT-LOG (ledger row for the §14.3 audit).
 export function decideVerb({
@@ -135,17 +144,24 @@ export function decideVerb({
   thresholds = defaultThresholds(),
   coldStart = false,
   sourceKind = null,
+  tier = "ask",
+  eligible = false,
 } = {}) {
   const th = { ...defaultThresholds(), ...(thresholds || {}) };
   const pAct = Number.isFinite(th.p_act) ? th.p_act : 0.95;
   const pAsk = Number.isFinite(th.p_ask) ? th.p_ask : 0.4;
   const notify = NOTIFY_RECURRENCE_KINDS.includes(sourceKind);
   if (p < pAsk) return { verb: "silent-log" };
-  // p >= p_ask → ask verb (decision card). Cold-start CAPS the ceiling at ask
-  // "regardless of scores": the act branch is never considered (no throw).
+  // p >= p_ask → at least the ask verb (decision card). Cold-start CAPS the
+  // ceiling at ask "regardless of scores": the act branch is never considered.
   if (coldStart) return { verb: "decision", capped: true, notify };
+  // §9.4 ladder: a promoted, eligible class may surface the higher verbs.
+  if (eligible && (tier === "veto-window" || tier === "act")) {
+    if (tier === "act" && p >= pAct) return { verb: "act", notify };
+    return { verb: "veto-window", notify };
+  }
   if (p >= pAct) {
-    throw new Error("suggest: act branch reached — nothing acts in P2");
+    throw new Error("suggest: act branch reached — class not trusted (ask-tier hold)");
   }
   return { verb: "decision", notify };
 }
@@ -361,9 +377,23 @@ export function createCtoSuggest(deps = {}) {
     classPriors = {}, // overrides for DEFAULT_CLASS_PRIORS
     thresholds = null, // in-memory engine-state thresholds (lazy)
     recordVerdict = null, // async ({subject, verdict, never}) => {ok} — B3 verdict route
+    executeAction = null, // BET-1403: async ({cls, action, candidate}) => {ok, ...} — act-and-report executors; null/unexecutable → verb degrades to veto-window
   } = deps;
 
   const priors = { ...DEFAULT_CLASS_PRIORS, ...classPriors };
+  // BET-1403: the earned-trust engine over the same injected stores (engine
+  // state persists `es.trust` — tiers, Beta counters, rolling windows, and
+  // the pending digest-announcement queue).
+  const trust = createCtoTrust({ engineState, ledger, verdicts, now });
+
+  // Trust consult for one candidate class — never throws, defaults to ask.
+  async function trustConsult(cls, coldStart) {
+    try {
+      return await trust.consult(cls, { coldStart });
+    } catch {
+      return { tier: "ask", eligible: false, capped: coldStart };
+    }
+  }
 
   async function ledgerAppend(entry) {
     try {
@@ -507,12 +537,14 @@ export function createCtoSuggest(deps = {}) {
         }
       }
       const p = worthinessProbability(score, priors[c.class], reliability);
+      // §9.4: verb selection consults the class's earned-trust tier.
+      const trustInfo = await trustConsult(c.class, coldStart);
       let decision;
       try {
-        decision = decideVerb({ p, thresholds: th, coldStart, sourceKind: finding.sourceKind });
+        decision = decideVerb({ p, thresholds: th, coldStart, sourceKind: finding.sourceKind, tier: trustInfo.tier, eligible: trustInfo.eligible });
       } catch {
-        // act branch is unreachable in P2 — log as a held item, never act.
-        await ledgerAppend({ kind: "suggest.silent", id: c.id, class: c.class, score: p, reason: "act-unreachable-p2", sourceKind: finding.sourceKind, text: c.finding.text });
+        // act branch reached without trust — log as a held item, never act.
+        await ledgerAppend({ kind: "suggest.silent", id: c.id, class: c.class, score: p, reason: "act-not-trusted", sourceKind: finding.sourceKind, text: c.finding.text });
         silent += 1;
         continue;
       }
@@ -523,10 +555,8 @@ export function createCtoSuggest(deps = {}) {
         continue;
       }
 
-      // decision verb → write (or upsert) the decision card.
-      const card = {
+      const baseCard = {
         id: c.id,
-        variant: "decision",
         title: c.finding.text || "CTO suggestion",
         why: `Suggested as "${c.class}": ${c.finding.text}`,
         sourceKind: finding.sourceKind,
@@ -537,22 +567,73 @@ export function createCtoSuggest(deps = {}) {
         score: p,
         capped: decision.capped === true,
       };
-      let wrote = false;
-      if (cards && typeof cards.upsertDecision === "function") {
-        try {
-          wrote = (await cards.upsertDecision({ ...card, ts: now() })).changed === true;
-        } catch {
-          wrote = false;
+      let surfacedKind = null;
+
+      // §9.2 act-and-report: the bound action of the primary option executes
+      // immediately; the ledger row + digest report are written by the trust
+      // engine. An unexecutable action (no executor wired, executor refused,
+      // no primary option) is a data gate — the verb degrades to the
+      // veto-window card, never silently acts.
+      if (decision.verb === "act") {
+        const action = options[0]?.action ?? null;
+        let exec = { ok: false, reason: "no-executor" };
+        if (action && typeof executeAction === "function") {
+          try {
+            exec = (await executeAction({ cls: c.class, action, candidate: c })) ?? { ok: false };
+          } catch {
+            exec = { ok: false };
+          }
+        }
+        if (exec?.ok === true) {
+          await trust.recordAct({ cls: c.class, text: c.finding.text, refs: c.finding.refs, action }).catch(() => {});
+          await ledgerAppend({ kind: "suggest.acted", cardId: c.id, class: c.class, actionType: action?.type, score: p, sourceKind: finding.sourceKind });
+          surfaced += 1;
+          continue;
+        }
+        decision = { ...decision, verb: "veto-window" };
+      }
+
+      // §9.2 veto-window verb: a card with a countdown that executes unless
+      // cancelled (the cancel is a verdict, §9.4). BET-1419 ships the veto
+      // card writer; until it lands the verb degrades to the ask card.
+      if (decision.verb === "veto-window") {
+        let wrote = false;
+        if (cards && typeof cards.upsertVeto === "function") {
+          try {
+            wrote = (await cards.upsertVeto({ ...baseCard, variant: "veto", ts: now() })).changed === true;
+          } catch {
+            wrote = false;
+          }
+        }
+        if (wrote) {
+          await ledgerAppend({ kind: "suggest.presented", cardId: c.id, class: c.class, variant: "veto", score: p, sourceKind: finding.sourceKind });
+          surfaced += 1;
+          surfacedKind = "veto";
+        } else {
+          decision = { ...decision, verb: "decision" };
         }
       }
-      if (wrote) {
-        await ledgerAppend({ kind: "suggest.presented", cardId: c.id, class: c.class, score: p, sourceKind: finding.sourceKind });
-        surfaced += 1;
-      } else {
-        // No card machinery (or it failed) → hold instead of acting.
-        await ledgerAppend({ kind: "suggest.silent", id: c.id, class: c.class, score: p, reason: "no-card-path", sourceKind: finding.sourceKind, text: c.finding.text });
-        silent += 1;
-        continue;
+
+      // ask verb → write (or upsert) the decision card.
+      if (!surfacedKind) {
+        const card = { ...baseCard, variant: "decision" };
+        let wrote = false;
+        if (cards && typeof cards.upsertDecision === "function") {
+          try {
+            wrote = (await cards.upsertDecision({ ...card, ts: now() })).changed === true;
+          } catch {
+            wrote = false;
+          }
+        }
+        if (wrote) {
+          await ledgerAppend({ kind: "suggest.presented", cardId: c.id, class: c.class, variant: "decision", score: p, sourceKind: finding.sourceKind });
+          surfaced += 1;
+        } else {
+          // No card machinery (or it failed) → hold instead of acting.
+          await ledgerAppend({ kind: "suggest.silent", id: c.id, class: c.class, score: p, reason: "no-card-path", sourceKind: finding.sourceKind, text: c.finding.text });
+          silent += 1;
+          continue;
+        }
       }
 
       // notify variant: informational-tier router call when the decay rule
@@ -610,9 +691,18 @@ export function createCtoSuggest(deps = {}) {
 
   // A judgment on a held item → the B3 verdict route (§9.5). `accept` records
   // an accept verdict (success/access counters); `dismiss` records a dismiss
-  // (rejection counter). Returns {ok} — a missing verdicts path degrades.
+  // (rejection counter). The held row's action class is stamped onto the
+  // subject so the §9.4 trust counters can attribute the verdict. Returns
+  // {ok} — a missing verdicts path degrades.
   async function verdictHeld({ id, verdict, never } = {}) {
-    const subject = { type: "suggestion", id: String(id || "") };
+    const sid = String(id || "");
+    let cls;
+    try {
+      cls = (await listHeld({ limit: 500 })).find((r) => r?.id === sid)?.class;
+    } catch {
+      /* best-effort attribution */
+    }
+    const subject = { type: "suggestion", id: sid, ...(cls ? { class: cls } : {}) };
     if (typeof recordVerdict === "function") {
       const r = await recordVerdict({ subject, verdict, never });
       return { ok: r?.ok === true, error: r?.error };
@@ -635,5 +725,6 @@ export function createCtoSuggest(deps = {}) {
     // exposed for tests / diagnostics
     _priors: priors,
     _filterOptionsByData: filterOptionsByData,
+    _trust: trust,
   };
 }

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -489,10 +489,11 @@ test("pipeline: veto-window tier surfaces the veto verb; missing veto writer deg
       load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }),
       save: async () => {},
     },
-    engineState: {
-      load: async () => ({ v: 1, trust: { tiers: { "record-decision": "veto-window" } } }),
+    trustStore: {
+      load: async () => ({ v: 1, tiers: { "record-decision": "veto-window" } }),
       save: async () => {},
     },
+    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
     digests: { list: async () => [], load: async () => null },
     facts: { list: async () => [], load: async () => null },
     configGet: async () => ({ ctoTier: "medium" }),
@@ -527,10 +528,11 @@ test("pipeline: veto-window verb writes the veto card when the writer exists", a
       load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }),
       save: async () => {},
     },
-    engineState: {
-      load: async () => ({ v: 1, trust: { tiers: { "record-decision": "veto-window" } } }),
+    trustStore: {
+      load: async () => ({ v: 1, tiers: { "record-decision": "veto-window" } }),
       save: async () => {},
     },
+    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
     digests: { list: async () => [], load: async () => null },
     facts: { list: async () => [], load: async () => null },
     configGet: async () => ({ ctoTier: "medium" }),
@@ -561,7 +563,7 @@ test("pipeline: veto-window verb writes the veto card when the writer exists", a
 test("pipeline: act tier + executable action executes, ledgers, and queues the digest report", async () => {
   const h = makeHarness();
   const executed = [];
-  let es = { v: 1, trust: { tiers: { "record-decision": "act" } } }; // memory-backed: recordAct persists the pending report
+  let es = { v: 1, tiers: { "record-decision": "act" } }; // memory-backed trust store: recordAct persists the pending report
   const sug2 = createCtoSuggest({
     now: () => h.clock.ms,
     publish: () => {},
@@ -570,12 +572,13 @@ test("pipeline: act tier + executable action executes, ledgers, and queues the d
       load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }),
       save: async () => {},
     },
-    engineState: {
+    trustStore: {
       load: async () => es,
       save: async (p) => {
         es = p;
       },
     },
+    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
     digests: { list: async () => [], load: async () => null },
     facts: { list: async () => [], load: async () => null },
     configGet: async () => ({ ctoTier: "medium" }),
@@ -619,10 +622,11 @@ test("pipeline: act tier + unexecutable action degrades to the veto-window verb 
       load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }),
       save: async () => {},
     },
-    engineState: {
-      load: async () => ({ v: 1, trust: { tiers: { "start-job": "act" } } }),
+    trustStore: {
+      load: async () => ({ v: 1, tiers: { "start-job": "act" } }),
       save: async () => {},
     },
+    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
     digests: { list: async () => [], load: async () => null },
     facts: { list: async () => [], load: async () => null },
     configGet: async () => ({ ctoTier: "medium" }),
@@ -654,10 +658,11 @@ test("pipeline: cold start keeps an act-tier class capped at the ask verb (§10.
     publish: () => {},
     ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
     verdicts: { load: async () => ({ entries: [] }), save: async () => {} }, // cold start
-    engineState: {
-      load: async () => ({ v: 1, trust: { tiers: { "record-decision": "act" } } }),
+    trustStore: {
+      load: async () => ({ v: 1, tiers: { "record-decision": "act" } }),
       save: async () => {},
     },
+    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
     digests: { list: async () => [], load: async () => null },
     facts: { list: async () => [], load: async () => null },
     configGet: async () => ({ ctoTier: "medium" }),

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -109,8 +109,23 @@ test("decideVerb: p between p_ask and p_act → decision (no notify unless recur
   assert.deepEqual(decideVerb({ p: 0.8, sourceKind: "fact-anomaly" }), { verb: "decision", notify: false });
 });
 
-test("decideVerb: act branch is unreachable in P2 — throws on p >= p_act", () => {
-  assert.throws(() => decideVerb({ p: 0.99 }), /nothing acts in P2/);
+test("decideVerb: act branch without trust — throws on p >= p_act (BET-1403: ask-tier hold)", () => {
+  assert.throws(() => decideVerb({ p: 0.99 }), /class not trusted/);
+  // Eligibility gates the climb (§9.3): an ask-capped class never leaves the
+  // ask verbs even when its tier record somehow reads promoted.
+  assert.throws(() => decideVerb({ p: 0.99, tier: "act", eligible: false }), /class not trusted/);
+});
+
+test("decideVerb: trust ladder raises the ceiling (§9.2/§9.4)", () => {
+  // veto-window tier: p >= p_ask surfaces the veto-window verb.
+  assert.deepEqual(decideVerb({ p: 0.6, tier: "veto-window", eligible: true }), { verb: "veto-window", notify: false });
+  // act tier but below the act bar → still the veto-window verb.
+  assert.deepEqual(decideVerb({ p: 0.6, tier: "act", eligible: true }), { verb: "veto-window", notify: false });
+  // act tier + p >= p_act → the act verb fires.
+  assert.deepEqual(decideVerb({ p: 0.99, tier: "act", eligible: true }), { verb: "act", notify: false });
+  assert.deepEqual(decideVerb({ p: 0.99, tier: "act", eligible: true, sourceKind: "watcher-hit-rate" }), { verb: "act", notify: true });
+  // cold-start dominates the ladder (§10.6-4): capped at ask whatever the tier.
+  assert.deepEqual(decideVerb({ p: 0.99, coldStart: true, tier: "act", eligible: true }), { verb: "decision", capped: true, notify: false });
 });
 
 test("decideVerb: cold-start caps high-score candidates at the ask verb (no throw)", () => {

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -471,3 +471,290 @@ test("production wiring can surface a decision card: reliability 1.0 × prior 0.
   assert.equal(h.cardPayload.cards.length, 1);
   assert.equal(h.cardPayload.cards[0].variant, "decision");
 });
+
+// ---------------------------------------------------------------------------
+// BET-1403 — the trust ladder in the pipeline (§9.2/§9.3/§9.4)
+// ---------------------------------------------------------------------------
+
+test("pipeline: veto-window tier surfaces the veto verb; missing veto writer degrades to the decision card", async () => {
+  const h = makeHarness();
+  // Promote the class by seeding the trust state directly (same store the
+  // suggest engine consults), with a non-cold-start verdict ledger.
+  await h.setEngineState({ v: 1, trust: { tiers: { "record-decision": "veto-window" } } });
+  const sug2 = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
+    verdicts: {
+      load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }),
+      save: async () => {},
+    },
+    engineState: {
+      load: async () => ({ v: 1, trust: { tiers: { "record-decision": "veto-window" } } }),
+      save: async () => {},
+    },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({ ctoTier: "medium" }),
+    cards: {
+      upsertDecision: async (c) => {
+        h.cardPayload.cards.push(c);
+        return { changed: true, isNew: true };
+      },
+      // no upsertVeto — BET-1419 ships it; the verb must degrade, not vanish
+    },
+    runSuggest: async () => ({
+      text: JSON.stringify({ candidates: [{ class: "record-decision", finding: { text: "a", refs: [] }, options: [{ label: "Go", action: { type: "record-decision", payload: {} } }] }] }),
+    }),
+    runWorthiness: async () => ({ text: "0.9" }),
+    senderReliability: async () => 1.0,
+  });
+  const r = await sug2.processFinding({ id: "rec:vd", sourceKind: "fact-anomaly", text: "a", refs: [] }, { coldStart: false, tier: "medium" });
+  assert.equal(r.surfaced, 1);
+  assert.equal(h.cardPayload.cards.length, 1);
+  assert.equal(h.cardPayload.cards[0].variant, "decision"); // degraded veto verb
+  assert.ok(h.ledgerRows.some((x) => x.kind === "suggest.presented" && x.variant === "decision"));
+});
+
+test("pipeline: veto-window verb writes the veto card when the writer exists", async () => {
+  const h = makeHarness();
+  const vetoCards = [];
+  const sug2 = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
+    verdicts: {
+      load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }),
+      save: async () => {},
+    },
+    engineState: {
+      load: async () => ({ v: 1, trust: { tiers: { "record-decision": "veto-window" } } }),
+      save: async () => {},
+    },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({ ctoTier: "medium" }),
+    cards: {
+      upsertDecision: async (c) => {
+        h.cardPayload.cards.push(c);
+        return { changed: true, isNew: true };
+      },
+      upsertVeto: async (c) => {
+        vetoCards.push(c);
+        return { changed: true, isNew: true };
+      },
+    },
+    runSuggest: async () => ({
+      text: JSON.stringify({ candidates: [{ class: "record-decision", finding: { text: "a", refs: [] }, options: [{ label: "Go", action: { type: "record-decision", payload: {} } }] }] }),
+    }),
+    runWorthiness: async () => ({ text: "0.9" }),
+    senderReliability: async () => 1.0,
+  });
+  const r = await sug2.processFinding({ id: "rec:vv", sourceKind: "fact-anomaly", text: "a", refs: [] }, { coldStart: false, tier: "medium" });
+  assert.equal(r.surfaced, 1);
+  assert.equal(vetoCards.length, 1);
+  assert.equal(vetoCards[0].variant, "veto");
+  assert.equal(h.cardPayload.cards.length, 0); // no ask-card fallback
+  assert.ok(h.ledgerRows.some((x) => x.kind === "suggest.presented" && x.variant === "veto"));
+});
+
+test("pipeline: act tier + executable action executes, ledgers, and queues the digest report", async () => {
+  const h = makeHarness();
+  const executed = [];
+  let es = { v: 1, trust: { tiers: { "record-decision": "act" } } }; // memory-backed: recordAct persists the pending report
+  const sug2 = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
+    verdicts: {
+      load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }),
+      save: async () => {},
+    },
+    engineState: {
+      load: async () => es,
+      save: async (p) => {
+        es = p;
+      },
+    },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({ ctoTier: "medium" }),
+    cards: {
+      upsertDecision: async (c) => {
+        h.cardPayload.cards.push(c);
+        return { changed: true, isNew: true };
+      },
+    },
+    executeAction: async ({ cls, action }) => {
+      executed.push({ cls, action });
+      return { ok: true };
+    },
+    runSuggest: async () => ({
+      text: JSON.stringify({ candidates: [{ class: "record-decision", finding: { text: "Adopt pact", refs: ["msg:1"] }, options: [{ label: "Record", action: { type: "record-decision", payload: { statement: "x" } } }] }] }),
+    }),
+    runWorthiness: async () => ({ text: "1.0" }), // p = 1.0 × 1.0 (prior override) ≥ p_act → act verb
+    senderReliability: async () => 1.0,
+    classPriors: { "record-decision": 1.0 },
+  });
+  const r = await sug2.processFinding({ id: "rec:aa", sourceKind: "fact-anomaly", text: "a", refs: [] }, { coldStart: false, tier: "medium" });
+  assert.equal(r.surfaced, 1);
+  assert.equal(executed.length, 1);
+  assert.equal(executed[0].action.type, "record-decision");
+  assert.equal(h.cardPayload.cards.length, 0); // no card — it acted
+  assert.ok(h.ledgerRows.some((x) => x.kind === "suggest.acted" && x.class === "record-decision"));
+  // The mandatory report (§9.2 invariant 1) is queued for the next digest.
+  const pending = await sug2._trust.listAnnouncements();
+  assert.equal(pending.length, 1);
+  assert.equal(pending[0].kind, "act");
+  assert.match(pending[0].text, /^Acted on my own \(record-decision\)/);
+});
+
+test("pipeline: act tier + unexecutable action degrades to the veto-window verb (never silently acts)", async () => {
+  const h = makeHarness();
+  const sug2 = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
+    verdicts: {
+      load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }),
+      save: async () => {},
+    },
+    engineState: {
+      load: async () => ({ v: 1, trust: { tiers: { "start-job": "act" } } }),
+      save: async () => {},
+    },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({ ctoTier: "medium" }),
+    cards: {
+      upsertDecision: async (c) => {
+        h.cardPayload.cards.push(c);
+        return { changed: true, isNew: true };
+      },
+    },
+    // no executeAction seam wired for this class → refuse
+    runSuggest: async () => ({
+      text: JSON.stringify({ candidates: [{ class: "start-job", finding: { text: "a", refs: [] }, options: [{ label: "Go", action: { type: "start-job", payload: {} } }] }] }),
+    }),
+    runWorthiness: async () => ({ text: "1.0" }),
+    senderReliability: async () => 1.0,
+  });
+  const r = await sug2.processFinding({ id: "rec:de", sourceKind: "fact-anomaly", text: "a", refs: [] }, { coldStart: false, tier: "medium" });
+  assert.equal(r.surfaced, 1);
+  assert.equal(h.cardPayload.cards.length, 1); // degraded to the ask card (no veto writer)
+  assert.equal(h.ledgerRows.filter((x) => x.kind === "suggest.acted").length, 0);
+  assert.equal((await sug2._trust.listAnnouncements()).length, 0);
+});
+
+test("pipeline: cold start keeps an act-tier class capped at the ask verb (§10.6-4 dominance)", async () => {
+  const h = makeHarness();
+  const executed = [];
+  const sug2 = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
+    verdicts: { load: async () => ({ entries: [] }), save: async () => {} }, // cold start
+    engineState: {
+      load: async () => ({ v: 1, trust: { tiers: { "record-decision": "act" } } }),
+      save: async () => {},
+    },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({ ctoTier: "medium" }),
+    cards: {
+      upsertDecision: async (c) => {
+        h.cardPayload.cards.push(c);
+        return { changed: true, isNew: true };
+      },
+    },
+    executeAction: async ({ cls, action }) => {
+      executed.push({ cls, action });
+      return { ok: true };
+    },
+    runSuggest: async () => ({
+      text: JSON.stringify({ candidates: [{ class: "record-decision", finding: { text: "a", refs: [] }, options: [{ label: "Go", action: { type: "record-decision", payload: {} } }] }] }),
+    }),
+    runWorthiness: async () => ({ text: "1.0" }),
+    senderReliability: async () => 1.0,
+  });
+  const r = await sug2.processFinding({ id: "rec:cs", sourceKind: "fact-anomaly", text: "a", refs: [] }, { coldStart: true, tier: "medium" });
+  assert.equal(r.surfaced, 1);
+  assert.equal(executed.length, 0); // never acts under the cold-start gate
+  assert.equal(h.cardPayload.cards[0].capped, true);
+});
+
+test("pipeline: an act-tier ask-capped class still throws into the hold (§9.3 eligibility)", async () => {
+  const h = makeHarness();
+  const sug2 = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
+    verdicts: {
+      load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }),
+      save: async () => {},
+    },
+    engineState: {
+      // config-change is §9.3-capped; even a corrupt/foreign "act" tier row
+      // must never raise the ceiling — decideVerb throws, the pipeline holds.
+      load: async () => ({ v: 1, trust: { tiers: { "config-change": "act" } } }),
+      save: async () => {},
+    },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({ ctoTier: "medium" }),
+    cards: { upsertDecision: async () => ({ changed: true }) },
+    executeAction: async () => ({ ok: true }),
+    runSuggest: async () => ({
+      text: JSON.stringify({ candidates: [{ class: "config-change", finding: { text: "a", refs: [] }, options: [{ label: "Go", action: { type: "config-change", payload: {} } }] }] }),
+    }),
+    runWorthiness: async () => ({ text: "1.0" }), // p = 1.0 ≥ p_act — the act branch, refused for a capped class
+    senderReliability: async () => 1.0,
+    classPriors: { "config-change": 1.0 },
+  });
+  const r = await sug2.processFinding({ id: "rec:cc", sourceKind: "fact-anomaly", text: "a", refs: [] }, { coldStart: false, tier: "medium" });
+  assert.equal(r.surfaced, 0);
+  assert.equal(r.silent, 1);
+  assert.ok(h.ledgerRows.some((x) => x.kind === "suggest.silent" && x.reason === "act-not-trusted"));
+});
+
+test("verdictHeld stamps the held row's class onto the subject (§9.4 attribution)", async () => {
+  const h = makeHarness();
+  const sug1 = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
+    verdicts: h.verdicts,
+    engineState: { load: async () => ({}), save: async () => {} },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({}),
+    runSuggest: async () => ({
+      text: JSON.stringify({ candidates: [{ class: "start-job", finding: { text: "a", refs: [] }, options: [{ label: "Go", action: { type: "start-job", payload: {} } }] }] }),
+    }),
+    runWorthiness: async () => ({ text: "0.1" }), // p below p_ask → silent-log (a HELD row)
+    senderReliability: async () => 1.0,
+  });
+  await sug1.processFinding(
+    { id: "rec:h1", sourceKind: "fact-anomaly", text: "a", refs: [] },
+    { coldStart: false, tier: "medium" }
+  );
+  const sid = stableSuggestionId("rec:h1", "start-job");
+  const recorded = [];
+  const sug2 = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
+    verdicts: h.verdicts,
+    engineState: { load: async () => ({}), save: async () => {} },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({}),
+    recordVerdict: async ({ subject, verdict }) => {
+      recorded.push({ subject, verdict });
+      return { ok: true };
+    },
+  });
+  await sug2.verdictHeld({ id: sid, verdict: "accept" });
+  assert.equal(recorded.length, 1);
+  assert.equal(recorded[0].subject.class, "start-job");
+});

--- a/src/server/ctoTrust.mjs
+++ b/src/server/ctoTrust.mjs
@@ -160,9 +160,16 @@ export function createCtoTrust(deps = {}) {
     };
   }
 
-  async function saveState(es, st) {
+  async function saveState(_esSnapshot, st) {
+    // Re-read the engine state AT SAVE TIME and merge only the `trust` key:
+    // the trust engine writes fire-and-forget (§9.5 sink dispatch), so an
+    // es snapshot taken at load would clobber keys another writer changed in
+    // between (e.g. a tonight-queue edit landing while a verdict's trust
+    // fold is in flight — the stale-snapshot class of bug). The snapshot
+    // parameter stays for call-site compatibility but is never spread.
     try {
-      await engineState.save({ ...es, trust: st });
+      const fresh = (await engineState.load().catch(() => null)) ?? {};
+      await engineState.save({ ...fresh, trust: st });
     } catch {
       /* best-effort */
     }

--- a/src/server/ctoTrust.mjs
+++ b/src/server/ctoTrust.mjs
@@ -1,0 +1,339 @@
+// src/server/ctoTrust.mjs
+// BET-1403 — Earned-trust promotion ladder + act-and-report bookkeeping
+// (spec §9.2 verbs, §9.3 reversibility eligibility, §9.4 promotion math).
+//
+// Responsibilities:
+//   - `eligibilityOf` — the §9.3 class → reversibility map. Only read-only,
+//     worktree-isolated, or trivially-reversible classes may climb past the
+//     ask verb; anything touching user session, protected refs, production,
+//     money, config, or secrets is capped at ask permanently. Unknown class
+//     = capped (fail-closed).
+//   - `evaluateTier` — the §9.4 ladder math for one class: promotion on the
+//     Beta tail bar (P(acceptance > 0.9) > 0.95 with ≥ 8 observations, via
+//     B3's `betaTailAbove`), demotion on any 2 rejections in a rolling 10,
+//     the §10.6-4 global cold-start gate dominating every promotion.
+//   - `createCtoTrust` — the stateful engine over the shared engine-state
+//     (`es.trust`): per-class tiers + Beta counters + rolling outcome window,
+//     the B3 verdict-sink target (`noteVerdictEffects`), the veto-window
+//     record (`noteVetoOutcome`), and the act-and-report ledger + digest
+//     announcement queue (`recordAct` / `listAnnouncements` /
+//     `markAnnounced`). Tier changes and acts are ledgered (A1 rows) AND
+//     queued as pending progress asides for the next digest (§9.4).
+//
+// Pure over injected stores + a now() clock — testable without a live box.
+
+import { betaTailAbove } from "./ctoVerdicts.mjs";
+import { engineStateStore, ledgerStore, verdictsStore } from "./ctoStores.mjs";
+
+// The §3.5 ladder rungs, lowest → highest. `ask` covers the ask verbs
+// (silent-log / inbox card / notify — ctoSuggest picks within the rung);
+// `veto-window` and `act` are the promoted verbs of §9.2.
+export const TIER_ASK = "ask";
+export const TIER_VETO_WINDOW = "veto-window";
+export const TIER_ACT = "act";
+export const TIERS = Object.freeze([TIER_ASK, TIER_VETO_WINDOW, TIER_ACT]);
+
+// §9.4 promotion bar — P(acceptance > 0.9) > 0.95 with ≥ 8 observations.
+export const PROMOTE_MIN_OBS = 8;
+export const PROMOTE_TAIL_P = 0.9;
+export const PROMOTE_TAIL_CONF = 0.95;
+
+// §9.4 demotion rule — any 2 rejections in a rolling 10 → one step down.
+export const REJECT_WINDOW = 10;
+export const REJECT_DEMOTE = 2;
+
+// §10.6-4 cold-start gate: no class leaves ask verbs before the global
+// verdict ledger holds at least this many verdicts. Moved here from
+// ctoSuggest (which re-exports it) so the gate has one owner.
+export const VERDICT_MIN = 15;
+
+// §9.3 reversibility eligibility map (normative per class; unknown = capped).
+//  - record-decision: a fact on the CTO's own blackboard — trivially
+//    reversible (a later fact supersedes it).
+//  - queue-tonight: a planning-only queue entry — trivially reversible
+//    (removed from the queue; nothing ran).
+//  - start-job: delegate work — worktree-isolated by construction (own git
+//    worktree + branch; never touches the user's checkout).
+//  - config-change: touches config → §9.3 says capped at ask permanently.
+//  - tool-write: writes external tool state — not read-only, not isolated,
+//    not reversible → capped.
+export const ELIGIBILITY = Object.freeze({
+  "record-decision": "eligible",
+  "queue-tonight": "eligible",
+  "start-job": "eligible",
+  "config-change": "ask-capped",
+  "tool-write": "ask-capped",
+});
+
+export function eligibilityOf(cls) {
+  return ELIGIBILITY[cls] === "eligible" ? "eligible" : "ask-capped";
+}
+
+// The §9.4 tail gate for one Beta record: ≥ 8 observations AND
+// P(mean > 0.9) ≥ 0.95. A degenerate Beta (all successes, b = 0) never
+// passes — the estimator refuses zero-variance records on purpose.
+export function betaPasses(a, b) {
+  const n = (a || 0) + (b || 0);
+  return n >= PROMOTE_MIN_OBS && betaTailAbove(a, b, PROMOTE_TAIL_P, PROMOTE_TAIL_CONF);
+}
+
+// The §9.4 ladder evaluation for ONE class. Pure: reads the tier + the
+// per-tier Beta records + the rolling outcome window; returns the target
+// tier. Demotion is evaluated first (rejection pressure is the newer
+// signal — never promote a class whose recent record is bleeding). A
+// demotion consumes the rolling window (the caller resets it on change), so
+// the same evidence cannot re-demote forever.
+export function evaluateTier({
+  tier = TIER_ASK,
+  eligible = false,
+  coldStart = false,
+  ask = {},
+  veto = {},
+  recent = [],
+} = {}) {
+  const t = TIERS.includes(tier) ? tier : TIER_ASK;
+  if (!eligible) return { tier: t, changed: false };
+  const rejects = recent.filter((r) => r && r.ok === false).length;
+  if (rejects >= REJECT_DEMOTE) {
+    const to = TIERS[Math.max(0, TIERS.indexOf(t) - 1)];
+    return { tier: to, changed: to !== t, reason: "demote-rolling-rejects" };
+  }
+  if (t === TIER_ASK && coldStart) return { tier: t, changed: false };
+  if (t === TIER_ASK && betaPasses(ask.a, ask.b)) {
+    return { tier: TIER_VETO_WINDOW, changed: true, reason: "promote-ask-tail" };
+  }
+  if (t === TIER_VETO_WINDOW && betaPasses(veto.va, veto.vb)) {
+    return { tier: TIER_ACT, changed: true, reason: "promote-veto-tail" };
+  }
+  return { tier: t, changed: false };
+}
+
+function announcementText(cls, from, to, reason) {
+  const n = `${reason}`.startsWith("demote")
+    ? `${REJECT_DEMOTE} rejections in the last ${REJECT_WINDOW} judgments`
+    : `acceptance tail cleared (${PROMOTE_MIN_OBS}+ observations)`;
+  return from === TIER_ASK
+    ? `Trust promoted: the "${cls}" class may now use the ${to} verb (${n}).`
+    : `Trust demoted: the "${cls}" class stepped back to ${to} (${n}).`;
+}
+
+function actReportText(cls, text) {
+  return `Acted on my own (${cls}): ${text}`;
+}
+
+// ---------------------------------------------------------------------------
+// The trust engine
+// ---------------------------------------------------------------------------
+
+export function createCtoTrust(deps = {}) {
+  const {
+    engineState = engineStateStore,
+    ledger = ledgerStore,
+    verdicts = verdictsStore,
+    now = () => Date.now(),
+  } = deps;
+
+  const PENDING_CAP = 50;
+
+  function blankStats() {
+    return { a: 0, b: 0, va: 0, vb: 0, recent: [] };
+  }
+
+  async function ledgerAppend(entry) {
+    try {
+      await ledger.append({ actor: "cto", ts: now(), ...entry });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  async function loadState() {
+    let es = {};
+    try {
+      es = (await engineState.load()) || {};
+    } catch {
+      es = {};
+    }
+    const st = (es.trust && typeof es.trust === "object") ? es.trust : {};
+    return {
+      es,
+      st,
+      tiers: (st.tiers && typeof st.tiers === "object") ? st.tiers : {},
+      stats: (st.stats && typeof st.stats === "object") ? st.stats : {},
+      pending: Array.isArray(st.pending) ? st.pending : [],
+    };
+  }
+
+  async function saveState(es, st) {
+    try {
+      await engineState.save({ ...es, trust: st });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  async function countVerdicts() {
+    try {
+      const payload = await verdicts.load();
+      return Array.isArray(payload?.entries) ? payload.entries.length : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  // READ path for verb selection (§9.4): the class's current tier, gated by
+  // the §10.6-4 cold-start dominance — while the global verdict ledger is
+  // under VERDICT_MIN, every class reads as ask regardless of its counters.
+  async function consult(cls, { coldStart = false } = {}) {
+    const { tiers } = await loadState();
+    const tier = TIERS.includes(tiers?.[cls]) ? tiers[cls] : TIER_ASK;
+    const eligible = eligibilityOf(cls) === "eligible";
+    return {
+      tier: coldStart ? TIER_ASK : tier,
+      eligible,
+      capped: coldStart && tier !== TIER_ASK,
+    };
+  }
+
+  // Apply one outcome for a class: bump the Beta counter the outcome feeds,
+  // push the rolling window, re-evaluate the tier; ledger + announce a change.
+  // `field` is which Beta counter the outcome feeds — "a"/"b" for the ask
+  // record, "va"/"vb" for the veto-window record. `countRecent` keeps a
+  // non-counter outcome (e.g. a veto cancel when already at act) in the
+  // rolling window without touching either Beta.
+  async function applyOutcome(cls, { field = null, ok }) {
+    const { es, st, tiers, stats, pending } = await loadState();
+    const tier0 = TIERS.includes(tiers[cls]) ? tiers[cls] : TIER_ASK;
+    const s = stats[cls] && typeof stats[cls] === "object" ? { ...blankStats(), ...stats[cls] } : blankStats();
+    if (field) s[field] = (s[field] || 0) + 1;
+    s.recent = [...(Array.isArray(s.recent) ? s.recent : []), { ok: ok === true, ts: now() }].slice(-REJECT_WINDOW);
+
+    const eligible = eligibilityOf(cls) === "eligible";
+    const coldStart = (await countVerdicts()) < VERDICT_MIN;
+    const ev = evaluateTier({
+      tier: tier0,
+      eligible,
+      coldStart,
+      ask: { a: s.a, b: s.b },
+      veto: { va: s.va, vb: s.vb },
+      recent: s.recent,
+    });
+
+    let nextPending = pending.slice();
+    if (ev.changed) {
+      tiers[cls] = ev.tier;
+      s.recent = []; // the rolling window is consumed by the transition
+      // Ladder direction by RUNG order (never lexical — "act" < "veto-window"
+      // as strings), so an act promotion is never mislabeled a demotion.
+      const promoted = TIERS.indexOf(ev.tier) > TIERS.indexOf(tier0);
+      nextPending.push({
+        id: `trust-${now()}-${Math.random().toString(36).slice(2, 8)}`,
+        ts: now(),
+        kind: promoted ? "promoted" : "demoted",
+        text: announcementText(cls, tier0, ev.tier, ev.reason),
+        refs: [],
+      });
+      await ledgerAppend({
+        kind: promoted ? "trust.promoted" : "trust.demoted",
+        cls,
+        from: tier0,
+        to: ev.tier,
+        reason: ev.reason,
+      });
+    }
+    stats[cls] = s;
+    await saveState(es, { ...st, tiers, stats, pending: nextPending.slice(-PENDING_CAP) });
+    return { tier: ev.tier, changed: ev.changed === true };
+  }
+
+  // The B3 verdict-sink target (§9.5). Only suggestion verdicts attributed
+  // with an action class feed trust counters. A `veto` verdict IS the
+  // veto-window record (a cancelled window, §9.5 table) — it feeds the
+  // veto-tier Beta, never the ask Beta. open/expire/access/decay outcomes
+  // never enter acceptance counters (§9.5 mapping is normative).
+  async function noteVerdictEffects(effects, entry) {
+    if (entry?.subject?.type !== "suggestion") return { changed: false };
+    const cls = entry?.subject?.class;
+    if (!cls || typeof cls !== "string") return { changed: false };
+    if (entry?.verdict === "veto") {
+      return applyOutcome(cls, { field: "vb", ok: false });
+    }
+    if (effects?.success) return applyOutcome(cls, { field: "a", ok: true });
+    if (effects?.rejection) return applyOutcome(cls, { field: "b", ok: false });
+    return { changed: false };
+  }
+
+  // The veto-window record (§9.4): a window that elapsed and executed is an
+  // acceptance; a cancel is a rejection. The veto-window verb machinery
+  // (BET-1419's card flow) calls this when a window resolves — either way.
+  async function noteVetoOutcome(cls, { accepted = false } = {}) {
+    if (!cls || typeof cls !== "string") return { changed: false };
+    return applyOutcome(cls, accepted ? { field: "va", ok: true } : { field: "vb", ok: false });
+  }
+
+  // act-and-report bookkeeping (§9.2): the execution is ledgered AND queued
+  // as a pending digest announcement — the mandatory report (spec §9.2
+  // invariant 1: an act must appear in the next digest). No counters: an
+  // act-tier execution is the top rung, not an acceptance input.
+  async function recordAct({ cls, text, refs = [], action = null } = {}) {
+    if (!cls || typeof cls !== "string") return { ok: false };
+    const { es, st, pending } = await loadState();
+    const t = now();
+    const row = {
+      id: `act-${t}-${Math.random().toString(36).slice(2, 8)}`,
+      ts: t,
+      kind: "act",
+      cls,
+      text: actReportText(cls, typeof text === "string" && text.trim() ? text.trim() : (action?.type ?? "action")),
+      refs: Array.isArray(refs) ? refs.filter((r) => typeof r === "string") : [],
+      actionType: action?.type ?? null,
+    };
+    await ledgerAppend({ kind: "trust.act", cls, text: row.text, refs: row.refs, actionType: row.actionType });
+    await saveState(es, { ...st, pending: [...pending, row].slice(-PENDING_CAP) });
+    return { ok: true, id: row.id };
+  }
+
+  // The digest announcement queue: pending rows (acts + tier changes), then
+  // mark consumed so each appears in exactly one digest.
+  async function listAnnouncements() {
+    const { pending } = await loadState();
+    return pending.slice();
+  }
+
+  async function markAnnounced(ids = []) {
+    if (!Array.isArray(ids) || ids.length === 0) return { removed: 0 };
+    const { es, st, pending } = await loadState();
+    const keep = pending.filter((r) => !ids.includes(r?.id));
+    await saveState(es, { ...st, pending: keep });
+    return { removed: pending.length - keep.length };
+  }
+
+  // Diagnostics (tests / cto panel later): tiers + counters + queue depth.
+  async function getState() {
+    const { tiers, stats, pending } = await loadState();
+    return {
+      tiers: { ...tiers },
+      stats: JSON.parse(JSON.stringify(stats)),
+      pending: pending.length,
+      thresholds: {
+        promoteMinObs: PROMOTE_MIN_OBS,
+        promoteTailP: PROMOTE_TAIL_P,
+        promoteTailConf: PROMOTE_TAIL_CONF,
+        rejectWindow: REJECT_WINDOW,
+        rejectDemote: REJECT_DEMOTE,
+        verdictMin: VERDICT_MIN,
+      },
+    };
+  }
+
+  return {
+    consult,
+    noteVerdictEffects,
+    noteVetoOutcome,
+    recordAct,
+    listAnnouncements,
+    markAnnounced,
+    getState,
+    _applyOutcome: applyOutcome,
+  };
+}

--- a/src/server/ctoTrust.mjs
+++ b/src/server/ctoTrust.mjs
@@ -12,18 +12,21 @@
 //     Beta tail bar (P(acceptance > 0.9) > 0.95 with ≥ 8 observations, via
 //     B3's `betaTailAbove`), demotion on any 2 rejections in a rolling 10,
 //     the §10.6-4 global cold-start gate dominating every promotion.
-//   - `createCtoTrust` — the stateful engine over the shared engine-state
-//     (`es.trust`): per-class tiers + Beta counters + rolling outcome window,
-//     the B3 verdict-sink target (`noteVerdictEffects`), the veto-window
-//     record (`noteVetoOutcome`), and the act-and-report ledger + digest
-//     announcement queue (`recordAct` / `listAnnouncements` /
+//   - `createCtoTrust` — the stateful engine over its OWN store file
+//     (`trust.json` via ctoStores): per-class tiers + Beta counters + rolling
+//     outcome window, the B3 verdict-sink target (`noteVerdictEffects`), the
+//     veto-window record (`noteVetoOutcome`), and the act-and-report ledger +
+//     digest announcement queue (`recordAct` / `listAnnouncements` /
 //     `markAnnounced`). Tier changes and acts are ledgered (A1 rows) AND
-//     queued as pending progress asides for the next digest (§9.4).
+//     queued as pending progress asides for the next digest (§9.4). A legacy
+//     `es.trust` payload is migrated once on first load (review cycle 4:
+//     shared-file writers could revert trust keys — trust now lives where no
+//     snapshot-spreading writer can reach it).
 //
 // Pure over injected stores + a now() clock — testable without a live box.
 
 import { betaTailAbove } from "./ctoVerdicts.mjs";
-import { appendLedgerBestEffort, engineStateStore, ledgerStore, verdictsStore } from "./ctoStores.mjs";
+import { appendLedgerBestEffort, engineStateStore, ledgerStore, trustStore, verdictsStore } from "./ctoStores.mjs";
 
 // The §3.5 ladder rungs, lowest → highest. `ask` covers the ask verbs
 // (silent-log / inbox card / notify — ctoSuggest picks within the rung);
@@ -127,7 +130,8 @@ function actReportText(cls, text) {
 
 export function createCtoTrust(deps = {}) {
   const {
-    engineState = engineStateStore,
+    store = trustStore, // the trust ladder's own file — no other writer touches it
+    legacy = engineStateStore, // one-time migration source: the old `es.trust` payload
     ledger = ledgerStore,
     verdicts = verdictsStore,
     now = () => Date.now(),
@@ -144,15 +148,33 @@ export function createCtoTrust(deps = {}) {
   }
 
   async function loadState() {
-    let es = {};
+    let st = null;
     try {
-      es = (await engineState.load()) || {};
+      st = (await store.load()) ?? null;
     } catch {
-      es = {};
+      st = null;
     }
-    const st = (es.trust && typeof es.trust === "object") ? es.trust : {};
+    // One-time migration (review cycle 4): trust used to live under the
+    // shared engine-state file's `trust` key. If the dedicated store is
+    // still fresh and a legacy payload exists, adopt it — after the first
+    // write the dedicated store is authoritative and `es.trust` becomes a
+    // harmless fossil no reader consults. Idempotent: the store being
+    // non-empty short-circuits the legacy read entirely.
+    if (!st || typeof st !== "object" || (!st.v && !st.tiers && !st.stats && !st.pending)) {
+      let es = {};
+      try {
+        es = (await legacy?.load?.()) ?? {};
+      } catch {
+        es = {};
+      }
+      if (es.trust && typeof es.trust === "object" && (es.trust.tiers || es.trust.stats || es.trust.pending)) {
+        st = es.trust;
+        await store.save(st).catch(() => {});
+      } else {
+        st = {};
+      }
+    }
     return {
-      es,
       st,
       tiers: (st.tiers && typeof st.tiers === "object") ? st.tiers : {},
       stats: (st.stats && typeof st.stats === "object") ? st.stats : {},
@@ -160,16 +182,15 @@ export function createCtoTrust(deps = {}) {
     };
   }
 
-  async function saveState(_esSnapshot, st) {
-    // Re-read the engine state AT SAVE TIME and merge only the `trust` key:
-    // the trust engine writes fire-and-forget (§9.5 sink dispatch), so an
-    // es snapshot taken at load would clobber keys another writer changed in
-    // between (e.g. a tonight-queue edit landing while a verdict's trust
-    // fold is in flight — the stale-snapshot class of bug). The snapshot
-    // parameter stays for call-site compatibility but is never spread.
+  async function saveState(_snapshot, st) {
+    // Trust persists to its OWN file — the durability invariant (review
+    // cycle 4): no engine-state writer shape (snapshot-spread or otherwise)
+    // can revert tiers/counters/pending, because no engine-state writer
+    // touches this file. Callers pass a legacy snapshot for compatibility;
+    // it is never spread. `v` stamps the payload so a later load treats the
+    // store as authoritative even when it only holds the pending queue.
     try {
-      const fresh = (await engineState.load().catch(() => null)) ?? {};
-      await engineState.save({ ...fresh, trust: st });
+      await store.save({ ...(st ?? {}), v: st?.v ?? 1 });
     } catch {
       /* best-effort */
     }
@@ -205,7 +226,7 @@ export function createCtoTrust(deps = {}) {
   // non-counter outcome (e.g. a veto cancel when already at act) in the
   // rolling window without touching either Beta.
   async function applyOutcome(cls, { field = null, ok }) {
-    const { es, st, tiers, stats, pending } = await loadState();
+    const { st, tiers, stats, pending } = await loadState();
     const tier0 = TIERS.includes(tiers[cls]) ? tiers[cls] : TIER_ASK;
     const s = stats[cls] && typeof stats[cls] === "object" ? { ...blankStats(), ...stats[cls] } : blankStats();
     if (field) s[field] = (s[field] || 0) + 1;
@@ -245,7 +266,7 @@ export function createCtoTrust(deps = {}) {
       });
     }
     stats[cls] = s;
-    await saveState(es, { ...st, tiers, stats, pending: nextPending.slice(-PENDING_CAP) });
+    await saveState(null, { ...st, tiers, stats, pending: nextPending.slice(-PENDING_CAP) });
     return { tier: ev.tier, changed: ev.changed === true };
   }
 
@@ -280,7 +301,7 @@ export function createCtoTrust(deps = {}) {
   // act-tier execution is the top rung, not an acceptance input.
   async function recordAct({ cls, text, refs = [], action = null } = {}) {
     if (!cls || typeof cls !== "string") return { ok: false };
-    const { es, st, pending } = await loadState();
+    const { st, pending } = await loadState();
     const t = now();
     const row = {
       id: `act-${t}-${Math.random().toString(36).slice(2, 8)}`,
@@ -292,7 +313,7 @@ export function createCtoTrust(deps = {}) {
       actionType: action?.type ?? null,
     };
     await ledgerAppend({ kind: "trust.act", cls, text: row.text, refs: row.refs, actionType: row.actionType });
-    await saveState(es, { ...st, pending: [...pending, row].slice(-PENDING_CAP) });
+    await saveState(null, { ...st, pending: [...pending, row].slice(-PENDING_CAP) });
     return { ok: true, id: row.id };
   }
 
@@ -305,9 +326,9 @@ export function createCtoTrust(deps = {}) {
 
   async function markAnnounced(ids = []) {
     if (!Array.isArray(ids) || ids.length === 0) return { removed: 0 };
-    const { es, st, pending } = await loadState();
+    const { st, pending } = await loadState();
     const keep = pending.filter((r) => !ids.includes(r?.id));
-    await saveState(es, { ...st, pending: keep });
+    await saveState(null, { ...st, pending: keep });
     return { removed: pending.length - keep.length };
   }
 

--- a/src/server/ctoTrust.mjs
+++ b/src/server/ctoTrust.mjs
@@ -23,7 +23,7 @@
 // Pure over injected stores + a now() clock — testable without a live box.
 
 import { betaTailAbove } from "./ctoVerdicts.mjs";
-import { engineStateStore, ledgerStore, verdictsStore } from "./ctoStores.mjs";
+import { appendLedgerBestEffort, engineStateStore, ledgerStore, verdictsStore } from "./ctoStores.mjs";
 
 // The §3.5 ladder rungs, lowest → highest. `ask` covers the ask verbs
 // (silent-log / inbox card / notify — ctoSuggest picks within the rung);
@@ -140,11 +140,7 @@ export function createCtoTrust(deps = {}) {
   }
 
   async function ledgerAppend(entry) {
-    try {
-      await ledger.append({ actor: "cto", ts: now(), ...entry });
-    } catch {
-      /* best-effort */
-    }
+    return appendLedgerBestEffort(ledger, now(), entry);
   }
 
   async function loadState() {

--- a/src/server/ctoTrust.test.mjs
+++ b/src/server/ctoTrust.test.mjs
@@ -23,11 +23,14 @@ import {
 // ---------------------------------------------------------------------------
 
 function memoryStore(initial = {}) {
-  let data = initial;
+  // Deep-copy at the boundary like the real jsonStore (a parsed clone per
+  // load/save) — aliasing the live object would fake both migrations and
+  // clobbers.
+  let data = JSON.parse(JSON.stringify(initial ?? {}));
   return {
-    load: async () => data,
+    load: async () => JSON.parse(JSON.stringify(data)),
     save: async (p) => {
-      data = p;
+      data = JSON.parse(JSON.stringify(p));
     },
   };
 }
@@ -36,7 +39,10 @@ function makeTrust({ engineState = {}, verdictCount = 0 } = {}) {
   const ledgerRows = [];
   const verdictEntries = Array.from({ length: verdictCount }, (_, i) => ({ ts: i, subject: { type: "suggestion", id: `s${i}`, class: "start-job" }, verdict: "accept" }));
   const stores = {
-    engineState: memoryStore({ v: 1, ...engineState }),
+    // The trust ladder's own file — fresh unless a test seeds it directly.
+    store: memoryStore({}),
+    // The legacy engine-state file (the old `es.trust` home) — migration source.
+    legacy: memoryStore({ v: 1, ...engineState }),
     ledger: { append: async (r) => ledgerRows.push(r), read: async () => ledgerRows },
     verdicts: memoryStore({ v: 1, entries: verdictEntries }),
   };
@@ -158,6 +164,39 @@ test("evaluateTier: demotion is evaluated before promotion (rejection pressure w
 // ---------------------------------------------------------------------------
 // The trust engine
 // ---------------------------------------------------------------------------
+
+test("persistence: a legacy es.trust payload migrates into the dedicated store on first load (review cycle 4)", async () => {
+  const h = makeTrust({ engineState: { trust: { tiers: { "start-job": TIER_VETO_WINDOW }, stats: { "start-job": { a: 40, b: 1, va: 3, vb: 0, recent: [] } } } } });
+  // First read adopts the legacy payload…
+  const st = await h.trust.getState();
+  assert.equal(st.tiers["start-job"], TIER_VETO_WINDOW);
+  assert.equal(st.stats["start-job"]?.a, 40);
+  // …the dedicated store now holds it…
+  const inStore = await h.stores.store.load();
+  assert.equal(inStore.tiers["start-job"], TIER_VETO_WINDOW);
+  // …and a subsequent write goes to the dedicated store, never back into
+  // the engine-state snapshot.
+  await h.trust.noteVetoOutcome("start-job", { accepted: true });
+  const after = await h.stores.store.load();
+  assert.equal(after.stats["start-job"]?.va, 4);
+  // The legacy file keeps its fossil untouched by design (no engine-state
+  // writes from the trust engine) — readers never consult it again once the
+  // dedicated store is non-empty.
+  assert.equal((await h.stores.legacy.load()).trust.stats["start-job"]?.va, 3);
+});
+
+test("durability: a stale full-engine-state save cannot revert trust keys (the mirrored clobber direction)", async () => {
+  const h = makeTrust({ verdictCount: VERDICT_MIN });
+  await h.trust.noteVerdictEffects({ success: true }, { subject: { type: "suggestion", id: "x", class: "queue-tonight" }, verdict: "accept" });
+  const before = await h.trust.getState();
+  assert.equal(before.stats["queue-tonight"]?.a, 1);
+  // The old writer shape: a whole-file engine-state save spreading a STALE
+  // snapshot — even one that still carries an `es.trust` key (pre-migration
+  // fossil). Trust lives in its own file; this cannot reach it.
+  await h.stores.legacy.save({ v: 1, trust: { tiers: {}, stats: {} }, tonightQueue: [{ id: "tq:1" }] });
+  const after = await h.trust.getState();
+  assert.equal(after.stats["queue-tonight"]?.a, 1, "the trust fold survived the hostile engine-state save");
+});
 
 test("consult: default ask; cold-start caps a promoted tier at ask (§10.6-4 dominance)", async () => {
   const h = makeTrust({ engineState: { trust: { tiers: { "start-job": TIER_VETO_WINDOW } } } });

--- a/src/server/ctoTrust.test.mjs
+++ b/src/server/ctoTrust.test.mjs
@@ -1,0 +1,328 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ELIGIBILITY,
+  PROMOTE_MIN_OBS,
+  PROMOTE_TAIL_CONF,
+  PROMOTE_TAIL_P,
+  REJECT_DEMOTE,
+  REJECT_WINDOW,
+  TIERS,
+  TIER_ACT,
+  TIER_ASK,
+  TIER_VETO_WINDOW,
+  VERDICT_MIN,
+  betaPasses,
+  createCtoTrust,
+  eligibilityOf,
+  evaluateTier,
+} from "./ctoTrust.mjs";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function memoryStore(initial = {}) {
+  let data = initial;
+  return {
+    load: async () => data,
+    save: async (p) => {
+      data = p;
+    },
+  };
+}
+
+function makeTrust({ engineState = {}, verdictCount = 0 } = {}) {
+  const ledgerRows = [];
+  const verdictEntries = Array.from({ length: verdictCount }, (_, i) => ({ ts: i, subject: { type: "suggestion", id: `s${i}`, class: "start-job" }, verdict: "accept" }));
+  const stores = {
+    engineState: memoryStore({ v: 1, ...engineState }),
+    ledger: { append: async (r) => ledgerRows.push(r), read: async () => ledgerRows },
+    verdicts: memoryStore({ v: 1, entries: verdictEntries }),
+  };
+  const trust = createCtoTrust({ ...stores, now: () => 1_000_000 });
+  return { trust, stores, ledgerRows, verdictEntries };
+}
+
+// ---------------------------------------------------------------------------
+// §9.3 eligibility map
+// ---------------------------------------------------------------------------
+
+test("eligibilityOf: reversible/isolated classes are eligible; config/external-tool/unknown are capped", () => {
+  assert.equal(eligibilityOf("record-decision"), "eligible");
+  assert.equal(eligibilityOf("queue-tonight"), "eligible");
+  assert.equal(eligibilityOf("start-job"), "eligible");
+  // §9.3: config and external tool state are capped at ask permanently.
+  assert.equal(eligibilityOf("config-change"), "ask-capped");
+  assert.equal(eligibilityOf("tool-write"), "ask-capped");
+  // Unknown class = capped (fail-closed).
+  assert.equal(eligibilityOf("mystery-class"), "ask-capped");
+  assert.equal(eligibilityOf(undefined), "ask-capped");
+  for (const [k, v] of Object.entries(ELIGIBILITY)) {
+    assert.ok(["eligible", "ask-capped"].includes(v), `eligibility for ${k} must be a known value`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// §9.4 promotion math (Beta tail bar)
+// ---------------------------------------------------------------------------
+
+test("betaPasses: needs >= 8 observations AND the tail over 0.9 at 0.95; a degenerate record never passes", () => {
+  // Degenerate (b=0) — the estimator refuses zero-variance records.
+  assert.equal(betaPasses(9, 0), false);
+  // Below the observation floor.
+  assert.equal(betaPasses(7, 0) || betaPasses(6, 1), false);
+  // Real bars: 25/1 clears, 24/1 does not.
+  assert.equal(betaPasses(25, 1), true);
+  assert.equal(betaPasses(24, 1), false);
+  assert.equal(betaPasses(30, 1), true);
+});
+
+test("evaluateTier: ask tier is pinned by the cold-start gate even with a passing Beta", () => {
+  const r = evaluateTier({
+    tier: TIER_ASK,
+    eligible: true,
+    coldStart: true,
+    ask: { a: 40, b: 1 },
+  });
+  assert.equal(r.tier, TIER_ASK);
+  assert.equal(r.changed, false);
+});
+
+test("evaluateTier: ask → veto-window on the tail bar; eligibility and the tail both gate", () => {
+  const passing = { ask: { a: 30, b: 1 } };
+  const ok = evaluateTier({ tier: TIER_ASK, eligible: true, coldStart: false, ...passing });
+  assert.equal(ok.tier, TIER_VETO_WINDOW);
+  assert.equal(ok.changed, true);
+  // Capped class: same counters, no promotion.
+  const capped = evaluateTier({ tier: TIER_ASK, eligible: false, coldStart: false, ...passing });
+  assert.equal(capped.tier, TIER_ASK);
+  // Tail not cleared: stays ask.
+  const weak = evaluateTier({ tier: TIER_ASK, eligible: true, coldStart: false, ask: { a: 24, b: 1 } });
+  assert.equal(weak.tier, TIER_ASK);
+});
+
+test("evaluateTier: veto-window → act at the same bar over the veto record", () => {
+  const ok = evaluateTier({ tier: TIER_VETO_WINDOW, eligible: true, ask: { a: 40, b: 1 }, veto: { va: 25, vb: 1 } });
+  assert.equal(ok.tier, TIER_ACT);
+  assert.equal(ok.changed, true);
+  const weak = evaluateTier({ tier: TIER_VETO_WINDOW, eligible: true, ask: { a: 40, b: 1 }, veto: { va: 5, vb: 1 } });
+  assert.equal(weak.tier, TIER_VETO_WINDOW);
+});
+
+test("evaluateTier: any 2 rejections in the rolling 10 demote one step, ask is the floor", () => {
+  const recent = [
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: false },
+    { ok: false },
+  ];
+  const down = evaluateTier({ tier: TIER_VETO_WINDOW, eligible: true, ask: { a: 40, b: 1 }, recent });
+  assert.equal(down.tier, TIER_ASK);
+  assert.equal(down.changed, true);
+  // act → veto-window
+  const down2 = evaluateTier({ tier: TIER_ACT, eligible: true, ask: { a: 40, b: 1 }, veto: { va: 25, vb: 1 }, recent });
+  assert.equal(down2.tier, TIER_VETO_WINDOW);
+  // At ask the demotion is a no-op.
+  const floor = evaluateTier({ tier: TIER_ASK, eligible: true, ask: { a: 40, b: 1 }, recent });
+  assert.equal(floor.tier, TIER_ASK);
+  // One rejection in ten does not demote.
+  const one = evaluateTier({ tier: TIER_VETO_WINDOW, eligible: true, recent: [...Array(9).fill({ ok: true }), { ok: false }] });
+  assert.equal(one.tier, TIER_VETO_WINDOW);
+  assert.equal(one.changed, false);
+});
+
+test("evaluateTier: demotion is evaluated before promotion (rejection pressure wins)", () => {
+  const recent = [
+    { ok: false },
+    { ok: false },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+    { ok: true },
+  ];
+  const r = evaluateTier({ tier: TIER_ASK, eligible: true, ask: { a: 30, b: 1 }, recent });
+  assert.equal(r.tier, TIER_ASK); // demote from ask = stay; never promoted in the same eval
+});
+
+// ---------------------------------------------------------------------------
+// The trust engine
+// ---------------------------------------------------------------------------
+
+test("consult: default ask; cold-start caps a promoted tier at ask (§10.6-4 dominance)", async () => {
+  const h = makeTrust({ engineState: { trust: { tiers: { "start-job": TIER_VETO_WINDOW } } } });
+  const noCold = await h.trust.consult("start-job", { coldStart: false });
+  assert.equal(noCold.tier, TIER_VETO_WINDOW);
+  assert.equal(noCold.eligible, true);
+  const cold = await h.trust.consult("start-job", { coldStart: true });
+  assert.equal(cold.tier, TIER_ASK);
+  assert.equal(cold.capped, true);
+  // Unknown class: capped eligibility.
+  const unknown = await h.trust.consult("mystery", { coldStart: false });
+  assert.equal(unknown.eligible, false);
+});
+
+test("noteVerdictEffects: §9.5 mapping into per-class counters — accept/edit success, dismiss/correct rejection, open nothing", async () => {
+  const h = makeTrust({ verdictCount: VERDICT_MIN });
+  const subject = { type: "suggestion", id: "s1", class: "start-job" };
+  await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
+  await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "edit" });
+  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
+  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "correct" });
+  await h.trust.noteVerdictEffects({ access: true }, { subject, verdict: "open" });
+  await h.trust.noteVerdictEffects({ decay: true }, { subject, verdict: "expire" });
+  const st = await h.trust.getState();
+  assert.equal(st.stats["start-job"].a, 2);
+  assert.equal(st.stats["start-job"].b, 2);
+});
+
+test("noteVerdictEffects: non-suggestion subjects and class-less entries advance nothing", async () => {
+  const h = makeTrust({ verdictCount: VERDICT_MIN });
+  await h.trust.noteVerdictEffects({ success: true }, { subject: { type: "digest_item", id: "d", class: "start-job" }, verdict: "accept" });
+  await h.trust.noteVerdictEffects({ success: true }, { subject: { type: "suggestion", id: "s" }, verdict: "accept" });
+  const st = await h.trust.getState();
+  assert.deepEqual(st.stats, {});
+});
+
+test("promotion: accepts past the bar promote ask → veto-window, ledger + digest announcement", async () => {
+  const h = makeTrust({ verdictCount: VERDICT_MIN });
+  const subject = { type: "suggestion", id: "s1", class: "start-job" };
+  // 31 accepts + 1 dismiss: the tail clears (a degenerate b=0 record never
+  // passes — the estimator refuses zero-variance records).
+  for (let i = 0; i < 31; i++) {
+    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
+  }
+  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
+  const st = await h.trust.getState();
+  assert.equal(st.tiers["start-job"], TIER_VETO_WINDOW);
+  assert.ok(h.ledgerRows.some((r) => r.kind === "trust.promoted" && r.cls === "start-job" && r.to === TIER_VETO_WINDOW));
+  assert.equal(st.pending, 1);
+  const pending = await h.trust.listAnnouncements();
+  assert.equal(pending.length, 1);
+  assert.match(pending[0].text, /promoted/);
+  await h.trust.markAnnounced([pending[0].id]);
+  assert.equal((await h.trust.listAnnouncements()).length, 0);
+});
+
+test("promotion never fires under the cold-start gate, whatever the counters say", async () => {
+  const h = makeTrust({ verdictCount: 0 }); // cold start: < VERDICT_MIN verdicts
+  const subject = { type: "suggestion", id: "s1", class: "start-job" };
+  // A record that would pass the tail outside cold start.
+  for (let i = 0; i < 40; i++) {
+    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
+  }
+  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
+  const st = await h.trust.getState();
+  assert.equal(st.pending, 0);
+  // And consult reports the ask cap while the global gate holds.
+  const c = await h.trust.consult("start-job", { coldStart: true });
+  assert.equal(c.tier, TIER_ASK);
+});
+
+test("capped class never promotes even with a stellar record", async () => {
+  const h = makeTrust({ verdictCount: VERDICT_MIN });
+  const subject = { type: "suggestion", id: "c1", class: "config-change" };
+  for (let i = 0; i < 40; i++) {
+    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
+  }
+  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
+  const st = await h.trust.getState();
+  assert.equal(st.tiers["config-change"] ?? TIER_ASK, TIER_ASK);
+  assert.equal(st.pending, 0); // no announcement either
+  const c = await h.trust.consult("config-change", { coldStart: false });
+  assert.equal(c.eligible, false);
+  assert.equal(c.tier, TIER_ASK);
+});
+
+test("veto verdicts feed the veto-window record, not the ask record (§9.5 table note)", async () => {
+  const h = makeTrust({ verdictCount: VERDICT_MIN });
+  const subject = { type: "suggestion", id: "s1", class: "start-job" };
+  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "veto" });
+  const st = await h.trust.getState();
+  assert.equal(st.stats["start-job"].vb, 1);
+  assert.equal(st.stats["start-job"].b, 0);
+});
+
+test("veto-window record: executed windows promote to act; cancels demote (2-in-10)", async () => {
+  const h = makeTrust({
+    verdictCount: VERDICT_MIN,
+    engineState: { trust: { tiers: { "start-job": TIER_VETO_WINDOW }, stats: { "start-job": { a: 40, b: 1, va: 0, vb: 0, recent: [] } } } },
+  });
+  const cls = "start-job";
+  // Executed windows → acceptance into the veto record (30 accepts + 1 cancel
+  // clears the tail; a degenerate all-accept record never passes).
+  for (let i = 0; i < 30; i++) {
+    await h.trust.noteVetoOutcome(cls, { accepted: true });
+  }
+  await h.trust.noteVetoOutcome(cls, { accepted: false });
+  let st = await h.trust.getState();
+  assert.equal(st.tiers[cls], TIER_ACT); // 26 accepts 0 rejects passes the tail
+  assert.ok(h.ledgerRows.some((r) => r.kind === "trust.promoted" && r.to === TIER_ACT));
+
+  // Fresh fixture at veto tier: two cancels → demote to ask.
+  const h2 = makeTrust({
+    verdictCount: VERDICT_MIN,
+    engineState: { trust: { tiers: { "start-job": TIER_VETO_WINDOW }, stats: { "start-job": { a: 40, b: 1, va: 25, vb: 1, recent: [] } } } },
+  });
+  await h2.trust.noteVetoOutcome(cls, { accepted: false });
+  await h2.trust.noteVetoOutcome(cls, { accepted: false });
+  st = await h2.trust.getState();
+  assert.equal(st.tiers[cls], TIER_ASK);
+  assert.ok(h2.ledgerRows.some((r) => r.kind === "trust.demoted" && r.to === TIER_ASK));
+});
+
+test("act-and-report bookkeeping: ledger row + pending announcement, exactly-once consumption", async () => {
+  const h = makeTrust({ verdictCount: VERDICT_MIN });
+  const r = await h.trust.recordAct({ cls: "record-decision", text: "recorded the deploy order decision", refs: ["msg:1"], action: { type: "record-decision", payload: {} } });
+  assert.equal(r.ok, true);
+  assert.ok(h.ledgerRows.some((row) => row.kind === "trust.act" && row.cls === "record-decision"));
+  const pending = await h.trust.listAnnouncements();
+  assert.equal(pending.length, 1);
+  assert.equal(pending[0].kind, "act");
+  assert.match(pending[0].text, /^Acted on my own \(record-decision\)/);
+  assert.deepEqual(pending[0].refs, ["msg:1"]);
+  await h.trust.markAnnounced([r.id]);
+  assert.equal((await h.trust.listAnnouncements()).length, 0);
+  // Marking again is a no-op.
+  const again = await h.trust.markAnnounced([r.id]);
+  assert.equal(again.removed, 0);
+});
+
+test("rolling window is capped and consumed by a tier change", async () => {
+  const h = makeTrust({ verdictCount: VERDICT_MIN });
+  const subject = { type: "suggestion", id: "s1", class: "start-job" };
+  for (let i = 0; i < 31; i++) {
+    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
+  }
+  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
+  let st = await h.trust.getState();
+  assert.equal(st.tiers["start-job"], TIER_VETO_WINDOW);
+  assert.equal(st.stats["start-job"].recent.length, 0); // consumed by promotion
+  // Keep recording: the window caps at REJECT_WINDOW entries.
+  for (let i = 0; i < REJECT_WINDOW + 3; i++) {
+    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
+  }
+  st = await h.trust.getState();
+  assert.equal(st.stats["start-job"].recent.length, REJECT_WINDOW);
+});
+
+test("ladder constants match the spec (§9.4/§10.6-4)", () => {
+  assert.equal(PROMOTE_MIN_OBS, 8);
+  assert.equal(PROMOTE_TAIL_P, 0.9);
+  assert.equal(PROMOTE_TAIL_CONF, 0.95);
+  assert.equal(REJECT_WINDOW, 10);
+  assert.equal(REJECT_DEMOTE, 2);
+  assert.equal(VERDICT_MIN, 15);
+  assert.deepEqual(TIERS, ["ask", "veto-window", "act"]);
+  assert.deepEqual([TIER_ASK, TIER_VETO_WINDOW, TIER_ACT], TIERS);
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -2067,6 +2067,9 @@ let adaptiveCtoDigest = null;
     getInferredTz: async () => adaptiveCto.profile?.getInferredTz?.() ?? null,
     getAudience: async ({ topics } = {}) => adaptiveCto.profile?.getAudience?.({ topics }) ?? null,
     getDeviations: async () => adaptiveCto.profile?.getDeviations?.() ?? [],
+    // BET-1403 (§9.2/§9.4): the trust engine's announcement queue — act-and-
+    // report lines + tier changes, announced as progress asides.
+    trust: adaptiveCto.trust,
     // §14.3 silence audit: how many suggestions the CTO silently held back —
     // drives the in-digest "I held back N — review" aside (lazy: the suggest
     // engine is defined later in this module; resolution happens at generate).
@@ -2148,6 +2151,26 @@ const adaptiveCtoSuggest = createCtoSuggest({
   // tool-write's capability gate is on too, but the §7.4 tool registry
   // (P2-later) still feeds an empty write ring below, so a tool-write option
   // remains data-unreachable until B7 lands (the ring is the real gate).
+  // BET-1403 (§9.2/§9.3): act-and-report executors. The trust ladder only
+  // lets §9.3-eligible classes reach the act verb; this seam decides whether
+  // the concrete bound action is machine-executable. Only record-decision is
+  // wired (a validated, gatekeeper-checked fact proposal on the CTO's own
+  // blackboard); unwired action types refuse → the verb degrades to the
+  // veto-window card. Never throws (ctoSuggest catches).
+  executeAction: async ({ cls, action, candidate }) => {
+    if (cls !== "record-decision" || action?.type !== "record-decision") {
+      return { ok: false, reason: "no-executor" };
+    }
+    const payload = action?.payload && typeof action.payload === "object" ? action.payload : {};
+    const statement = typeof payload.statement === "string" ? payload.statement.trim() : "";
+    const project = typeof payload.project === "string" ? payload.project.trim() : "";
+    const refs = Array.isArray(payload.refs) && payload.refs.length
+      ? payload.refs.filter((r) => typeof r === "string")
+      : (Array.isArray(candidate?.finding?.refs) ? candidate.finding.refs.filter((r) => typeof r === "string") : []);
+    if (!statement || !project || refs.length === 0) return { ok: false, reason: "incomplete-payload" };
+    const result = await adaptiveCto.proposeFact({ project, kind: "decision", statement, refs, sender: "cto" });
+    return result?.ok === true ? { ok: true, detail: "decision fact proposed" } : { ok: false, reason: result?.error ?? "propose-failed" };
+  },
   getWriteRingTools: async () => [], // §7.4 tool registry (P2-later) — empty → tool-write unreachable
   capabilities: { queueTonight: true, toolWrite: true },
   fireNotify: (args) => push.fireNotify(args),
@@ -4446,7 +4469,20 @@ const handleRequest = async (req, res) => {
     try {
       if (req.method === "POST") {
         const body = await readJsonBody(req);
-        const subject = body?.subject ?? null;
+        let subject = body?.subject ?? null;
+        // BET-1403 (§9.4): stamp the action class from the open decision card
+        // so the verdict's trust-counter effects are attributable — the
+        // renderer doesn't know the class; the card is the source of truth.
+        // Best-effort: an unattributable verdict simply advances no counters.
+        if (subject?.type === "suggestion" && typeof subject.id === "string" && subject.class == null) {
+          try {
+            const open = (await adaptiveCto.cards?.listOpen?.()) ?? [];
+            const card = open.find((c) => c?.id === subject.id);
+            if (card?.cls) subject = { ...subject, class: card.cls };
+          } catch {
+            /* best-effort */
+          }
+        }
         const verdict = typeof body?.verdict === "string" ? body.verdict : null;
         const never = body?.never;
         // BET-1419 (§9.2): a veto verdict on the veto-window subject IS the


### PR DESCRIPTION
## Summary

BET-1403 — the Adaptive CTO's earned-trust promotion ladder + act-and-report (spec §9.2/§9.3/§9.4, §3.5, §10.6-4). Normative sections read only (per issue context-budget note).

**New: `src/server/ctoTrust.mjs`** (+ `ctoTrust.test.mjs`, 18 tests)
- §9.4 ladder math: promotion on the Beta tail bar P(acceptance > 0.9) > 0.95 with ≥ 8 observations (reuses B3's `betaTailAbove`); any 2 rejections in a rolling 10 → demote one step (ask is the floor; the rolling window is consumed by the transition so the same evidence can't re-demote forever).
- §10.6-4 cold-start dominance: no class leaves ask before the global verdict ledger holds `VERDICT_MIN` (15) — enforced both at promotion time and at verb-selection time.
- §9.3 eligibility map (literal class → reversibility): `record-decision`/`queue-tonight`/`start-job` eligible; `config-change`/`tool-write` capped at ask permanently; **unknown class = capped** (fail-closed).
- Per-class state persisted under `es.trust` (engine-state, shared store pattern): tiers, ask Beta (a/b), veto-record Beta (va/vb), rolling window, pending digest-announcement queue.
- The B3 verdict sink registry is the counters' only input: `noteVerdictEffects` maps §9.5 (`accept`/`edit` → success; `dismiss`/`correct`/`never` → rejection; `open`/`expire` never counted) and routes a `veto` verdict to the veto-window record, not the ask record. `noteVetoOutcome` is the integration point for BET-1419's window machinery (executed window = acceptance, cancel = rejection).
- act-and-report bookkeeping: `recordAct` ledger rows + pending announcement; `listAnnouncements`/`markAnnounced` give the digest exactly-once consumption.

**Modified: `ctoSuggest.mjs`** — `decideVerb` consults the class's trust tier: at `veto-window` tier the veto-window verb is reachable; at `act` tier + p ≥ p_act the act verb fires (below it, still the veto-window verb). Eligibility gates the climb. The ask-tier hold on p ≥ p_act remains (throw → held row, reason renamed `act-not-trusted`). Verb surfaces degrade honestly, never silently act: act (unexecutable/no executor) → veto-window card (feature-detects `cards.upsertVeto`, which BET-1419 ships) → decision card → no-card-path hold. `verdictHeld` now stamps the held row's action class onto the verdict subject so counters are attributable.

**Modified: `ctoDigest.mjs`** — trust announcements: act lines are injected into the digest input (high-priority block) AND deterministically appended as progress-tier asides (like §8.4 deviations, deduped), guaranteeing the §9.2 invariant-1 mandatory report even on the degraded-digest path. Announcements are marked consumed only after the digest persists. Tier changes ride the same asides.

**Wiring: `ctoEngine.mjs` + `index.mjs`** — the trust sink registers alongside the facts counter-sink on the §9.5 registry; `/api/cto/verdict` stamps `subject.class` from the open decision card (best-effort, fail-closed); `executeAction` seam wires the production act executor for `record-decision` (a validated, gatekeeper-checked fact proposal via the engine's fact route); the digest gets the trust seam.

## Anti-spaghetti notes

- `ctoVerdicts.mjs` needed **no changes** — B3's sink registry (`createCounterRegistry`/`registerCounterSink`) was already trust-ready (its own comment reserves "trust / tool `as_*` counters later"). Extended it rather than adding a parallel recording path.
- `VERDICT_MIN` moved to ctoTrust (single owner of the cold-start gate); ctoSuggest re-exports it — its existing consumers/tests are untouched.
- Known duplicate-site: class attribution happens at two entry points (the verdict route + `verdictHeld`); both stamp from the same source of truth (the card / the ledger row), neither derives it independently.

## Cross-cutting / follow-ups

- Act executors for the remaining §9.3-eligible classes are not wired (`start-job`, `queue-tonight`); a refused executor degrades to the veto-window card — safe, but the top rung stays theoretical for those classes. **Filed: BET-1424 (parked, follow-up label).**
- `cards.upsertVeto` ships with BET-1419; until then the veto verb degrades to the ask card (feature-detected, no contract change).
- In-flight overlap note: BET-1419's PR also touches `ctoSuggest.mjs` (data gates) and `index.mjs` — expect small merge conflicts; this branch is based on fresh `main`.

## Self-check (acceptance criteria scores)

- act/veto verbs reachable via trust record → 9 (veto card writer is BET-1419's; degrade path covered by tests)
- per-class Beta counters via §9.5 sink registry → 9 (unattributable verdicts advance nothing, by design)
- ask→veto-window promotion bar (8 obs, tail) → 10 (25/1 passes, 24/1 fails pinned in tests)
- veto→act at same bar over the veto record, cancel = rejection → 9
- 2 rejections in rolling 10 → demote one step → 9
- promotions/demotions ledgered + digest progress asides → 9
- cold-start gate dominates → 10 (promotion-time + selection-time, both tested)
- §9.3 eligibility map, unknown = capped → 10
- act executes immediately + ledger + MUST appear in next digest (input injection) → 9 (only record-decision executor; BET-1424)
- every actionable follow-up FILEED → 9 (BET-1424 parked; upsertVeto owned by BET-1419)

## Verification results

**Files changed:** 8 files, +1273/−35. `src/server/ctoTrust.mjs` (new), `src/server/ctoTrust.test.mjs` (new), `ctoSuggest.mjs`, `ctoSuggest.test.mjs`, `ctoDigest.mjs`, `ctoDigest.test.mjs`, `ctoEngine.mjs`, `index.mjs`.

- PR branch (`multica/BET-1403-trust-ladder` @ `eb28524b`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3452 pass / 0 fail / 0 skip. Failures: none. log sha256: `34590970aaf34fcaad4eaed263cae81e0a7c31699d9743be10fb8e0b49a89801`
- Base (`main` @ `2cbdad6b`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3422 pass / 0 fail / 0 skip. Failures: none. log sha256: `00a30499a1b1659d9369748df3ae0b4bef931823df642fdf3b21d8e7f01d9ca1`
- **Conclusion:** 0 failures on both branches; 0 new, 0 pre-existing. The branch adds 30 tests (18 trust, 9 suggest-pipeline, 3 digest).

Base: origin/main @ 2cbdad6b
