### PR TITLE
BET-1425: engine-state write hygiene — per-key read-modify-write for every engine-state.json writer

### DIFF
--- a/src/server/ctoBackfill.mjs
+++ b/src/server/ctoBackfill.mjs
@@ -26,7 +26,7 @@
 
 import { DAY_MS, HOUR_MS, WEEK_MS, createRollupRunner, defaultExists, startOfDay, startOfHour, startOfWeek, windowFor, windowId } from "./ctoRollups.mjs";
 import { createSegmenter } from "./ctoSegments.mjs";
-import { engineStateStore, segmentsStore, rollupsStore, ledgerStore } from "./ctoStores.mjs";
+import { engineStateStore, segmentsStore, rollupsStore, ledgerStore, patchEngineState } from "./ctoStores.mjs";
 import { fetchLedgerRows } from "./modelLedger.mjs";
 
 export const DEFAULT_BACKFILL_CAP_USD = 3;
@@ -172,8 +172,9 @@ export function createCtoBackfill(deps = {}) {
     return st && typeof st === "object" ? st : {};
   }
   async function saveState(patch) {
-    const cur = await readState();
-    await engineState.save({ ...cur, ...patch });
+    // BET-1425: per-key RMW — patches carry only backfill-owned keys, so a
+    // concurrent writer's keys survive this save.
+    await patchEngineState(patch, { engineState });
   }
 
   // The A7 rollup runner is constructed lazily + cached; it reduces past

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -55,6 +55,7 @@ import {
   verdictsStore,
   watchersStore,
   factsArchiveStore,
+  patchEngineState,
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
 import { createVerdictEngine } from "./ctoVerdicts.mjs";
@@ -414,19 +415,21 @@ export function createCtoEngine(deps = {}) {
   // into engine-state.json. Best-effort — the health record never throws.
   async function recordBlocker(source, reason) {
     try {
-      const payload = await engineState.load();
-      const pending = Array.isArray(payload?.pendingBlockers)
-        ? payload.pendingBlockers
-        : [];
-      pending.push({
+      const blocker = {
         id: nextId(),
         kind: "blocker",
         source,
         reason,
         ts: now(),
         resolved: false,
-      });
-      await engineState.save({ ...payload, pendingBlockers: pending });
+      };
+      // BET-1425: per-key RMW — an array push derived from the FRESH state, so
+      // a concurrent writer's keys survive this save.
+      await patchEngineState((fresh) => {
+        const pending = Array.isArray(fresh?.pendingBlockers) ? [...fresh.pendingBlockers] : [];
+        pending.push(blocker);
+        return { pendingBlockers: pending };
+      }, { engineState });
     } catch {
       /* best-effort */
     }
@@ -1100,7 +1103,13 @@ export function createCtoEngine(deps = {}) {
       if (lastAutoDay === todayKey) return;
       const dayRollups = await loadRecentDayRollups();
       const result = await getWatchers().autoCreate(dayRollups);
-      await engineState.save({ ...es, watchers: { ...(es?.watchers || {}), lastAutoDay: todayKey } });
+      // BET-1425: sub-key merge on `watchers` from the FRESH state — this key
+      // is shared with ctoWatchers' migration marker, so a stale spread would
+      // resurrect/clobber the other writer's marker.
+      await patchEngineState(
+        (fresh) => ({ watchers: { ...(fresh?.watchers || {}), lastAutoDay: todayKey } }),
+        { engineState },
+      );
       if (result.added.length > 0) {
         await ledgerLog({ kind: "watcher.auto_created", count: result.added.length, signatures: result.added.map((a) => a.patternSignature) });
       }
@@ -1172,8 +1181,8 @@ export function createCtoEngine(deps = {}) {
   }
 
   async function saveTonightQueueRows(rows) {
-    const es = (await engineState.load()) ?? {};
-    await engineState.save({ ...es, tonightQueue: rows });
+    // BET-1425: per-key RMW — the rows are the only key this writer owns.
+    await patchEngineState({ tonightQueue: rows }, { engineState });
   }
 
   function queueCandidatesFromRows(rows) {
@@ -1708,11 +1717,16 @@ export function createCtoEngine(deps = {}) {
       if (!runner) return;
       const payload = (await engineState.load()) || {};
       const cursor = { ...(payload.rollupCursor ?? {}) };
+      // BET-1425: per-level cursor deltas, saved per-key at the end — the old
+      // shape spread the whole load-time `payload` back after minutes of
+      // rollup processing, resurrecting every other writer's keys.
+      const cursorUpdates = {};
       const t = now();
       let cursorInit = false;
       for (const level of ROLLUP_LEVELS) {
         if (cursor[level] == null) {
           cursor[level] = rollupWindowFor(level, t)[0];
+          cursorUpdates[level] = cursor[level];
           cursorInit = true;
         }
       }
@@ -1735,6 +1749,7 @@ export function createCtoEngine(deps = {}) {
           // windows so they are never re-attempted later. The next DAY reduce
           // reconstructs the missing hours from segments (ctoRollups).
           cursor[level] = list[list.length - 1].window[1];
+          cursorUpdates[level] = cursor[level];
           changed = true;
           continue;
         }
@@ -1743,12 +1758,16 @@ export function createCtoEngine(deps = {}) {
           const next = outcomes[outcomes.length - 1].window[1];
           if (next > cursor[level]) {
             cursor[level] = next;
+            cursorUpdates[level] = cursor[level];
             changed = true;
           }
         }
       }
       if (changed) {
-        await engineState.save({ ...payload, rollupCursor: cursor });
+        await patchEngineState(
+          (fresh) => ({ rollupCursor: { ...(fresh?.rollupCursor || {}), ...cursorUpdates } }),
+          { engineState },
+        );
       }
       // BET-1397 breakpoint drain (rollup close): fold unread inbox notes into
       // evidence. Best-effort — never blocks or breaks the rollup fold.

--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -28,7 +28,7 @@
 
 import { readdir } from "node:fs/promises";
 import { createHash } from "node:crypto";
-import { factsStore, factsArchiveStore, ledgerStore, engineStateStore } from "./ctoStores.mjs";
+import { factsStore, factsArchiveStore, ledgerStore, engineStateStore, patchEngineState } from "./ctoStores.mjs";
 
 export const FACT_VERSION = 1;
 
@@ -497,6 +497,11 @@ export function createFactsEngine(deps = {}) {
     } catch {}
   }
 
+  // The engine-state keys this engine owns (BET-1425): the threaded `state`
+  // object starts as a full engine-state load, but ONLY these keys may be
+  // written back — a stale snapshot must never spread another writer's keys.
+  const FACTS_STATE_KEYS = ["factReliability", "factQueue", "appliedProposals", "factTuning"];
+
   async function loadState() {
     try {
       const s = await engineState.load();
@@ -507,7 +512,12 @@ export function createFactsEngine(deps = {}) {
   }
   async function saveState(s) {
     try {
-      await engineState.save({ ...s, v: 1 });
+      const patch = {};
+      for (const key of FACTS_STATE_KEYS) {
+        if (key in s) patch[key] = s[key];
+      }
+      // BET-1425: per-key RMW (load-fresh → merge owned keys → atomic save).
+      await patchEngineState(patch, { engineState });
     } catch {}
   }
 

--- a/src/server/ctoSegments.mjs
+++ b/src/server/ctoSegments.mjs
@@ -32,7 +32,7 @@
 //   - Segments persist 30d in the segments area of the rollups store (A1),
 //     swept by ctoStores.sweepSegments.
 
-import { engineStateStore, segmentsStore, ledgerStore } from "./ctoStores.mjs";
+import { engineStateStore, segmentsStore, ledgerStore, patchEngineState } from "./ctoStores.mjs";
 import { isUserPromptEvent } from "./ctoEvidence.mjs";
 import { validateProposalList } from "./ctoJournal.mjs";
 
@@ -479,8 +479,8 @@ export function createSegmenter(deps = {}) {
 
   async function persistG(nextMinutes) {
     try {
-      const p = await engineState.load();
-      await engineState.save({ ...p, segmentGMinutes: nextMinutes });
+      // BET-1425: per-key RMW — only `segmentGMinutes` is owned here.
+      await patchEngineState({ segmentGMinutes: nextMinutes }, { engineState });
     } catch {
       /* best-effort */
     }

--- a/src/server/ctoSessions.mjs
+++ b/src/server/ctoSessions.mjs
@@ -8,7 +8,7 @@
 // tmux/opencode/network in tests.
 
 import { startPoller } from "./startPoller.mjs";
-import { engineStateStore } from "./ctoStores.mjs";
+import { engineStateStore, patchEngineState } from "./ctoStores.mjs";
 import { listRoutableModels } from "./opencode.mjs";
 import { buildRoutingServices } from "./routingServices.mjs";
 import { lookupModel, matchModel, allModels } from "./modelCatalog.mjs";
@@ -154,29 +154,20 @@ export function removeActive(set, id) {
   return (Array.isArray(set) ? set : []).filter((x) => x !== id);
 }
 
-async function loadActivePayload(engineState) {
-  try {
-    const p = await engineState.load();
-    return p && typeof p === "object" ? p : {};
-  } catch {
-    return {};
-  }
-}
-
 async function activeAdd(sid, { engineState }) {
-  const payload = await loadActivePayload(engineState);
-  await engineState.save({
-    ...payload,
-    activeEphemeral: addActive(payload.activeEphemeral, sid),
-  });
+  // BET-1425: per-key RMW — the add/remove is derived from the FRESH
+  // activeEphemeral, so a concurrent writer's keys survive this save.
+  await patchEngineState(
+    (fresh) => ({ activeEphemeral: addActive(fresh?.activeEphemeral, sid) }),
+    { engineState },
+  );
 }
 
 async function activeRemove(sid, { engineState }) {
-  const payload = await loadActivePayload(engineState);
-  await engineState.save({
-    ...payload,
-    activeEphemeral: removeActive(payload.activeEphemeral, sid),
-  });
+  await patchEngineState(
+    (fresh) => ({ activeEphemeral: removeActive(fresh?.activeEphemeral, sid) }),
+    { engineState },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -27,7 +27,7 @@ import { readFile, writeFile, appendFile, mkdir, rm, readdir } from "node:fs/pro
 import { dirname, join } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { statePath } from "../shared/paths.mjs";
-import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { readJsonSync, writeJsonAtomic, createMutex } from "./jsonStore.mjs";
 import { startPoller } from "./startPoller.mjs";
 
 const MODE = 0o600;
@@ -157,6 +157,53 @@ export const engineStateStore = createCtoJsonStore("engine-state", ctoPath("engi
 // so it moved to a dedicated file no other writer touches. ctoTrust.mjs
 // migrates a legacy `es.trust` payload on first load.
 export const trustStore = createCtoJsonStore("trust", ctoPath("trust.json"));
+
+// ---------------------------------------------------------------------------
+// BET-1425 engine-state write hygiene — per-key read-modify-write.
+//
+// `engineStateStore.save(data)` writes the WHOLE file, so a writer that spreads
+// a load-time snapshot (`{ ...es, myKey }`) silently reverts every other key
+// another writer changed between its load and its save (the resurrect/clobber
+// demonstrated in the BET-1403 review). The durability invariant: a key's
+// value must survive any concurrent writer that does not own that key.
+//
+// `patchEngineState` is the one sanctioned save path for engine-state writers:
+// under a process-wide mutex it loads FRESH, applies only the patch keys the
+// writer owns, and atomically saves. The mutex serializes the whole
+// load→merge→save sequence (the path mutex inside writeJsonAtomic only covers
+// the rename, not the read — a different mutex, so no nesting deadlock), so
+// two concurrent patches each re-derive from the other's committed state.
+//
+// `mutation` is either a static patch object (keys owned by the writer) or a
+// `(fresh) => patch` function for writers whose value derives from state
+// (array pushes, sub-key merges like `watchers.lastAutoDay` vs the
+// `watchers` migration marker). Setting a patch key to `undefined` deletes it.
+// ---------------------------------------------------------------------------
+
+const engineStateWriteLock = createMutex();
+
+export async function patchEngineState(mutation, { engineState = engineStateStore } = {}) {
+  if (
+    typeof mutation !== "function" &&
+    (mutation === null || typeof mutation !== "object" || Array.isArray(mutation))
+  ) {
+    throw new Error("engine-state patch must be a plain object or a (fresh) => patch function");
+  }
+  return engineStateWriteLock.runExclusive(async () => {
+    const fresh = (await engineState.load()) ?? {};
+    const patch = typeof mutation === "function" ? await mutation(fresh) : mutation;
+    if (patch === null || typeof patch !== "object" || Array.isArray(patch)) {
+      throw new Error("engine-state patch must resolve to a plain object");
+    }
+    const next = { ...fresh };
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === undefined) delete next[key];
+      else next[key] = value;
+    }
+    await engineState.save(next);
+    return next;
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Single-level directory JSON stores: one file per id, e.g. `facts/<project>.json`

--- a/src/server/ctoStores.test.mjs
+++ b/src/server/ctoStores.test.mjs
@@ -30,7 +30,10 @@ import {
   INBOX_TTL_MS,
   inboxExpiresAt,
   purgeExpiredInbox,
+  engineStateStore,
+  patchEngineState,
 } from "./ctoStores.mjs";
+import { createStandingQueryEngine, WATCHER_MIGRATION_KEY } from "./ctoWatchers.mjs";
 
 const NOW_MS = 1_000_000_000_000;
 const DAY = 86_400_000;
@@ -280,4 +283,164 @@ test("purgeExpiredInbox drops only expired entries, silently (no trace)", () => 
   const { keep, dropped } = purgeExpiredInbox(entries, { nowMs });
   assert.deepEqual(keep.map((e) => e.id), ["c", "d"]);
   assert.deepEqual(dropped.map((e) => e.id), ["a", "b"]);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1425 engine-state write hygiene — per-key read-modify-write.
+//
+// The durability invariant (BET-1403 review, carried into BET-1425): a key's
+// value must survive any concurrent writer that does not own that key. The
+// pre-1425 writer shape — load once, then `save({ ...snapshot, myKey })` —
+// spread the whole load-time snapshot back over the file, resurrecting or
+// clobbering every other writer's keys. `patchEngineState` is the sanctioned
+// per-key RMW: under a process-wide mutex it loads FRESH, merges only the
+// patch keys, and atomically saves.
+//
+// Interleaving regressions reuse the mirrored-order pattern from
+// ctoTrust.test.mjs ("stale full-engine-state save cannot revert trust
+// keys"), applied to engine-state keys — including the real shared-sub-key
+// collision on `watchers` (the engine's `lastAutoDay` day marker vs the
+// standing-query engine's migration marker).
+// ---------------------------------------------------------------------------
+
+// Deep-copy at the boundary like the real jsonStore (a parsed clone per
+// load/save) — aliasing the live object would fake both stale snapshots and
+// clobbers. Same shape as the memoryStore fixture in ctoTrust.test.mjs.
+function memoryStore(initial = {}) {
+  let data = JSON.parse(JSON.stringify(initial ?? {}));
+  return {
+    load: async () => JSON.parse(JSON.stringify(data)),
+    save: async (p) => {
+      data = JSON.parse(JSON.stringify(p));
+    },
+  };
+}
+
+async function seedEngineState(payload) {
+  await engineStateStore.save({ v: 1, ...payload });
+}
+
+test("patchEngineState: a static patch merges only its keys — a concurrent writer's key survives (both orders)", async () => {
+  // Order 1: A (owns X) lands first, then B — whose patch was computed from a
+  // STALE snapshot still carrying old X — saves Y. The old spread shape would
+  // resurrect old X; the per-key patch cannot.
+  await seedEngineState({ X: "old" });
+  const stale = await engineStateStore.load(); // B's stale snapshot: X=old
+  await patchEngineState({ X: "new" }); // A commits X=new
+  await patchEngineState({ Y: 42 }, { engineState: engineStateStore }); // B saves (stale-derived) Y
+  const after1 = await engineStateStore.load();
+  assert.equal(after1.X, "new", "X survived B's stale-snapshot save");
+  assert.equal(after1.Y, 42, "Y landed");
+
+  // Order 2 (mirrored): B's Y lands first, then A's X.
+  await seedEngineState({ X: "old" });
+  await patchEngineState({ Y: 42 });
+  await patchEngineState({ X: "new" });
+  const after2 = await engineStateStore.load();
+  assert.equal(after2.X, "new");
+  assert.equal(after2.Y, 42);
+  assert.ok(stale, "the stale snapshot was taken (test hygiene)");
+});
+
+test("patchEngineState: parallel patches compose — every key lands (the mutex, not the rename, is the guard)", async () => {
+  await seedEngineState({});
+  // Without the RMW mutex all three would load the same fresh state and the
+  // last atomic rename would win with a single key — two writers' keys lost.
+  await Promise.all([
+    patchEngineState({ a: 1 }),
+    patchEngineState({ b: 2 }),
+    patchEngineState({ c: 3 }),
+  ]);
+  const after = await engineStateStore.load();
+  assert.equal(after.a, 1);
+  assert.equal(after.b, 2);
+  assert.equal(after.c, 3);
+});
+
+test("patchEngineState: a (fresh) => patch mutation derives from the state as of ITS save, so read-modify-writes compose", async () => {
+  await seedEngineState({ count: 1 });
+  // Two concurrent incrementers: each must read the other's committed value.
+  await Promise.all([
+    patchEngineState((fresh) => ({ count: (fresh.count ?? 0) + 1 })),
+    patchEngineState((fresh) => ({ count: (fresh.count ?? 0) + 1 })),
+  ]);
+  const after = await engineStateStore.load();
+  assert.equal(after.count, 3, "both increments landed on each other's committed state");
+});
+
+test("patchEngineState: setting a key to undefined deletes it; other keys survive", async () => {
+  await seedEngineState({ keep: "yes", drop: "gone" });
+  await patchEngineState({ drop: undefined });
+  const after = await engineStateStore.load();
+  assert.equal(after.keep, "yes");
+  assert.equal("drop" in after, false);
+});
+
+test("patchEngineState: rejects a non-object, non-function mutation and a function resolving to one", async () => {
+  await seedEngineState({});
+  await assert.rejects(() => patchEngineState(null), /plain object/);
+  await assert.rejects(() => patchEngineState([1, 2]), /plain object/);
+  await assert.rejects(() => patchEngineState(() => [1, 2]), /plain object/);
+  await assert.rejects(() => patchEngineState(() => null), /plain object/);
+});
+
+// Shared-sub-key regression: `watchers` is written by TWO engines (the
+// engine's per-day auto-create marker and the standing-query engine's one-time
+// migration marker). Pre-1425 each wrote the whole `watchers` object from its
+// own stale snapshot, so whichever landed second resurrected/clobbered the
+// other's sub-key. Both now merge their sub-key onto the FRESH object.
+
+function makeWatchersHarness() {
+  return createStandingQueryEngine({
+    store: memoryStore({ watchers: [] }),
+    ledger: { append: async () => {} },
+    engineState: engineStateStore,
+    now: () => 1_000_000,
+  });
+}
+
+async function writeDayMarker() {
+  // The engine's watcherTick write shape: `watchers.lastAutoDay` merged onto
+  // the FRESH `watchers` object.
+  await patchEngineState(
+    (fresh) => ({ watchers: { ...(fresh?.watchers || {}), lastAutoDay: "2026-08-29" } }),
+    { engineState: engineStateStore },
+  );
+}
+
+test("durability: the watchers day marker and the migration marker coexist regardless of landing order", async () => {
+  // Order 1: migration first, then the day marker.
+  await seedEngineState({});
+  const migA = await makeWatchersHarness().migrateLegacy([{ patternSignature: "sig-1" }]);
+  assert.equal(migA.migrated, true);
+  await writeDayMarker();
+  const afterA = await engineStateStore.load();
+  assert.equal(afterA.watchers.migrated, true, "migration marker survived the day marker");
+  assert.equal(afterA.watchers.lastAutoDay, "2026-08-29", "day marker landed");
+
+  // Order 2 (mirrored): day marker first, then migration — the pre-1425
+  // migration save spread a stale `meta` snapshot and reverted lastAutoDay.
+  await seedEngineState({});
+  await writeDayMarker();
+  const migB = await makeWatchersHarness().migrateLegacy([]);
+  assert.equal(migB.migrated, true);
+  const afterB = await engineStateStore.load();
+  assert.equal(afterB.watchers.lastAutoDay, "2026-08-29", "day marker survived the migration save");
+  assert.equal(afterB.watchers.migrated, true);
+  assert.equal(WATCHER_MIGRATION_KEY, "watchers");
+});
+
+test("durability: an engine-state writer that does not own tonightQueue cannot revert it (the BET-1403 resurrect shape, engine-state keys)", async () => {
+  // The original report: a tonight-queue removal resurrected by a late writer
+  // spreading a pre-edit snapshot. With per-key writers the queue removal and
+  // unrelated writers' patches compose in both orders.
+  const queue = [{ id: "tq:1", name: "n" }];
+  await seedEngineState({ tonightQueue: queue });
+  await patchEngineState({ pendingBlockers: [{ id: "b1" }] }); // unrelated writer
+  await patchEngineState({ tonightQueue: [] }); // the removal, from a stale read of the queue
+  await patchEngineState({ segmentGMinutes: 7 }); // another unrelated writer, late
+  const after = await engineStateStore.load();
+  assert.deepEqual(after.tonightQueue, [], "the removal landed");
+  assert.deepEqual(after.pendingBlockers, [{ id: "b1" }], "the blocker survived both saves");
+  assert.equal(after.segmentGMinutes, 7, "the late writer's key landed");
 });

--- a/src/server/ctoSuggest.mjs
+++ b/src/server/ctoSuggest.mjs
@@ -416,14 +416,6 @@ export function createCtoSuggest(deps = {}) {
     return { es, st, thresholds: th, used };
   }
 
-  async function saveState(es, st) {
-    try {
-      await engineState.save({ ...es, suggest: st });
-    } catch {
-      /* best-effort */
-    }
-  }
-
   async function getThresholds() {
     const { thresholds: th } = await loadState();
     return { ...(thresholds || {}), ...th };

--- a/src/server/ctoWatchers.mjs
+++ b/src/server/ctoWatchers.mjs
@@ -38,6 +38,7 @@
 // without a hit, or when the underlying fact/pattern is archived.
 
 import { randomBytes } from "node:crypto";
+import { patchEngineState } from "./ctoStores.mjs";
 
 // Closed set of predicate kinds (spec §13.4). Adding a kind is a spec change.
 export const PREDICATE_KINDS = Object.freeze(["event-pattern", "rate-threshold", "usage-burn"]);
@@ -668,10 +669,15 @@ export function createStandingQueryEngine(deps = {}) {
       await saveAll([...all, ...fresh]);
     }
     try {
-      await engineState.save({
-        ...meta,
-        [WATCHER_MIGRATION_KEY]: { ...(meta?.[WATCHER_MIGRATION_KEY] || {}), migrated: true, at: now() },
-      });
+      // BET-1425: sub-key merge on `watchers` from the FRESH state — this key
+      // is shared with the engine's `watchers.lastAutoDay` day marker, so a
+      // stale spread would resurrect/clobber the other writer's sub-key.
+      await patchEngineState(
+        (fresh) => ({
+          [WATCHER_MIGRATION_KEY]: { ...(fresh?.[WATCHER_MIGRATION_KEY] || {}), migrated: true, at: now() },
+        }),
+        { engineState },
+      );
     } catch {
       /* best-effort */
     }


### PR DESCRIPTION
# BET-1425 — Engine-state write hygiene: per-key read-modify-write for every engine-state.json writer

**Base: origin/main @ ece348b0**

## Mechanism choice (per the issue's pick-one mandate)

**Per-key read-modify-write helper** (`patchEngineState` in `src/server/ctoStores.mjs`), not a per-key store split. A store split would change every reader's access pattern and reshuffle state shapes (out of scope); the helper fixes the write path only, in one place, and every writer keeps its keys.

## The bug

Every writer on the shared `engine-state.json` loaded once, then saved `{ ...snapshot, myKey }` — spreading the whole load-time snapshot back over the file. Any key another writer changed between a writer's load and its save was silently resurrected/clobbered. Durability invariant (BET-1403 review wording): **a key's value must survive any concurrent writer that does not own that key.**

## The fix

`patchEngineState(mutation, { engineState })` — under a process-wide mutex it **loads fresh → applies only the patch keys → atomic save** (reusing the jsonStore temp-file+rename atomicity via the store's own `save`). `mutation` is a static patch object (keys the writer owns) or a `(fresh) => patch` function for derived values (array pushes, sub-key merges). Setting a key to `undefined` deletes it.

The mutex serializes the whole load→merge→save sequence — the path mutex inside `writeJsonAtomic` covers only the rename, not the read, so it alone could not deliver the invariant. (Different mutexes; no nesting deadlock.)

## Writer migration (re-derived at implement time via `grep -rn "engineState.save(" src/server`; the review's line numbers were stale post-#1413/#1414)

| Writer | Owned key(s) | Form |
|---|---|---|
| `ctoEngine.recordBlocker` | `pendingBlockers` | push derived from fresh |
| `ctoEngine.watcherTick` | `watchers.lastAutoDay` | sub-key merge on fresh (`watchers` is shared with the migration marker) |
| `ctoEngine.saveTonightQueueRows` | `tonightQueue` | static patch |
| `ctoEngine.finalizeRollups` | `rollupCursor` | per-level deltas onto fresh — the old shape spread the whole pre-rollup payload back after minutes of rollup processing |
| `ctoBackfill.saveState` (10 call sites) | `backfill*` | static patches |
| `ctoSegments.persistG` | `segmentGMinutes` | static patch |
| `ctoWatchers.migrateLegacy` | `watchers.migrated/at` | sub-key merge on fresh |
| `ctoFacts.saveState` (6 call sites) | `factReliability`, `factQueue`, `appliedProposals`, `factTuning` | owned-key projection (its threaded `state` starts as a full-file load — only its own keys may be written back) |
| `ctoSessions.activeAdd/activeRemove` | `activeEphemeral` | add/remove derived from fresh |

Out of scope per the issue: `ctoTrust.mjs` (writes nothing to engine-state since #1412 — verified by grep). `ctoSuggest.saveState` was **dead code** (no callers, not in the factory's return) — deleted rather than migrated.

Post-migration grep: zero direct `engineState.save` calls outside `ctoStores.mjs` (the helper itself + test seeding).

## Tests

7 new cases in `src/server/ctoStores.test.mjs` (appended to the existing BET-1375 harness; interleaving regressions reuse the mirrored-order pattern from `ctoTrust.test.mjs`):

- static patch vs a stale-snapshot writer, **both orders** — X survives B's save, Y lands
- parallel patches compose (every key lands — the mutex, not the rename, is the guard)
- `(fresh) => patch` read-modify-writes compose under concurrency (two increments both land)
- undefined-deletes; validation rejects non-object/non-function mutations
- `watchers` sub-key coexistence via the REAL standing-query engine's `migrateLegacy` vs the engine's day-marker patch shape, **both orders**
- the BET-1403 resurrect shape (tonight-queue removal vs unrelated writers), engine-state keys

Existing engine-state suites stay green.

## Cross-cutting

- None. Renderer/main untouched; engine-state file shape unchanged (keys and values identical, only write ordering changes). The overnight test's raw-save seam (`engineStateSave`) is deliberately kept — it simulates the hostile pre-1425 writer shape for the trust-durability regression.

## Verification results

- PR branch (`multica/BET-1425-engine-state-per-key` @ `c749469e`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3505 pass / 0 fail / 0 skip. Failures: none. log sha256: `7aa72cebfb539c07a12818379862d9436f75fdff506f13dc20268996404619a0`
- Base (`main` @ `ece348b0`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3498 pass / 0 fail / 0 skip. Failures: none. log sha256: `6b575209186f525a9956df5677e2162e0f214074ebff42da7d60a0ea2b78cd0b`
- **Conclusion:** 0 failures on either branch; the +7 tests are this PR's new regressions.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
