### PR TITLE
BET-1426: tonight-queue project validation at add time + one-time dispatch cleanup

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1291,12 +1291,43 @@ export function createCtoEngine(deps = {}) {
         const parent =
           typeof project === "string" && project ? resolveForgeOwner(projects, project) : null;
         if (!parent?.parentSessionID) {
-          await ledgerLog({
-            kind: "cto.overnight.skip",
-            id: cand.id,
-            reason: "no tracked project session to host the job",
-            project,
-          });
+          // BET-1426: an unresolvable project can never host the job — re-skip
+          // per tick would pollute the ledger forever. When the project list
+          // was READABLE (a null/throw is a transient read failure, not a
+          // verdict) and the candidate is a queue row, remove the entry on the
+          // first skip: one final skip row + a needs-you blocker. Rows queued
+          // before the add-time validation are cleaned here too.
+          if (Array.isArray(projects) && task) {
+            const rows = await tonightQueueRows();
+            await saveTonightQueueRows(rows.filter((r) => r?.id !== task.id));
+            if (overnight) {
+              await overnight
+                .updateWindow((prev) =>
+                  prev?.pinnedOrder?.length
+                    ? normalizeWindow({ ...normalizeWindow(prev), pinnedOrder: prev.pinnedOrder.filter((pid) => pid !== task.id) })
+                    : null,
+                )
+                .catch(() => {});
+            }
+            await ledgerLog({
+              kind: "cto.overnight.skip",
+              id: cand.id,
+              reason: "no tracked project session to host the job — entry removed from tonight's queue",
+              project,
+              removed: true,
+            });
+            await recordBlocker(
+              "overnight_queue",
+              `Tonight task "${task.name ?? cand.id}" was removed — no tracked project session could host it.`,
+            );
+          } else {
+            await ledgerLog({
+              kind: "cto.overnight.skip",
+              id: cand.id,
+              reason: "no tracked project session to host the job",
+              project,
+            });
+          }
           continue;
         }
         const prompt =
@@ -1467,9 +1498,28 @@ export function createCtoEngine(deps = {}) {
     return { tasks, window: win };
   }
 
+  // A project can host an overnight job only when one of its windows carries
+  // a live opencode session — the same shape resolveForgeOwner returns an
+  // owner for (BET-1426 add-time validation + dispatch backstop).
+  function hostableProjects(projects) {
+    if (!Array.isArray(projects)) return [];
+    return projects.filter(
+      (p) =>
+        Array.isArray(p?.windows) &&
+        p.windows.some((w) => typeof w?.opencodeSessionId === "string" && w.opencodeSessionId),
+    );
+  }
+
   // Queue a task for tonight (the `queue-tonight` decision-card option
   // executor). Gated: engine enabled, High tier, Overnight switch, injected
   // scheduler. A 13th add is refused with a note (never silent truncation).
+  // BET-1426: the task's project is resolved HERE, at add time — both add
+  // paths (renderer ask, act executor) funnel into this one point, so the
+  // queue only ever holds rows the §11.5 dispatch can host. A payload without
+  // a resolvable project auto-resolves to the single tracked project session
+  // when there is exactly one (noted in the ack + ledger row) and is refused
+  // otherwise — an unresolvable row would otherwise skip on every overnight
+  // tick forever.
   async function tonightAdd(task = {}) {
     if (!(await overnightGate())) return { ok: false, error: "overnight is not enabled (High tier + Overnight switch)" };
     const name = typeof task.name === "string" ? task.name.trim() : "";
@@ -1478,11 +1528,46 @@ export function createCtoEngine(deps = {}) {
     if (rows.length >= TONIGHT_QUEUE_MAX) {
       return { ok: false, error: `tonight's queue is full (${TONIGHT_QUEUE_MAX}) — cancel or edit first` };
     }
+    let project = typeof task.project === "string" && task.project ? task.project : null;
+    let projectResolved = "explicit";
+    let projects = null;
+    if (typeof listProjects === "function") {
+      try {
+        projects = await listProjects();
+      } catch {
+        projects = null;
+      }
+    }
+    if (!Array.isArray(projects)) {
+      return { ok: false, error: "cannot verify the task's project (project list unavailable) — try again" };
+    }
+    if (project) {
+      const owner = resolveForgeOwner(projects, project);
+      if (owner?.parentSessionID) {
+        // Canonicalize to the owning project's directory so the row keeps
+        // resolving by exact match even when window paths churn.
+        if (owner.defaultCwd) project = owner.defaultCwd;
+      } else {
+        project = null; // named but unresolvable → fall through to auto/refuse
+      }
+    }
+    if (!project) {
+      const hostable = hostableProjects(projects);
+      if (hostable.length === 1) {
+        project = typeof hostable[0].defaultCwd === "string" && hostable[0].defaultCwd ? hostable[0].defaultCwd : null;
+        if (!project) return { ok: false, error: "the only tracked project session has no project directory to host the task" };
+        projectResolved = "auto";
+      } else if (hostable.length === 0) {
+        return { ok: false, error: "no tracked project session to host the task — open a project session first" };
+      } else {
+        return { ok: false, error: "no resolvable project for the task — name one of the open project sessions" };
+      }
+    }
     const entry = {
       id: `tq:${nextId()}`,
       name: name.slice(0, 200),
       prompt: typeof task.prompt === "string" && task.prompt.trim() ? task.prompt.trim() : name,
-      project: typeof task.project === "string" && task.project ? task.project : null,
+      project,
       value: Number.isFinite(task.value) ? task.value : 1,
       confidence: Number.isFinite(task.confidence) ? task.confidence : 0.8,
       predictedCost: Number.isFinite(task.predictedCost) ? task.predictedCost : 1,
@@ -1492,9 +1577,9 @@ export function createCtoEngine(deps = {}) {
       addedMs: now(),
     };
     await saveTonightQueueRows([...rows, entry]);
-    await ledgerLog({ kind: "cto.overnight.queue_add", id: entry.id, name: entry.name });
+    await ledgerLog({ kind: "cto.overnight.queue_add", id: entry.id, name: entry.name, project: entry.project, resolved: projectResolved });
     await syncState().catch(() => {});
-    return { ok: true, task: entry };
+    return { ok: true, task: entry, projectResolved };
   }
 
   // Remove one task (a Tonight drill-down edit — itself a verdict, §10.4).

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -12,7 +12,7 @@ const HOUR = 3_600_000;
 // Minimal harness: fake clock, in-memory stores, injected delegate seams +
 // overnight scheduler. Presence is "gone" (stale desktop beat), profile seam
 // returns a caller-controlled trough, and the queue pre-seeds engine-state.
-function makeHarness({ trough = null, queue = [], projects = [], tier = "high", overnightEnabled = true, budgetPlan = null } = {}) {
+function makeHarness({ trough = null, queue = [], projects = [], tier = "high", overnightEnabled = true, budgetPlan = null, listProjectsFn = null } = {}) {
   const clock = { ms: 1_700_000_000_000 };
   const now = () => clock.ms;
   const ledgerRows = [];
@@ -130,7 +130,7 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
       pausedJobs.push(id);
       return { ok: true };
     },
-    listProjects: async () => projects,
+    listProjects: listProjectsFn ?? (async () => projects),
   });
 
   return {
@@ -211,12 +211,44 @@ test("overnight: no window without the trough or the Overnight switch (or at tie
   assert.deepEqual(switchOff.engineStateObj.tonightQueue, [QUEUE_TASK]);
 });
 
-test("overnight: a candidate with no tracked project session is skipped and ledgered, not dropped", async () => {
-  const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [] });
+test("overnight: an unreadable project list skips + retains the queue row (transient, not a verdict)", async () => {
+  const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], listProjectsFn: async () => {
+    throw new Error("tmux down");
+  } });
   await h.engine.tick();
   assert.equal(h.startedJobs.length, 0);
   assert.ok(h.ledgerRows.some((r) => r.kind === "cto.overnight.skip" && r.reason?.includes("no tracked project session")));
-  assert.deepEqual(h.engineStateObj.tonightQueue, [QUEUE_TASK], "the queued task survives a skip");
+  assert.deepEqual(h.engineStateObj.tonightQueue, [QUEUE_TASK], "a transient project-list failure retains the row");
+  assert.equal(h.engineStateObj.pendingBlockers.length, 0, "no needs-you item for a transient failure");
+});
+
+test("overnight: a queue entry with no tracked project session is removed on the FIRST skip (one final row + needs-you), never re-skipped (BET-1426)", async () => {
+  const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [] });
+  await h.engine.tick();
+  assert.equal(h.startedJobs.length, 0);
+  const final = h.ledgerRows.find((r) => r.kind === "cto.overnight.skip" && r.id === "tq:1");
+  assert.ok(final, "one final skip row for the removed entry");
+  assert.ok(final.reason?.includes("no tracked project session"));
+  assert.equal(final.removed, true, "the row records the removal");
+  assert.deepEqual(h.engineStateObj.tonightQueue, [], "the unresolvable entry leaves the queue");
+  assert.ok(
+    h.engineStateObj.pendingBlockers.some((b) => b.reason?.includes("Reconcile the ledger")),
+    "a needs-you blocker records the removal",
+  );
+
+  // §10.4: the tonight count reflects the removal.
+  const s = await h.engine.getState();
+  assert.equal(s.tonightCount, 0);
+
+  // The next tick of the open window writes NO further skip rows for the
+  // removed entry — the repeated-skip loop is gone.
+  h.advance(60 * 1000);
+  await h.engine.tick();
+  assert.equal(
+    h.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.id === "tq:1").length,
+    1,
+    "no re-skip for the removed entry on the next tick",
+  );
 });
 
 test("overnight: dispatch enforces the §3.3 concurrent sub-cap (2) by counting running cto jobs + accepted starts", async () => {
@@ -370,8 +402,11 @@ test("overnight: an executed window feeds the veto record's acceptance (BET-1403
   assert.equal(st.stats["queue-tonight"]?.vb ?? 0, 0);
 
   // And a cancel on a LATER night demotes the rolling pressure the same way —
-  // both sides of the record are fed by the same machinery.
+  // both sides of the record are fed by the same machinery. BET-1426: night 1
+  // consumed (removed) the unresolvable queue row, so a fresh accepted task
+  // backs tomorrow's candidates — an empty queue arms no veto card.
   const nextDue = due + 24 * HOUR;
+  h.setQueue([{ ...QUEUE_TASK, id: "tq:next" }]);
   h.setTrough({ startMs: nextDue, endMs: nextDue + 6 * HOUR });
   h.advance(24 * HOUR - 25 * 60_000);
   await h.engine.tick(); // arm tomorrow's card
@@ -397,10 +432,14 @@ test("tonight verbs: add gates on the switch, caps at 12, remove + reorder pin t
   assert.equal(denied.ok, false, "overnight switch off → refused");
   assert.equal(offSwitch.engineStateObj.tonightQueue.length, 0);
 
-  const h = makeHarness({ trough: TROUGH, projects: [] });
+  // BET-1426: adds resolve against the tracked projects — one hostable
+  // project auto-resolves a project-less add; the named "/repo" matches.
+  const h = makeHarness({ trough: TROUGH, projects: [PROJECT_ROW] });
   const ok = await h.engine.tonightAdd({ name: "Nightly sweep", prompt: "sweep", project: "/repo", value: 1, confidence: 0.8 });
   assert.equal(ok.ok, true);
   assert.equal(ok.task.cls, "queue-tonight");
+  assert.equal(ok.task.project, "/repo");
+  assert.equal(ok.projectResolved, "explicit");
   assert.deepEqual(h.engineStateObj.tonightQueue.map((t) => t.name), ["Nightly sweep"]);
 
   const noName = await h.engine.tonightAdd({ name: "   " });
@@ -427,6 +466,72 @@ test("tonight verbs: add gates on the switch, caps at 12, remove + reorder pin t
   await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(h.engineStateObj.tonightQueue.length, 11);
+});
+
+test("tonightAdd project resolution (BET-1426): explicit canonicalize, auto-resolve on a single hostable project, refuse otherwise", async () => {
+  // Explicit: the named dir resolves → stored (canonicalized to the owning
+  // project's defaultCwd when they differ).
+  const two = makeHarness({
+    trough: TROUGH,
+    projects: [
+      PROJECT_ROW,
+      { tmuxSession: "s2", defaultCwd: "/other", windows: [{ opencodeSessionId: "sess-2" }] },
+    ],
+  });
+  const explicit = await two.engine.tonightAdd({ name: "A", project: "/repo" });
+  assert.equal(explicit.ok, true);
+  assert.equal(explicit.projectResolved, "explicit");
+  assert.equal(explicit.task.project, "/repo");
+  assert.ok(two.ledgerRows.some((r) => r.kind === "cto.overnight.queue_add" && r.id === explicit.task.id && r.resolved === "explicit" && r.project === "/repo"));
+
+  // A subdir that matches via a window path canonicalizes to defaultCwd.
+  const winRow = { tmuxSession: "s3", defaultCwd: "/canonical", windows: [{ opencodeSessionId: "sess-3", paneCurrentPath: "/canonical/sub" }] };
+  const win = makeHarness({ trough: TROUGH, projects: [winRow] });
+  const canon = await win.engine.tonightAdd({ name: "E", project: "/canonical/sub" });
+  assert.equal(canon.ok, true);
+  assert.equal(canon.task.project, "/canonical", "the canonical project dir is stored, not the raw match path");
+
+  // Ambiguous: two hostable projects, the named project unresolvable → refuse.
+  const ambiguous = await two.engine.tonightAdd({ name: "B", project: "/nowhere" });
+  assert.equal(ambiguous.ok, false);
+  assert.match(ambiguous.error ?? "", /project/);
+
+  // Ambiguous: no project named at all → refuse (can't pick a host).
+  const noName2 = await two.engine.tonightAdd({ name: "B2" });
+  assert.equal(noName2.ok, false);
+  assert.match(noName2.error ?? "", /project/);
+
+  // Auto-resolve: missing project + exactly one hostable project → queued
+  // under it, noted in the ack and the ledger row.
+  const single = makeHarness({ trough: TROUGH, projects: [PROJECT_ROW] });
+  const auto = await single.engine.tonightAdd({ name: "C" });
+  assert.equal(auto.ok, true);
+  assert.equal(auto.projectResolved, "auto");
+  assert.equal(auto.task.project, "/repo");
+  assert.ok(single.ledgerRows.some((r) => r.kind === "cto.overnight.queue_add" && r.id === auto.task.id && r.resolved === "auto" && r.project === "/repo"));
+
+  // Auto-resolve also rescues a NAMED-but-unresolvable project when exactly
+  // one hostable project exists (the triage's missing-or-unresolvable branch).
+  const auto2 = await single.engine.tonightAdd({ name: "C2", project: "/ghost" });
+  assert.equal(auto2.ok, true);
+  assert.equal(auto2.projectResolved, "auto");
+  assert.equal(auto2.task.project, "/repo");
+
+  // Refuse: zero hostable projects (nothing can ever host the job).
+  const none = makeHarness({ trough: TROUGH, projects: [] });
+  const refused = await none.engine.tonightAdd({ name: "D" });
+  assert.equal(refused.ok, false);
+  assert.match(refused.error ?? "", /no tracked project session/);
+
+  // Refuse: an unreadable project list cannot verify resolvability — the
+  // queue only ever holds runnable rows, so the add fails loudly.
+  const unreadable = makeHarness({ trough: TROUGH, projects: [], listProjectsFn: async () => {
+    throw new Error("tmux down");
+  } });
+  const unverifiable = await unreadable.engine.tonightAdd({ name: "F", project: "/repo" });
+  assert.equal(unverifiable.ok, false);
+  assert.match(unverifiable.error ?? "", /cannot verify/);
+  assert.equal(unreadable.engineStateObj.tonightQueue.length, 0);
 });
 
 test("overnight: queue-tonight verdicts fold into the overnight Thompson counters", async () => {

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -275,9 +275,11 @@ export function resolveOwner(projects, sessionID) {
 // Resolve the real parent for a forge-triggered delegate job (BET-844, spec
 // §3.4⑥). A forge event has no user session to inherit from, so the job's
 // window must land in the tmux project on this box that OWNS the repo checkout
-// being branched off. Returns { parentSessionID, tmuxSession } — the opencode
-// session id to place the job window under, plus the owning project — or null
-// when no tracked project wraps that directory. Pure.
+// being branched off. Returns { parentSessionID, tmuxSession, defaultCwd } —
+// the opencode session id to place the job window under, the owning project,
+// and the project's canonical directory (BET-1426: lets callers store the
+// canonical cwd instead of the raw matched path) — or null when no tracked
+// project wraps that directory. Pure.
 export function resolveForgeOwner(projects, parentDirectory) {
   if (!Array.isArray(projects) || typeof parentDirectory !== "string" || !parentDirectory) return null;
   for (const p of projects) {
@@ -292,7 +294,11 @@ export function resolveForgeOwner(projects, parentDirectory) {
     if (!ownsDir) continue;
     const win = windows.find((w) => w?.opencodeSessionId) ?? windows[0];
     if (!win?.opencodeSessionId) return null;
-    return { parentSessionID: win.opencodeSessionId, tmuxSession: p.tmuxSession };
+    return {
+      parentSessionID: win.opencodeSessionId,
+      tmuxSession: p.tmuxSession,
+      defaultCwd: typeof p.defaultCwd === "string" && p.defaultCwd ? p.defaultCwd : null,
+    };
   }
   return null;
 }

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -265,6 +265,7 @@ test("resolveForgeOwner finds the project that owns the repo checkout (BET-844)"
   assert.deepEqual(resolveForgeOwner(projects, "/repo"), {
     parentSessionID: "ses_parent",
     tmuxSession: "forge-work",
+    defaultCwd: "/repo",
   });
 });
 
@@ -279,6 +280,7 @@ test("resolveForgeOwner matches a window whose cwd is nested inside the checkout
   const owner = resolveForgeOwner(projects, "/repo");
   assert.equal(owner.parentSessionID, "ses_par");
   assert.equal(owner.tmuxSession, "repo-project");
+  assert.equal(owner.defaultCwd, "/");
 });
 
 test("resolveForgeOwner returns null when no project wraps the directory", () => {


### PR DESCRIPTION
## Summary

Fixes BET-1426. An overnight-queue entry whose `project` does not resolve to a tracked project session was never dispatched and never removed: every tick of the open window it hit the dispatch guard and appended a `cto.overnight.skip` ledger row, lingering in the Tonight queue indefinitely.

Per the triage decision on the issue (fix centrally in `tonightAdd`, keep both add paths as pass-through, plus a one-time dispatch-time cleanup):

### 1. Add-time validation (`tonightAdd`, src/server/ctoEngine.mjs)
Both add paths (renderer ask path, act-path executor) funnel into `tonightAdd` — one validation point covers both, and `ctoView.ts`/`ctoAct.mjs` stay untouched (BET-1424's pass-through design preserved).
- Named project resolves via `resolveForgeOwner(listProjects(), project)` → store the **canonical** owner dir (the owning project's `defaultCwd`, so the row keeps resolving by exact match even when window paths churn). `resolveForgeOwner` now returns `defaultCwd` alongside `parentSessionID`/`tmuxSession` (additive; all existing consumers destructure).
- Missing/unresolvable + **exactly one** hostable tracked project session → auto-resolve to it; noted in the ack (`projectResolved: "auto"`) and the `cto.overnight.queue_add` ledger row (`resolved`).
- Otherwise **refuse** with a reason the existing call paths already surface (act path → card error; ask path → option-executor error). The user learns at the moment they act; the queue only ever holds runnable rows.
- An unreadable project list (tmux down / seam missing) refuses the add — it cannot verify resolvability.

### 2. Dispatch-time backstop (`dispatchPlan`)
Rows queued before this fix are cleaned on the **first** skip: when the project list was READABLE (a null/throw is a transient failure, not a verdict — those keep the old skip-and-retain behavior) and the candidate is a queue row, the entry is removed once: one final `cto.overnight.skip` row (`removed: true`), its pinned slot dropped (same discipline as `tonightRemove`), and a needs-you blocker via the engine's `recordBlocker` → blocker-card channel. No re-skip per tick; §10.4 tonight counts reflect the removal (`getState().tonightCount` reads the queue).

Base: origin/main @ 7dc49d94 (BET-1424 merged — sequencing per the triage comment: BET-1424 → BET-1426 → BET-1425).

## Verification results

```
typecheck: exit 0 (tsc node + web)
test: 3498 pass / 0 fail / 0 skip (node:test + vitest)
```

Logs: /tmp/typecheck-pr.log, /tmp/test-pr.log

## Tests

- `tonightAdd` resolution: explicit resolve + canonicalization (subdir match → `defaultCwd`), auto-resolve (single hostable project, both missing and named-but-unresolvable payloads), refuse (zero hostable / ambiguous two / unreadable list), ledger `resolved` marker.
- Dispatch backstop: single removal on first skip (`removed: true` final row + needs-you blocker + §10.4 count 0) and **no re-skip on the next tick**; transient unreadable list retains the row with no blocker.
- Updated the pre-BET-1426 test that asserted the old survive-on-skip behavior, and the veto-lifecycle test that unknowingly relied on the survive-forever bug to keep `candidateCount > 0` across nights (now re-seeds a fresh task for night 2).
- `delegate.test.mjs`: `resolveForgeOwner` shape assertions updated for the additive `defaultCwd`.