### PR TITLE
Wire act-and-report executors for start-job and queue-tonight (BET-1424)

### DIFF
--- a/src/server/ctoAct.mjs
+++ b/src/server/ctoAct.mjs
@@ -1,0 +1,217 @@
+// src/server/ctoAct.mjs
+// BET-1424 — the §9.2 act-and-report executors for the §9.3-eligible classes.
+//
+// The suggestion engine's act branch (ctoSuggest.mjs) calls ONE injected
+// `executeAction({cls, action, candidate})` with the candidate's primary bound
+// option. BET-1403 wired only `record-decision` inline in index.mjs; this
+// module owns all three §9.3-eligible executors (ctoTrust.mjs eligibility map)
+// behind one factory:
+//
+//   - record-decision → a gatekeeper-checked decision fact on the CTO's own
+//     blackboard (the engine's fact route). Behavior carried over verbatim
+//     from the BET-1403 inline executor.
+//   - queue-tonight   → an entry in tonight's overnight queue via the engine's
+//     tonightAdd (§10.4/§11.4 — planning-only, nothing runs until the window
+//     opens; trivially reversible).
+//   - start-job       → a worktree-isolated delegate job (own git worktree +
+//     branch; never touches the user's checkout), started with actor "cto"
+//     under the §3.3 delegate gate (kill switch, pause, concurrent cap).
+//
+// Everything else refuses with `no-executor` (config-change is §9.3-capped at
+// ask permanently; tool-write stays data-unreachable until a tool holds the
+// §7.4 write ring). The refusal contract is load-bearing (§9.2): act-and-report
+// must never silently no-op — every refusal returns {ok:false, reason} so the
+// verb degrades to the veto-window card, whose options remain user-executable
+// through the renderer's ask-path executors.
+//
+// Payload normalization: the generator emits free-form payloads; a present-but
+// malformed field refuses the act (incomplete-payload) rather than being
+// silently dropped — the card rendered THIS payload, so executing a doctored
+// version of it would not be acting on what was shown. The field names follow
+// the renderer's ask-path contract (ctoView.ts executeSuggestionOption) where
+// one exists: start-job accepts `cwd` (alias `directory`), queue-tonight reads
+// `cost` as the predictedCost alias.
+//
+// Pure over injected I/O — testable without a live tmux/opencode/delegate.
+
+import { ACTOR, RATE_LIMITS } from "./ctoEngine.mjs";
+import { resolveForgeOwner } from "./delegate.mjs";
+
+// ---------------------------------------------------------------------------
+// Payload normalization (§9.1 schema → the executor's typed input)
+// ---------------------------------------------------------------------------
+
+// record-decision: {statement, project, refs?} (+ finding refs fallback).
+export function normalizeRecordDecisionPayload(payload, { findingRefs = [] } = {}) {
+  const p = payload && typeof payload === "object" ? payload : {};
+  const statement = typeof p.statement === "string" ? p.statement.trim() : "";
+  const project = typeof p.project === "string" ? p.project.trim() : "";
+  const refs = Array.isArray(p.refs) && p.refs.length
+    ? p.refs.filter((r) => typeof r === "string")
+    : (Array.isArray(findingRefs) ? findingRefs.filter((r) => typeof r === "string") : []);
+  if (!statement || !project || refs.length === 0) return null;
+  return { statement, project, refs };
+}
+
+// start-job: {prompt, cwd | directory, model?, ...}. `model` mirrors the
+// delegate engine's startJob contract: a free-text name or a structured
+// {providerID, modelID, variant?}. Returns null when prompt/cwd are missing or
+// when a supplied model has neither a valid shape.
+export function normalizeStartJobPayload(payload) {
+  const p = payload && typeof payload === "object" ? payload : {};
+  const prompt = typeof p.prompt === "string" ? p.prompt.trim() : "";
+  const cwdRaw = typeof p.cwd === "string" && p.cwd.trim() ? p.cwd : (typeof p.directory === "string" ? p.directory : "");
+  const cwd = cwdRaw.trim();
+  if (!prompt || !cwd) return null;
+  let model;
+  if (p.model != null) {
+    if (typeof p.model === "string" && p.model.trim()) {
+      model = p.model.trim();
+    } else if (
+      typeof p.model === "object" && !Array.isArray(p.model) &&
+      typeof p.model.providerID === "string" && p.model.providerID.trim() &&
+      typeof p.model.modelID === "string" && p.model.modelID.trim()
+    ) {
+      model = { providerID: p.model.providerID, modelID: p.model.modelID };
+      if (typeof p.model.variant === "string" && p.model.variant.trim()) model.variant = p.model.variant;
+    } else {
+      return null;
+    }
+  }
+  return model === undefined ? { prompt, cwd } : { prompt, cwd, model };
+}
+
+// queue-tonight: {name?, prompt?, project?, value?, confidence?, cost?/predictedCost?, refs?}.
+// The name falls back to the finding text (what the card shows); tonightAdd
+// still enforces its own name/prompt defaults and caps.
+export function normalizeQueueTonightPayload(payload, { findingText = "", findingRefs = [] } = {}) {
+  const p = payload && typeof payload === "object" ? payload : {};
+  const name = (typeof p.name === "string" && p.name.trim()) || String(findingText ?? "").trim();
+  if (!name) return null;
+  const out = { name };
+  if (typeof p.prompt === "string" && p.prompt.trim()) out.prompt = p.prompt;
+  if (typeof p.project === "string" && p.project.trim()) out.project = p.project.trim();
+  if (Number.isFinite(p.value)) out.value = p.value;
+  if (Number.isFinite(p.confidence)) out.confidence = p.confidence;
+  if (Number.isFinite(p.predictedCost)) out.predictedCost = p.predictedCost;
+  else if (Number.isFinite(p.cost)) out.predictedCost = p.cost;
+  const refs = Array.isArray(p.refs) && p.refs.length
+    ? p.refs.filter((r) => typeof r === "string")
+    : (Array.isArray(findingRefs) ? findingRefs.filter((r) => typeof r === "string") : []);
+  if (refs.length) out.refs = refs;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The executor factory — one `executeAction` for the suggest engine's act verb
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {object} deps injected I/O
+ * @param {(input: {project, kind, statement, refs, sender}) => Promise<{ok?:boolean, error?:string}|null>} [deps.proposeFact]
+ * @param {(task: object) => Promise<{ok?:boolean, task?:object, error?:string}|null>} [deps.tonightAdd]
+ *   the engine's tonightAdd (self-gated: overnight switch + High tier).
+ * @param {() => Promise<{ok?:boolean, release?:() => void, error?:string}|null>} [deps.beginDelegateJob]
+ *   the §3.3 delegate gate (kill switch / pause / concurrent tracker).
+ * @param {() => Promise<Array>} [deps.listProjects]
+ * @param {(projects: Array, cwd: string) => {parentSessionID?:string}|null} [deps.resolveParent]
+ * @param {(input: {prompt, model?, parentSessionID, parentDirectory, actor}) => Promise<{ok?:boolean, job?:{id?:string}, error?:string}|null>} [deps.startDelegateJob]
+ * @param {() => Promise<Array>} [deps.listDelegateJobs] the persisted job rows
+ *   (loadJobs) — the persistent source the running-CTO-job cap counts.
+ * @param {number} [deps.maxConcurrentDelegate] §3.3 concurrent cto-delegate cap
+ * @returns {({cls, action, candidate}) => Promise<{ok:boolean, reason?:string, detail?:string, jobId?:string|null, taskId?:string|null}>}
+ */
+export function createCtoActExecutor(deps = {}) {
+  const {
+    proposeFact = null,
+    tonightAdd = null,
+    beginDelegateJob = null,
+    listProjects = async () => [],
+    resolveParent = resolveForgeOwner,
+    startDelegateJob = null,
+    listDelegateJobs = async () => [],
+    maxConcurrentDelegate = RATE_LIMITS.concurrentDelegate,
+  } = deps;
+
+  return async function executeAction({ cls, action, candidate } = {}) {
+    // The act bookkeeping (trust counters, ledger row, digest report) is
+    // per-class; executing an option whose type diverges from the candidate's
+    // class would record one class and perform another. Refuse.
+    if (typeof cls !== "string" || cls !== action?.type) {
+      return { ok: false, reason: "class-mismatch" };
+    }
+    const payload = action?.payload && typeof action.payload === "object" ? action.payload : {};
+
+    if (cls === "record-decision") {
+      if (typeof proposeFact !== "function") return { ok: false, reason: "no-executor" };
+      const p = normalizeRecordDecisionPayload(payload, { findingRefs: candidate?.finding?.refs });
+      if (!p) return { ok: false, reason: "incomplete-payload" };
+      const result = await proposeFact({ project: p.project, kind: "decision", statement: p.statement, refs: p.refs, sender: "cto" });
+      return result?.ok === true
+        ? { ok: true, detail: "decision fact proposed" }
+        : { ok: false, reason: result?.error ?? "propose-failed" };
+    }
+
+    if (cls === "queue-tonight") {
+      if (typeof tonightAdd !== "function") return { ok: false, reason: "no-executor" };
+      const p = normalizeQueueTonightPayload(payload, { findingText: candidate?.finding?.text, findingRefs: candidate?.finding?.refs });
+      if (!p) return { ok: false, reason: "incomplete-payload" };
+      // originId binds the queue entry back to the suggestion card so the
+      // drill-down edits (tonightRemove/tonightReorder) record their verdicts
+      // against the suggestion's verdict subject.
+      const result = await tonightAdd({ ...p, cls: "queue-tonight", originId: typeof candidate?.id === "string" ? candidate.id : null });
+      return result?.ok === true
+        ? { ok: true, detail: "queued for tonight", taskId: result?.task?.id ?? null }
+        : { ok: false, reason: result?.error ?? "queue-refused" };
+    }
+
+    if (cls === "start-job") {
+      if (typeof startDelegateJob !== "function" || typeof beginDelegateJob !== "function") {
+        return { ok: false, reason: "no-executor" };
+      }
+      const p = normalizeStartJobPayload(payload);
+      if (!p) return { ok: false, reason: "incomplete-payload" };
+      // §3.3 concurrent delegate sub-cap: count RUNNING cto-actor rows — the
+      // persistent source the overnight dispatch counts too. The gate's
+      // transient tracker only spans the start call itself, so the running
+      // rows are the real concurrency bound; the gate below still supplies
+      // the kill switch / pause checks + the cto.delegate_begin ledger row.
+      let running = 0;
+      try {
+        const jobs = await listDelegateJobs();
+        running = (Array.isArray(jobs) ? jobs : []).filter((j) => j?.actor === ACTOR && j?.status === "running").length;
+      } catch {
+        running = 0;
+      }
+      if (running >= maxConcurrentDelegate) {
+        return { ok: false, reason: "rate_limit:concurrentDelegate" };
+      }
+      // A queued act needs a tracked project session to host the job (the
+      // same resolve the overnight dispatch uses). Resolve BEFORE arming the
+      // gate so a refused start never writes a cto.delegate_begin row.
+      let parent = null;
+      try {
+        parent = resolveParent(await listProjects(), p.cwd);
+      } catch {
+        parent = null;
+      }
+      if (!parent?.parentSessionID) return { ok: false, reason: "no-project-session" };
+      const gate = await beginDelegateJob();
+      if (gate?.ok !== true) return { ok: false, reason: gate?.error ?? "gate-refused" };
+      try {
+        const input = { prompt: p.prompt, parentSessionID: parent.parentSessionID, parentDirectory: p.cwd, actor: ACTOR };
+        if (p.model !== undefined) input.model = p.model;
+        const res = await startDelegateJob(input);
+        if (res?.ok !== true) return { ok: false, reason: res?.error ?? "start-refused" };
+        return { ok: true, detail: "delegate job started", jobId: res?.job?.id ?? null };
+      } finally {
+        // The transient gate tracker spans the START only — the running job's
+        // concurrency is bounded by the rows count above (the overnight
+        // dispatch precedent; a long-lived job can never release a tracker).
+        gate.release?.();
+      }
+    }
+
+    return { ok: false, reason: "no-executor" };
+  };
+}

--- a/src/server/ctoAct.test.mjs
+++ b/src/server/ctoAct.test.mjs
@@ -1,0 +1,292 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createCtoActExecutor,
+  normalizeQueueTonightPayload,
+  normalizeRecordDecisionPayload,
+  normalizeStartJobPayload,
+} from "./ctoAct.mjs";
+import { ACTOR } from "./ctoEngine.mjs";
+
+// ---------------------------------------------------------------------------
+// Payload normalization (§9.1 schema → typed executor input)
+// ---------------------------------------------------------------------------
+
+test("normalizeRecordDecisionPayload: statement/project/refs required; refs fall back to the finding", () => {
+  assert.deepEqual(
+    normalizeRecordDecisionPayload({ statement: " Adopt pact ", project: " manta ", refs: ["msg:1", 5, "msg:2"] }),
+    { statement: "Adopt pact", project: "manta", refs: ["msg:1", "msg:2"] },
+  );
+  assert.deepEqual(
+    normalizeRecordDecisionPayload({ statement: "s", project: "p" }, { findingRefs: ["ref:9"] }),
+    { statement: "s", project: "p", refs: ["ref:9"] },
+  );
+  assert.equal(normalizeRecordDecisionPayload({ statement: "s", project: "p" }), null);
+  assert.equal(normalizeRecordDecisionPayload({ statement: "s", refs: ["r"] }), null);
+  assert.equal(normalizeRecordDecisionPayload({ project: "p", refs: ["r"] }), null);
+  assert.equal(normalizeRecordDecisionPayload(null), null);
+});
+
+test("normalizeStartJobPayload: prompt+cwd required; model passes through in either valid shape", () => {
+  assert.deepEqual(normalizeStartJobPayload({ prompt: "Run the sweep", cwd: "/srv/app" }), {
+    prompt: "Run the sweep",
+    cwd: "/srv/app",
+  });
+  // the renderer's ask-path spells the directory `directory` — accepted as an alias
+  assert.deepEqual(normalizeStartJobPayload({ prompt: "p", directory: "/srv/app" }), { prompt: "p", cwd: "/srv/app" });
+  assert.deepEqual(normalizeStartJobPayload({ prompt: "p", cwd: "/srv/app", model: " opus " }), {
+    prompt: "p",
+    cwd: "/srv/app",
+    model: "opus",
+  });
+  assert.deepEqual(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: { providerID: "anthropic", modelID: "claude", variant: "v" } }), {
+    prompt: "p",
+    cwd: "c",
+    model: { providerID: "anthropic", modelID: "claude", variant: "v" },
+  });
+  assert.deepEqual(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: { providerID: "a", modelID: "m" } }), {
+    prompt: "p",
+    cwd: "c",
+    model: { providerID: "a", modelID: "m" },
+  });
+  // a present-but-invalid model refuses the whole act (never silently dropped)
+  assert.equal(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: 7 }), null);
+  assert.equal(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: ["opus"] }), null);
+  assert.equal(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: "" }), null);
+  assert.equal(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: { providerID: "a" } }), null);
+  assert.equal(normalizeStartJobPayload({ prompt: "", cwd: "c" }), null);
+  assert.equal(normalizeStartJobPayload({ prompt: "p" }), null);
+  assert.equal(normalizeStartJobPayload(null), null);
+});
+
+test("normalizeQueueTonightPayload: name falls back to the finding text; cost is the predictedCost alias", () => {
+  assert.deepEqual(
+    normalizeQueueTonightPayload(
+      { name: "Nightly sweep", prompt: "Sweep it", project: "/srv/app", value: 2, confidence: 0.9, cost: 3, refs: ["a", 1] },
+      { findingText: "ignored when a name exists" },
+    ),
+    { name: "Nightly sweep", prompt: "Sweep it", project: "/srv/app", value: 2, confidence: 0.9, predictedCost: 3, refs: ["a"] },
+  );
+  assert.deepEqual(
+    normalizeQueueTonightPayload({ predictedCost: 1.5 }, { findingText: "Build failures recurred" }),
+    { name: "Build failures recurred", predictedCost: 1.5 },
+  );
+  // non-finite numbers and junk project shapes are dropped, not refused
+  assert.deepEqual(
+    normalizeQueueTonightPayload({ name: "n", value: "high", confidence: NaN, project: 42 }, {}),
+    { name: "n" },
+  );
+  assert.equal(normalizeQueueTonightPayload({}, { findingText: "" }), null);
+  assert.equal(normalizeQueueTonightPayload(null, {}), null);
+});
+
+// ---------------------------------------------------------------------------
+// The executor — refusal contract + wired paths
+// ---------------------------------------------------------------------------
+
+function makeDeps(overrides = {}) {
+  const calls = { proposeFact: [], tonightAdd: [], beginDelegateJob: 0, startDelegateJob: [], gateReleased: 0 };
+  const deps = {
+    proposeFact: async (input) => {
+      calls.proposeFact.push(input);
+      return { ok: true };
+    },
+    tonightAdd: async (task) => {
+      calls.tonightAdd.push(task);
+      return { ok: true, task: { id: "tq:1" } };
+    },
+    beginDelegateJob: async () => {
+      calls.beginDelegateJob += 1;
+      return { ok: true, release: () => (calls.gateReleased += 1) };
+    },
+    listProjects: async () => [
+      { tmuxSession: "app", defaultCwd: "/srv/app", windows: [{ opencodeSessionId: "ses-1", paneCurrentPath: "/srv/app" }] },
+    ],
+    startDelegateJob: async (input) => {
+      calls.startDelegateJob.push(input);
+      return { ok: true, job: { id: "job-9" } };
+    },
+    listDelegateJobs: async () => [],
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+test("executor: record-decision proposes the gatekeeper-checked fact (behavior carried over from BET-1403)", async () => {
+  const { deps, calls } = makeDeps();
+  const exec = createCtoActExecutor(deps);
+  const out = await exec({
+    cls: "record-decision",
+    action: { type: "record-decision", payload: { statement: "Adopt pact", project: "manta" } },
+    candidate: { id: "cand-1", finding: { text: "f", refs: ["ref:1"] } },
+  });
+  assert.deepEqual(out, { ok: true, detail: "decision fact proposed" });
+  assert.deepEqual(calls.proposeFact, [{ project: "manta", kind: "decision", statement: "Adopt pact", refs: ["ref:1"], sender: "cto" }]);
+});
+
+test("executor: record-decision refusal surfaces the fact route's error", async () => {
+  const { deps } = makeDeps({ proposeFact: async () => ({ ok: false, error: "gatekeeper refused" }) });
+  const exec = createCtoActExecutor(deps);
+  const out = await exec({
+    cls: "record-decision",
+    action: { type: "record-decision", payload: { statement: "s", project: "p", refs: ["r"] } },
+    candidate: { finding: { text: "f", refs: [] } },
+  });
+  assert.deepEqual(out, { ok: false, reason: "gatekeeper refused" });
+});
+
+test("executor: queue-tonight adds the normalized task bound to the suggestion (cls + originId)", async () => {
+  const { deps, calls } = makeDeps();
+  const exec = createCtoActExecutor(deps);
+  const out = await exec({
+    cls: "queue-tonight",
+    action: { type: "queue-tonight", payload: { name: "Nightly sweep", prompt: "Sweep it", project: "/srv/app", cost: 2 } },
+    candidate: { id: "cand-2", finding: { text: "f", refs: ["ref:2"] } },
+  });
+  assert.deepEqual(out, { ok: true, detail: "queued for tonight", taskId: "tq:1" });
+  assert.deepEqual(calls.tonightAdd, [
+    { name: "Nightly sweep", prompt: "Sweep it", project: "/srv/app", predictedCost: 2, refs: ["ref:2"], cls: "queue-tonight", originId: "cand-2" },
+  ]);
+});
+
+test("executor: queue-tonight refusal carries tonightAdd's own gate error (overnight off, queue full)", async () => {
+  for (const error of ["overnight is not enabled (High tier + Overnight switch)", "tonight's queue is full (12) — cancel or edit first"]) {
+    const { deps } = makeDeps({ tonightAdd: async () => ({ ok: false, error }) });
+    const exec = createCtoActExecutor(deps);
+    const out = await exec({
+      cls: "queue-tonight",
+      action: { type: "queue-tonight", payload: { name: "n" } },
+      candidate: { finding: { text: "f", refs: [] } },
+    });
+    assert.deepEqual(out, { ok: false, reason: error });
+  }
+});
+
+test("executor: start-job starts a worktree-isolated delegate job as actor cto under the §3.3 gate", async () => {
+  const { deps, calls } = makeDeps();
+  const exec = createCtoActExecutor(deps);
+  const out = await exec({
+    cls: "start-job",
+    action: { type: "start-job", payload: { prompt: "Investigate flaky tests", cwd: "/srv/app", model: "opus" } },
+    candidate: { finding: { text: "f", refs: [] } },
+  });
+  assert.deepEqual(out, { ok: true, detail: "delegate job started", jobId: "job-9" });
+  assert.equal(calls.beginDelegateJob, 1);
+  assert.equal(calls.gateReleased, 1);
+  assert.deepEqual(calls.startDelegateJob, [
+    { prompt: "Investigate flaky tests", model: "opus", parentSessionID: "ses-1", parentDirectory: "/srv/app", actor: ACTOR },
+  ]);
+});
+
+test("executor: start-job refuses at the §3.3 concurrent cto-delegate cap without arming the gate", async () => {
+  const { deps, calls } = makeDeps({
+    listDelegateJobs: async () => [
+      { id: "a", actor: ACTOR, status: "running" },
+      { id: "b", actor: ACTOR, status: "running" },
+      { id: "c", actor: "user", status: "running" },
+    ],
+  });
+  const exec = createCtoActExecutor(deps);
+  const out = await exec({
+    cls: "start-job",
+    action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } },
+    candidate: { finding: { text: "f", refs: [] } },
+  });
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, "rate_limit:concurrentDelegate");
+  assert.equal(calls.beginDelegateJob, 0);
+  assert.equal(calls.startDelegateJob.length, 0);
+});
+
+test("executor: start-job refuses when no tracked project session hosts the cwd (gate never armed)", async () => {
+  const { deps, calls } = makeDeps({ listProjects: async () => [] });
+  const exec = createCtoActExecutor(deps);
+  const out = await exec({
+    cls: "start-job",
+    action: { type: "start-job", payload: { prompt: "p", cwd: "/elsewhere" } },
+    candidate: { finding: { text: "f", refs: [] } },
+  });
+  assert.deepEqual(out, { ok: false, reason: "no-project-session" });
+  assert.equal(calls.beginDelegateJob, 0);
+});
+
+test("executor: start-job refusal from the delegate engine degrades with its error and releases the gate", async () => {
+  const { deps, calls } = makeDeps({
+    startDelegateJob: async () => ({ ok: false, error: "at MAX_RUNNING_JOBS" }),
+  });
+  const exec = createCtoActExecutor(deps);
+  const out = await exec({
+    cls: "start-job",
+    action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } },
+    candidate: { finding: { text: "f", refs: [] } },
+  });
+  assert.deepEqual(out, { ok: false, reason: "at MAX_RUNNING_JOBS" });
+  assert.equal(calls.beginDelegateJob, 1);
+  assert.equal(calls.gateReleased, 1);
+});
+
+test("executor: a §3.3 gate refusal (kill switch / pause) refuses the act before any start", async () => {
+  const { deps, calls } = makeDeps({ beginDelegateJob: async () => ({ ok: false, error: "cto_paused" }) });
+  const exec = createCtoActExecutor(deps);
+  const out = await exec({
+    cls: "start-job",
+    action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } },
+    candidate: { finding: { text: "f", refs: [] } },
+  });
+  assert.deepEqual(out, { ok: false, reason: "cto_paused" });
+  assert.equal(calls.startDelegateJob.length, 0);
+  assert.equal(calls.gateReleased, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Refusal contract: class/action coherence, unknown classes, unwired deps
+// ---------------------------------------------------------------------------
+
+test("executor: class and action.type must agree (act bookkeeping is per-class)", async () => {
+  const { deps, calls } = makeDeps();
+  const exec = createCtoActExecutor(deps);
+  assert.deepEqual(
+    await exec({ cls: "start-job", action: { type: "record-decision", payload: { statement: "s", project: "p", refs: ["r"] } } }),
+    { ok: false, reason: "class-mismatch" },
+  );
+  assert.deepEqual(await exec({ cls: undefined, action: { type: "start-job", payload: {} } }), { ok: false, reason: "class-mismatch" });
+  assert.deepEqual(await exec({ cls: "start-job", action: null }), { ok: false, reason: "class-mismatch" });
+  assert.equal(calls.startDelegateJob.length, 0);
+});
+
+test("executor: §9.3-ineligible and data-unreachable classes refuse as unwired (veto-window fallback)", async () => {
+  const exec = createCtoActExecutor(makeDeps().deps);
+  assert.deepEqual(await exec({ cls: "config-change", action: { type: "config-change", payload: { patch: {} } } }), {
+    ok: false,
+    reason: "no-executor",
+  });
+  assert.deepEqual(await exec({ cls: "tool-write", action: { type: "tool-write", payload: { tool: "t" } } }), {
+    ok: false,
+    reason: "no-executor",
+  });
+  assert.deepEqual(await exec({ cls: "unknown", action: { type: "unknown", payload: {} } }), { ok: false, reason: "no-executor" });
+});
+
+test("executor: an unwired dep refuses its class as no-executor; malformed payloads refuse as incomplete", async () => {
+  const { deps } = makeDeps();
+  const noTonight = createCtoActExecutor({ ...deps, tonightAdd: null });
+  assert.deepEqual(
+    await noTonight({ cls: "queue-tonight", action: { type: "queue-tonight", payload: { name: "n" } } }),
+    { ok: false, reason: "no-executor" },
+  );
+  const noDelegate = createCtoActExecutor({ ...deps, startDelegateJob: null, beginDelegateJob: null });
+  assert.deepEqual(
+    await noDelegate({ cls: "start-job", action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } } }),
+    { ok: false, reason: "no-executor" },
+  );
+  const exec = createCtoActExecutor(deps);
+  assert.deepEqual(await exec({ cls: "start-job", action: { type: "start-job", payload: {} } }), { ok: false, reason: "incomplete-payload" });
+  assert.deepEqual(await exec({ cls: "queue-tonight", action: { type: "queue-tonight", payload: {} }, candidate: { finding: { text: "", refs: [] } } }), {
+    ok: false,
+    reason: "incomplete-payload",
+  });
+  assert.deepEqual(await exec({ cls: "record-decision", action: { type: "record-decision", payload: {} } }), {
+    ok: false,
+    reason: "incomplete-payload",
+  });
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -147,6 +147,7 @@ import { composeProfileRender } from "./ctoProfile.mjs";
 import { runEphemeral, createEphemeralReaper } from "./ctoSessions.mjs";
 import { createCtoDigest, STALE_MS } from "./ctoDigest.mjs";
 import { createCtoSuggest } from "./ctoSuggest.mjs";
+import { createCtoActExecutor } from "./ctoAct.mjs";
 import {
   parseSegmentSummaryText,
   validateSegmentSummary,
@@ -2134,6 +2135,26 @@ async function gatedSuggestionEphemeral(taskClass, opts) {
     gate.release?.();
   }
 }
+// BET-1424 (§9.2/§9.3): the act-and-report executors for the §9.3-eligible
+// classes, wired to the live box subsystems. Refusals (and the still-unwired
+// config-change / tool-write classes) return {ok:false} so the suggest engine
+// degrades the act verb to the veto-window card — act-and-report never
+// silently no-ops.
+const ctoActExecutor = createCtoActExecutor({
+  proposeFact: (input) => adaptiveCto.proposeFact(input),
+  tonightAdd: (task) => adaptiveCto.tonightAdd(task),
+  beginDelegateJob: () => adaptiveCto.beginDelegateJob(),
+  listProjects: () => tmux.listProjects(),
+  startDelegateJob: async ({ prompt, model, parentSessionID, parentDirectory, actor } = {}) =>
+    delegateEngine.startJob({ prompt, model, parentSessionID, parentDirectory, actor }),
+  listDelegateJobs: async () => {
+    try {
+      return await loadDelegateJobs();
+    } catch {
+      return [];
+    }
+  },
+});
 const adaptiveCtoSuggest = createCtoSuggest({
   now: () => Date.now(),
   publish: (evt) => bus.publish(evt),
@@ -2153,24 +2174,14 @@ const adaptiveCtoSuggest = createCtoSuggest({
   // remains data-unreachable until B7 lands (the ring is the real gate).
   // BET-1403 (§9.2/§9.3): act-and-report executors. The trust ladder only
   // lets §9.3-eligible classes reach the act verb; this seam decides whether
-  // the concrete bound action is machine-executable. Only record-decision is
-  // wired (a validated, gatekeeper-checked fact proposal on the CTO's own
-  // blackboard); unwired action types refuse → the verb degrades to the
-  // veto-window card. Never throws (ctoSuggest catches).
-  executeAction: async ({ cls, action, candidate }) => {
-    if (cls !== "record-decision" || action?.type !== "record-decision") {
-      return { ok: false, reason: "no-executor" };
-    }
-    const payload = action?.payload && typeof action.payload === "object" ? action.payload : {};
-    const statement = typeof payload.statement === "string" ? payload.statement.trim() : "";
-    const project = typeof payload.project === "string" ? payload.project.trim() : "";
-    const refs = Array.isArray(payload.refs) && payload.refs.length
-      ? payload.refs.filter((r) => typeof r === "string")
-      : (Array.isArray(candidate?.finding?.refs) ? candidate.finding.refs.filter((r) => typeof r === "string") : []);
-    if (!statement || !project || refs.length === 0) return { ok: false, reason: "incomplete-payload" };
-    const result = await adaptiveCto.proposeFact({ project, kind: "decision", statement, refs, sender: "cto" });
-    return result?.ok === true ? { ok: true, detail: "decision fact proposed" } : { ok: false, reason: result?.error ?? "propose-failed" };
-  },
+  // the concrete bound action is machine-executable. BET-1424: all three
+  // §9.3-eligible classes are wired in ctoAct.mjs — record-decision (a
+  // validated, gatekeeper-checked fact proposal on the CTO's own blackboard),
+  // queue-tonight (the engine's tonightAdd) and start-job (a worktree-isolated
+  // delegate job as actor "cto" under the §3.3 gate). Anything unwired or
+  // refused → {ok:false} → the verb degrades to the veto-window card (the
+  // human-in-the-loop fallback). Never throws (ctoSuggest catches).
+  executeAction: ctoActExecutor,
   getWriteRingTools: async () => [], // §7.4 tool registry (P2-later) — empty → tool-write unreachable
   capabilities: { queueTonight: true, toolWrite: true },
   fireNotify: (args) => push.fireNotify(args),


### PR DESCRIPTION
## What

Wires the remaining §9.3-eligible act-and-report executors into the suggest engine's `executeAction` seam (BET-1403 shipped it with `record-decision` only):

- **`start-job`** → the delegate engine's job-start path. Normalizes the candidate option's payload (`prompt` / `cwd` — the ask path's `directory` spelling is accepted as an alias — / `model` free-text or structured), resolves the hosting project session via the same `resolveForgeOwner` the overnight dispatch uses, then arms the §3.3 delegate gate (`beginDelegateJob`: kill switch, pause, `cto.delegate_begin` ledger row) and starts the job with `actor: "cto"`. The §3.3 concurrent cto-delegate sub-cap is enforced by counting **running** cto-actor job rows — the persistent source the overnight dispatch counts too, since the gate's transient tracker only spans the start call.
- **`queue-tonight`** → the engine's `tonightAdd` (BET-1402 subsystem). The task is normalized from the payload (`name` falling back to the finding text, `prompt`, `project`, finite `value`/`confidence`/`predictedCost` with `cost` as the ask-path alias, refs) and bound to the suggestion card via `cls` + `originId`, so Tonight drill-down edits record their verdicts against the suggestion's verdict subject. `tonightAdd`'s own gates (overnight switch + High tier + queue-full) surface as refusals.
- **`record-decision`** moves verbatim into the same executor factory (one implementation, not two parallel paths).

Refusal contract unchanged and now unit-tested: class/action mismatch, §9.3-ineligible classes (`config-change`), data-unreachable `tool-write`, unwired deps, malformed/incomplete payloads, gate refusals — all return `{ok:false, reason}` so the verb degrades to the veto-window card (whose options stay user-executable through the ask-path executors). A present-but-invalid `model` field refuses the whole act rather than being silently dropped — the card rendered that payload.

## Structure

New `src/server/ctoAct.mjs` (pure factory + payload normalizers, injectable I/O — testable without a live box) + `src/server/ctoAct.test.mjs` (15 tests). `index.mjs` now wires the factory to the live subsystems (`adaptiveCto.proposeFact` / `tonightAdd` / `beginDelegateJob`, `tmux.listProjects`, `delegateEngine.startJob`, `loadDelegateJobs`) in ~20 lines instead of owning executor logic inline.

## Files changed

`src/server/ctoAct.mjs` (new), `src/server/ctoAct.test.mjs` (new), `src/server/index.mjs`.

## Verification results

- PR branch (`multica/BET-1424-act-executors` @ 34534e8f):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709
  - test: exit 0, 3851 pass / 0 fail / 7 skip (vitest, 198 files) + 3496 pass / 0 fail (node). Failures: none. log sha256: 3fbbc6914556f41e54cc4d16b5209a39ea96f2d3253a906a616b4c909ff58260
- Base (`main` @ ff3e93d6):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709
  - test: exit 0, 3851 pass / 0 fail / 7 skip + 3481 pass / 0 fail. Failures: none. log sha256: db695e2f59e9a7b9321bd91b0558735e83642ba29766ccad5ad163098d8c6327
- **Conclusion:** 0 new failures, 0 pre-existing failures. The +15 node tests are this PR's (`ctoAct.test.mjs`).

## Follow-ups

- **Follow-up filed: BET-1426 (PM, high).** Queue entries whose `project` never resolves to a tracked session are skip-ledgered every overnight tick forever — pre-existing since BET-1419 on the ask path (`project: payload.project ?? null`); the act path passes the payload through consistently and this follow-up owns the systemic fix on both add paths / dispatch.

**Base: origin/main @ ff3e93d6**
