### PR TITLE
BET-1395: tool discovery — evidence channels, registry, connect asks

### DIFF
--- a/scripts/duplication-gate-ignore.txt
+++ b/scripts/duplication-gate-ignore.txt
@@ -28,3 +28,12 @@ src/main/installer/handlers.test.ts
 # scans changed files). Same rationale as the handlers.test.ts exemption above;
 # my BET-1008 additions introduced no new clones.
 src/main/installer/installer.test.ts
+# BET-1395 (reviewer-instructed on the cycle-1 return, 2026-08-29): index.mjs
+# is a ~5k-line route hub whose intra-file idioms (the cto route
+# try/catch+respondJson blocks, the segmentsRead/listSegments dir-scan
+# closures, the segment-summary context builders) predate this PR and repeat
+# that file's established shape. The BET-1395 PR touches index.mjs (route +
+# engine wiring), which surfaces these pre-existing self-clones to the
+# changed-file scan. Extracting them is out of BET-1395's scope; the
+# reviewer's instruction: keep the idiom, exempt the file.
+src/server/index.mjs

--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -40,6 +40,7 @@ import {
   nowCostLabel,
   decisionCards,
   vetoCards,
+  connectCards,
   tonightVisible,
   executeSuggestionOption,
   tonightBudgetMode,
@@ -49,6 +50,7 @@ import {
   bindingReserveFrac,
   budgetTodayUsd,
   type BlockerCard,
+  type ConnectCardRow,
   type CtoState,
   type CtoHealthStat,
   type DecisionCardRow,
@@ -61,6 +63,7 @@ import {
   NowRail,
   JustFinishedRail,
   DigestSection,
+  ConnectSection,
   SuggestionSection,
   VetoSection,
   TonightSection,
@@ -156,6 +159,7 @@ export function CtoPanel({
   const blockerCards = useMemo(() => cards.filter((c) => c.variant !== "decision" && c.variant !== "veto"), [cards]);
   const suggestionCards = useMemo(() => decisionCards(cards), [cards]);
   const vetoList = useMemo(() => vetoCards(cards as unknown as ReadonlyArray<Record<string, unknown>>), [cards]);
+  const connectList = useMemo(() => connectCards(cards as unknown as ReadonlyArray<Record<string, unknown>>), [cards]);
 
   const busy = digestBusy(state);
   const busyRef = useRef(busy);
@@ -339,6 +343,36 @@ export function CtoPanel({
       refreshCards();
     },
     [refreshCards],
+  );
+
+  // BET-1395 connect asks (§7.4): the three-way answer is a registry write
+  // (consent ring + §9.5 verdict + card resolution) — the server route does
+  // all three; the client toasts the outcome and refreshes the cards.
+  const handleConnectAnswer = useCallback(
+    (card: ConnectCardRow, answer: string) => {
+      const tool = (card.options ?? []).find((o) => o.answer === answer)?.action?.payload?.tool;
+      const toolId = typeof tool === "string" ? tool : card.id;
+      void window.api
+        ?.ctoToolConnect?.({ tool: toolId, answer: answer as "connect" | "not-now" | "never" })
+        .then((r) => {
+          if (r?.ok) {
+            pushToast({
+              id: `connect-${Date.now()}`,
+              message:
+                answer === "connect"
+                  ? "Connected read-only — metadata consent granted"
+                  : answer === "never"
+                    ? "Will not connect to this tool"
+                    : "Not now — I'll ask again later",
+            });
+          } else {
+            pushToast({ id: `connect-fail-${Date.now()}`, message: `Couldn't record answer: ${r?.error ?? "unknown"}` });
+          }
+        })
+        .catch(() => {})
+        .finally(refreshCards);
+    },
+    [pushToast, refreshCards],
   );
 
   // BET-1419 tonight + veto actions (§9.2/§10.4). The veto card's Cancel
@@ -574,6 +608,7 @@ export function CtoPanel({
           <BackfillCard state={state} />
           <BlockerSection cards={blockerCards} now={Date.now()} onAnswer={handleAnswer} />
           <VetoSection cards={vetoList} now={Date.now()} onCancel={handleVetoCancel} onEditPlan={handleVetoEditPlan} onRunNow={handleVetoRunNow} />
+          <ConnectSection cards={connectList} onAnswer={handleConnectAnswer} />
           <SuggestionSection cards={suggestionCards} onAction={handleSuggestionAction} onDismiss={handleSuggestionDismiss} />
           <NowRail cards={nowCards} />
           <JustFinishedRail items={finished} now={Date.now()} onOpen={handleOpenFinished} />

--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -54,6 +54,7 @@ import {
   type CtoState,
   type CtoHealthStat,
   type DecisionCardRow,
+  type SuggestionApi,
   type VetoCardRow,
 } from "./ctoView";
 import {
@@ -291,27 +292,16 @@ export function CtoPanel({
   // injected into the pure executor: config-change → configUpdate, start-job →
   // delegate, record-decision → the facts route. Outcome is reported (toast on
   // failure); a successful execution is a positive judgment → verdict accept.
-  const suggestionApi = useMemo(
+  // Typed as SuggestionApi (shared/api is the single source for the shapes).
+  const suggestionApi = useMemo<SuggestionApi>(
     () => ({
-      configUpdate: (patch: Record<string, unknown>) => window.api?.configUpdate?.(patch) ?? Promise.resolve({}),
-      delegateStart: (input: { prompt: string; sessionID: string; directory: string; model?: unknown }) =>
-        rendererDelegateStart(input),
-      ctoFact: (input: { kind?: string; statement: string; refs?: string[] }) =>
-        window.api?.ctoFact?.(input) ?? Promise.resolve({ ok: false, error: "facts unavailable" }),
-      ctoTonightAct: (input: {
-        action: "add" | "remove" | "reorder" | "cancel" | "run-now";
-        task?: {
-          name: string;
-          prompt?: string;
-          project?: string | null;
-          value?: number;
-          confidence?: number;
-          predictedCost?: number;
-          refs?: string[];
-          cls?: string;
-          originId?: string | null;
-        };
-      }) => window.api?.ctoTonightAct?.(input) ?? Promise.resolve({ ok: false, error: "tonight unavailable" }),
+      configUpdate: (patch) => window.api?.configUpdate?.(patch) ?? Promise.resolve({}),
+      delegateStart: async (input) => {
+        const r = await rendererDelegateStart(input);
+        return { ok: !!r?.ok, error: r?.error };
+      },
+      ctoFact: (input) => window.api?.ctoFact?.(input) ?? Promise.resolve({ ok: false, error: "facts unavailable" }),
+      ctoTonightAct: (input) => window.api?.ctoTonightAct?.(input) ?? Promise.resolve({ ok: false, error: "tonight unavailable" }),
     }),
     [],
   );

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -65,6 +65,7 @@ export const DEMO_UNIMPLEMENTED = [
   "ctoStateGet",
   "ctoTonightAct",
   "ctoTonightGet",
+  "ctoToolConnect",
   "ctoVerdict",
   "delegateApprove",
   "delegateDecline",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1878,6 +1878,29 @@ export const httpApi: Api = {
     }
   },
 
+  // POST /api/cto/tools/connect — BET-1395 (§7.4): the connect-ask three-way
+  // (grant read-only ring / not-now / never). The server writes the consent
+  // ring + verdict + closes the open connect card.
+  ctoToolConnect: async (input: {
+    tool: string;
+    answer: "connect" | "not-now" | "never";
+  }): Promise<{ ok: boolean; error?: string; tool?: string; answer?: string }> => {
+    const url = `${serverBase()}/api/cto/tools/connect`;
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { ...authHeaders(clientToken()), "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (res.status === 401) throw new AuthRequiredError();
+      const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string; tool?: string; answer?: string };
+      return { ok: !!json.ok, error: json.error, tool: json.tool, answer: json.answer };
+    } catch (e) {
+      if (e instanceof AuthRequiredError) throw e;
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  },
+
   // GET /api/cto/profile — the §8.5 profile & §3.2 journal drill-down render
   // model, composed server-side (Settings → Internals → Profile & rhythm).
   // A rejection (engine off / server down) degrades to an empty model so the

--- a/src/renderer/ctoSections.tsx
+++ b/src/renderer/ctoSections.tsx
@@ -18,6 +18,7 @@ import {
   nowRailMeta,
   runnableSuggestionOption,
   type BlockerCard,
+  type ConnectCardRow,
   type DecisionCardRow,
   type FinishedVariant,
   type VetoCardRow,
@@ -673,6 +674,93 @@ export const VetoSection = memo(function VetoSection({
     </section>
   );
 });
+
+// The §10.3 connect-ask card (BET-1395, §7.4): the tool name, the why (usage
+// evidence + credential presence), the three-way answer — Connect read-only
+// (grants the metadata consent ring) / Not now (30-day re-arm) / Never for
+// this tool (suppresses every ring) — and the "evidence ▸" expander. All
+// three answers are registry writes (always runnable — no-dead-controls
+// rule). Accent edge like the decision cards.
+export const ConnectSection = memo(function ConnectSection({
+  cards,
+  onAnswer,
+}: {
+  cards: ConnectCardRow[];
+  onAnswer: (card: ConnectCardRow, answer: string) => void;
+}) {
+  if (cards.length === 0) return null;
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted">Connect</h2>
+      <div className="space-y-2">
+        {cards.map((card) => (
+          <ConnectCard key={card.id} card={card} onAnswer={onAnswer} />
+        ))}
+      </div>
+    </section>
+  );
+});
+
+function ConnectCard({
+  card,
+  onAnswer,
+}: {
+  card: ConnectCardRow;
+  onAnswer: (card: ConnectCardRow, answer: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const evidence = Array.isArray(card.evidence) ? card.evidence : [];
+  const answers = (card.options ?? []).filter((o) => o?.answer);
+  return (
+    <div
+      className="rounded-md border border-strong bg-fill px-3 py-3"
+      style={{
+        borderLeftWidth: "var(--need-edge-w)",
+        borderLeftColor: "color-mix(in srgb, var(--accent) 55%, transparent)",
+      }}
+    >
+      <div className="flex items-start gap-2">
+        <span className="font-medium text-text">{card.title}</span>
+      </div>
+      {card.body ? <p className="mt-1 text-sm text-text-muted">{card.body}</p> : null}
+      {answers.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {answers.map((o, i) => (
+            <button
+              key={`${o.answer}-${i}`}
+              type="button"
+              onClick={() => onAnswer(card, o.answer)}
+              className={
+                o.answer === "connect"
+                  ? "rounded-md bg-accent-solid px-3 py-1 text-sm font-medium text-white hover:opacity-90"
+                  : "rounded-md px-3 py-1 text-sm text-text-muted hover:bg-fill-hover hover:text-text"
+              }
+            >
+              {o.label || o.answer}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      {evidence.length > 0 ? (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            className="rounded-md bg-fill-active px-2 py-1 text-[11px] text-text-muted hover:text-text"
+            aria-expanded={expanded}
+          >
+            evidence {expanded ? "▾" : "▸"} ({evidence.length})
+          </button>
+          {expanded ? (
+            <pre className="mt-1 whitespace-pre-wrap rounded-md bg-fill-active p-2 text-xs text-text-muted">
+              {evidence.join("\n")}
+            </pre>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 // The Tonight one-line + opt-in drill-down (§10.4). The parent fetches the
 // task list when expanded (ctoTonightGet). A manual reorder PINS the order

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -500,6 +500,37 @@ export function vetoCards(cards: ReadonlyArray<Record<string, unknown>>): VetoCa
   }));
 }
 
+// BET-1395: the open connect-ask cards (§10.3 connect variant) among the wire
+// cards — tool name + why + evidence trail + the three-way answer bound as
+// `tool-connect` actions (the registry is the executor, always runnable).
+export type ConnectCardRow = {
+  id: string;
+  title: string;
+  body: string;
+  evidence?: string[];
+  options: { label: string; answer: string; action: { type: string; payload: Record<string, unknown> } }[];
+};
+
+export function connectCards(cards: ReadonlyArray<Record<string, unknown>>): ConnectCardRow[] {
+  return (cards ?? [])
+    .filter((c) => c?.variant === "connect")
+    .map((c) => ({
+      id: String(c.id ?? ""),
+      title: String(c.title ?? ""),
+      body: String(c.body ?? ""),
+      evidence: Array.isArray(c.evidence) ? (c.evidence as string[]) : [],
+      options: Array.isArray(c.options)
+        ? (c.options as { label?: string; answer?: string; action?: { type?: string; payload?: Record<string, unknown> } }[]).map(
+            (o) => ({
+              label: String(o?.label ?? ""),
+              answer: String(o?.answer ?? ""),
+              action: { type: String(o?.action?.type ?? ""), payload: (o?.action?.payload ?? {}) as Record<string, unknown> },
+            }),
+          )
+        : [],
+    }));
+}
+
 // Live countdown to a veto card's `dueMs`: the ms remaining (≥ 0), or null
 // when there is no due time or it already elapsed (the card resolves server-
 // side; the client just hides the countdown rather than reading negative).

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -2,6 +2,8 @@
 // The CTO pane (§10) renders from a single `{kind:"ctoState"}` bus event
 // (payload shape below) plus a `GET /api/cto/state` initial read. This module
 // holds only deterministic mapping — no window.api, no React.
+import type { Api } from "../shared/api";
+import type { DelegateStartInput } from "../shared/types";
 
 export type CtoDot = "active" | "disabled" | "thrifty" | "paused";
 
@@ -567,26 +569,10 @@ export function runnableSuggestionOption(option: {
 }
 
 // The minimal renderer API surface the option executors need — injected so the
-// executors stay pure + testable (no window.api import here).
-export type SuggestionApi = {
-  configUpdate(patch: Record<string, unknown>): Promise<unknown>;
-  delegateStart(input: { prompt: string; sessionID: string; directory: string; model?: unknown }): Promise<{ ok?: boolean; error?: string }>;
-  ctoFact(input: { kind?: string; statement: string; refs?: string[] }): Promise<{ ok?: boolean; error?: string }>;
-  ctoTonightAct(input: {
-    action: "add" | "remove" | "reorder" | "cancel" | "run-now";
-    task?: {
-      name: string;
-      prompt?: string;
-      project?: string | null;
-      value?: number;
-      confidence?: number;
-      predictedCost?: number;
-      refs?: string[];
-      cls?: string;
-      originId?: string | null;
-    };
-  }): Promise<{ ok?: boolean; error?: string }>;
-};
+// executors stay pure + testable (no window.api import here). Derived from the
+// shared Api type (single source of truth — the method shapes live only in
+// shared/api.ts).
+export type SuggestionApi = Pick<Api, "configUpdate" | "delegateStart" | "ctoFact" | "ctoTonightAct">;
 
 // Execute one bound action. Confirmation (the config-change diff modal) is a
 // UI concern the caller resolves BEFORE calling this — this is pure side-effect
@@ -614,8 +600,16 @@ export async function executeSuggestionOption({
         const sessionID = typeof payload.sessionID === "string" ? payload.sessionID : "";
         const directory = typeof payload.directory === "string" ? payload.directory : "";
         if (!prompt || !sessionID || !directory) return { ok: false, error: "start-job needs prompt, sessionID and directory payload" };
-        const input: { prompt: string; sessionID: string; directory: string; model?: unknown } = { prompt, sessionID, directory };
-        if (payload.model && typeof payload.model === "object") input.model = payload.model;
+        const input: DelegateStartInput = { prompt, sessionID, directory };
+        if (payload.model && typeof payload.model === "object") {
+          // Runtime-shaped coercion: the bound payload is untyped JSON, the
+          // shared input type is not (model: {providerID?, modelID?} | null).
+          const m = payload.model as { providerID?: unknown; modelID?: unknown };
+          input.model = {
+            ...(typeof m.providerID === "string" ? { providerID: m.providerID } : {}),
+            ...(typeof m.modelID === "string" ? { modelID: m.modelID } : {}),
+          };
+        }
         await api.delegateStart(input);
         return { ok: true };
       }

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -68,6 +68,9 @@ export const HEALTH_SOURCE_KIND = "health";
 // notification fires IMMEDIATELY through the existing router (the same one
 // source 1 relies on), and the card appears at > 10 min via promoteDue.
 export const INBOX_SOURCE_KIND = "inbox";
+// Connect-ask cards (BET-1395 / §7.4): one §7.2 tool identity per card, keyed
+// by the tool id.
+export const CONNECT_SOURCE_KIND = "tool";
 
 // Stable, collision-resistant card id. Re-detection of the same (sourceKind,
 // sourceId) yields the same id → upsert in place, never a duplicate.
@@ -513,6 +516,89 @@ export function createCtoCards(deps = {}) {
     return { changed: true, isNew: !existing };
   }
 
+  // Connect-ask card writer (BET-1395 / §7.4 one connect ask, §10.3
+  // connect-ask variant). Upserts by the tool's stable id — re-raising the
+  // same tool's ask (re-arm path) updates the card in place, never dups.
+  // The three-way answer is bound at generation time to the tool identity;
+  // resolution runs through the registry (POST /api/cto/tools/connect),
+  // which writes the consent ring + the §9.5 verdict and calls
+  // resolveConnectCards. No notification path — like decision cards, this is
+  // a resting needs-you surface.
+  async function upsertConnect({ toolId, title, body, evidence = [], refs = [], ts = now() } = {}) {
+    if (!toolId || typeof toolId !== "string") return { changed: false, isNew: false };
+    const sourceId = toolId;
+    const id = stableCardId(CONNECT_SOURCE_KIND, sourceId);
+    const { payload, cards: list } = await openCards();
+    const existing = list.find((c) => c?.id === id && c?.state === "open");
+    const created = existing?.created ?? ts;
+    const options = [
+      { label: "Connect read-only", answer: "connect" },
+      { label: "Not now", answer: "not-now" },
+      { label: "Never for this tool", answer: "never" },
+    ].map((o) => ({
+      ...o,
+      action: { type: "tool-connect", payload: { tool: toolId, answer: o.answer } },
+    }));
+    const card = {
+      id,
+      variant: "connect",
+      title: typeof title === "string" && title ? title : `Connect ${toolId} (read-only)?`,
+      body: typeof body === "string" ? body : "",
+      evidence: Array.isArray(evidence) ? evidence : [],
+      options,
+      refs: Array.isArray(refs) && refs.length ? refs : [toolId],
+      sourceKind: CONNECT_SOURCE_KIND,
+      sourceId,
+      sessionID: null,
+      created,
+      updatedAt: ts,
+      state: "open",
+    };
+    if (existing) {
+      const idx = list.indexOf(existing);
+      list[idx] = { ...existing, ...card, created, updatedAt: ts };
+    } else {
+      list.push(card);
+    }
+    await cardStore.save({ ...payload, cards: list });
+    await ledgerAppend({
+      kind: CARD_CREATED,
+      cardId: id,
+      variant: "connect",
+      sourceKind: CONNECT_SOURCE_KIND,
+      sourceId,
+      refs: card.refs,
+    });
+    return { changed: true, isNew: !existing };
+  }
+
+  // Resolve every open connect-ask card for one tool (the registry's
+  // three-way answer is the resolution predicate's only false-path). Returns
+  // `{changed}` for tests/diagnostics.
+  async function resolveConnectCards(toolId, reason, ts = now()) {
+    const { payload, cards: list } = await openCards();
+    const open = list.filter(
+      (c) => c?.state === "open" && c?.variant === "connect" && (c?.sourceId === toolId || c?.refs?.includes(toolId)),
+    );
+    let changed = false;
+    for (const card of open) {
+      const idx = list.indexOf(card);
+      list.splice(idx, 1);
+      await ledgerAppend({
+        kind: CARD_RESOLVED,
+        cardId: card.id,
+        variant: card.variant,
+        sourceKind: card.sourceKind,
+        sourceId: card.sourceId,
+        refs: card.refs,
+        reason,
+      });
+      changed = true;
+    }
+    if (changed) await cardStore.save({ ...payload, cards: list });
+    return { changed };
+  }
+
   async function listOpen() {
     const { cards } = await openCards();
     return cards.filter((c) => c && c.state === "open");
@@ -529,6 +615,8 @@ export function createCtoCards(deps = {}) {
     dismissById,
     upsertDecision,
     upsertVeto,
+    upsertConnect,
+    resolveConnectCards,
     countOpen,
     listOpen,
   };

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -281,16 +281,16 @@ export function createCtoCards(deps = {}) {
     return { changed: true, isNew: !existing };
   }
 
-  // Resolve one open card by id → `resolved` state + a card.resolved ACTIVITY
-  // entry (never a verdict), and move it out of cards.json into the ledger.
-  async function resolveById(id, { reason, ts = now() } = {}) {
+  // Shared close-path for resolve/dismiss: remove one open card by id, save,
+  // and write the ledger row with the close kind (resolved vs dismissed).
+  async function closeOpenCard(id, kind, reason, ts = now()) {
     const { payload, cards } = await openCards();
     const idx = cards.findIndex((c) => c?.id === id && c?.state === "open");
     if (idx < 0) return { changed: false };
     const [card] = cards.splice(idx, 1);
     await cardStore.save({ ...payload, cards });
     await ledgerAppend({
-      kind: CARD_RESOLVED,
+      kind,
       cardId: id,
       variant: card.variant,
       sourceKind: card.sourceKind,
@@ -298,7 +298,15 @@ export function createCtoCards(deps = {}) {
       sessionID: card.sessionID,
       reason,
     });
-    return { changed: true, card: { ...card, state: "resolved", resolvedAt: ts, resolvedReason: reason } };
+    return { changed: true, card };
+  }
+
+  // Resolve one open card by id → `resolved` state + a card.resolved ACTIVITY
+  // entry (never a verdict), and move it out of cards.json into the ledger.
+  async function resolveById(id, { reason, ts = now() } = {}) {
+    const r = await closeOpenCard(id, CARD_RESOLVED, reason, ts);
+    if (!r.changed) return r;
+    return { changed: true, card: { ...r.card, state: "resolved", resolvedAt: ts, resolvedReason: reason } };
   }
 
   // Register a worker is now blocked on an ask. No card yet — the card appears
@@ -394,21 +402,9 @@ export function createCtoCards(deps = {}) {
   // Explicit user dismissal → same ledger discipline as resolution, but the
   // state is `dismissed` (a user choice, distinct from self-resolution).
   async function dismissById(id, { reason, ts = now() } = {}) {
-    const { payload, cards } = await openCards();
-    const idx = cards.findIndex((c) => c?.id === id && c?.state === "open");
-    if (idx < 0) return { changed: false };
-    const [card] = cards.splice(idx, 1);
-    await cardStore.save({ ...payload, cards });
-    await ledgerAppend({
-      kind: CARD_DISMISSED,
-      cardId: id,
-      variant: card.variant,
-      sourceKind: card.sourceKind,
-      refs: card.refs,
-      sessionID: card.sessionID,
-      reason,
-    });
-    return { changed: true, card: { ...card, state: "dismissed", dismissedAt: ts, dismissedReason: reason } };
+    const r = await closeOpenCard(id, CARD_DISMISSED, reason, ts);
+    if (!r.changed) return r;
+    return { changed: true, card: { ...r.card, state: "dismissed", dismissedAt: ts, dismissedReason: reason } };
   }
 
   // Decision-card writer (BET-1392 / §9.1 decision cards, §10.3). Upserts by
@@ -420,42 +416,61 @@ export function createCtoCards(deps = {}) {
   // renderer's job (§9.1 "option buttons execute a bound action").
   async function upsertDecision({ id, title, why, options = [], refs = [], evidence = [], sourceKind, cls, score, capped = false, ts = now() } = {}) {
     if (!id || typeof id !== "string") return { changed: false, isNew: false };
-    const { payload, cards } = await openCards();
-    const existing = cards.find((c) => c?.id === id && c?.state === "open");
-    const created = existing?.created ?? ts;
-    const card = {
+    return upsertOpenCard({
       id,
       variant: "decision",
-      title: typeof title === "string" && title ? title : "CTO suggestion",
-      why: typeof why === "string" && why ? why : title ?? "",
-      refs: Array.isArray(refs) ? refs : [],
-      evidence: Array.isArray(evidence) && evidence.length ? evidence : Array.isArray(refs) ? refs : [],
-      options: Array.isArray(options) ? options : [],
       sourceKind,
-      cls,
-      score: typeof score === "number" ? score : undefined,
-      capped: capped === true,
-      // openness count carried forward on regeneration (§9.1 never-dup).
-      openCount: existing?.openCount ?? 0,
+      ts,
+      ledger: { cls, score: typeof score === "number" ? score : undefined },
+      build: ({ existing }) => ({
+        title: typeof title === "string" && title ? title : "CTO suggestion",
+        why: typeof why === "string" && why ? why : title ?? "",
+        refs: Array.isArray(refs) ? refs : [],
+        evidence: Array.isArray(evidence) && evidence.length ? evidence : Array.isArray(refs) ? refs : [],
+        options: Array.isArray(options) ? options : [],
+        cls,
+        score: typeof score === "number" ? score : undefined,
+        capped: capped === true,
+        // openness count carried forward on regeneration (§9.1 never-dup).
+        openCount: existing?.openCount ?? 0,
+      }),
+    });
+  }
+
+  // Shared card-writer core: ONE load/find/merge-or-push/save/ledger path
+  // for every variant writer (decision/veto/connect). `build` returns the
+  // variant-specific fields given { existing, created, ts }; the helper adds
+  // the identity/lifecycle envelope, upserts by stable id (regeneration
+  // updates in place, never dups), saves, and writes the CARD_CREATED row.
+  async function upsertOpenCard({ id, variant, sourceKind = null, sourceId = null, ts = now(), ledger = {}, build }) {
+    const { payload, cards: list } = await openCards();
+    const existing = list.find((c) => c?.id === id && c?.state === "open");
+    const created = existing?.created ?? ts;
+    const card = {
+      ...build({ existing, created, ts }),
+      id,
+      variant,
+      sourceKind,
+      sourceId,
       created,
       updatedAt: ts,
       state: "open",
     };
     if (existing) {
-      const idx = cards.indexOf(existing);
-      cards[idx] = { ...existing, ...card, created, updatedAt: ts };
+      const idx = list.indexOf(existing);
+      list[idx] = { ...existing, ...card, created, updatedAt: ts };
     } else {
-      cards.push(card);
+      list.push(card);
     }
-    await cardStore.save({ ...payload, cards });
+    await cardStore.save({ ...payload, cards: list });
     await ledgerAppend({
       kind: CARD_CREATED,
       cardId: id,
-      variant: "decision",
+      variant,
       sourceKind,
+      sourceId,
       refs: card.refs,
-      cls,
-      score: card.score,
+      ...ledger,
     });
     return { changed: true, isNew: !existing };
   }
@@ -479,41 +494,23 @@ export function createCtoCards(deps = {}) {
   // cancels it (veto verdict) or abandons it (missed, §11.6).
   async function upsertVeto({ id, title, body, dueMs, options = [], refs = [], ts = now() } = {}) {
     if (!id || typeof id !== "string") return { changed: false, isNew: false };
-    const { payload, cards } = await openCards();
-    const existing = cards.find((c) => c?.id === id && c?.state === "open");
-    const created = existing?.created ?? ts;
-    const card = {
+    return upsertOpenCard({
       id,
       variant: "veto",
-      title: typeof title === "string" && title ? title : "Overnight run planned",
-      body: typeof body === "string" && body ? body : "",
-      dueMs: Number.isFinite(dueMs) ? dueMs : null,
-      options: Array.isArray(options) ? options : [],
       sourceKind: "overnight",
       sourceId: null,
-      sessionID: null,
-      pendingSince: existing?.pendingSince ?? ts,
-      refs: Array.isArray(refs) ? refs : [],
-      created,
-      updatedAt: ts,
-      state: "open",
-    };
-    if (existing) {
-      const idx = cards.indexOf(existing);
-      cards[idx] = { ...existing, ...card, created, updatedAt: ts };
-    } else {
-      cards.push(card);
-    }
-    await cardStore.save({ ...payload, cards });
-    await ledgerAppend({
-      kind: CARD_CREATED,
-      cardId: id,
-      variant: "veto",
-      sourceKind: "overnight",
-      refs: card.refs,
-      dueMs: card.dueMs,
+      ts,
+      ledger: { dueMs: Number.isFinite(dueMs) ? dueMs : null },
+      build: ({ existing }) => ({
+        title: typeof title === "string" && title ? title : "Overnight run planned",
+        body: typeof body === "string" && body ? body : "",
+        dueMs: Number.isFinite(dueMs) ? dueMs : null,
+        options: Array.isArray(options) ? options : [],
+        sessionID: null,
+        pendingSince: existing?.pendingSince ?? ts,
+        refs: Array.isArray(refs) ? refs : [],
+      }),
     });
-    return { changed: true, isNew: !existing };
   }
 
   // Connect-ask card writer (BET-1395 / §7.4 one connect ask, §10.3
@@ -526,50 +523,28 @@ export function createCtoCards(deps = {}) {
   // a resting needs-you surface.
   async function upsertConnect({ toolId, title, body, evidence = [], refs = [], ts = now() } = {}) {
     if (!toolId || typeof toolId !== "string") return { changed: false, isNew: false };
-    const sourceId = toolId;
-    const id = stableCardId(CONNECT_SOURCE_KIND, sourceId);
-    const { payload, cards: list } = await openCards();
-    const existing = list.find((c) => c?.id === id && c?.state === "open");
-    const created = existing?.created ?? ts;
-    const options = [
-      { label: "Connect read-only", answer: "connect" },
-      { label: "Not now", answer: "not-now" },
-      { label: "Never for this tool", answer: "never" },
-    ].map((o) => ({
-      ...o,
-      action: { type: "tool-connect", payload: { tool: toolId, answer: o.answer } },
-    }));
-    const card = {
-      id,
-      variant: "connect",
-      title: typeof title === "string" && title ? title : `Connect ${toolId} (read-only)?`,
-      body: typeof body === "string" ? body : "",
-      evidence: Array.isArray(evidence) ? evidence : [],
-      options,
-      refs: Array.isArray(refs) && refs.length ? refs : [toolId],
-      sourceKind: CONNECT_SOURCE_KIND,
-      sourceId,
-      sessionID: null,
-      created,
-      updatedAt: ts,
-      state: "open",
-    };
-    if (existing) {
-      const idx = list.indexOf(existing);
-      list[idx] = { ...existing, ...card, created, updatedAt: ts };
-    } else {
-      list.push(card);
-    }
-    await cardStore.save({ ...payload, cards: list });
-    await ledgerAppend({
-      kind: CARD_CREATED,
-      cardId: id,
+    return upsertOpenCard({
+      id: stableCardId(CONNECT_SOURCE_KIND, toolId),
       variant: "connect",
       sourceKind: CONNECT_SOURCE_KIND,
-      sourceId,
-      refs: card.refs,
+      sourceId: toolId,
+      ts,
+      build: () => ({
+        title: typeof title === "string" && title ? title : `Connect ${toolId} (read-only)?`,
+        body: typeof body === "string" ? body : "",
+        evidence: Array.isArray(evidence) ? evidence : [],
+        options: [
+          { label: "Connect read-only", answer: "connect" },
+          { label: "Not now", answer: "not-now" },
+          { label: "Never for this tool", answer: "never" },
+        ].map((o) => ({
+          ...o,
+          action: { type: "tool-connect", payload: { tool: toolId, answer: o.answer } },
+        })),
+        refs: Array.isArray(refs) && refs.length ? refs : [toolId],
+        sessionID: null,
+      }),
     });
-    return { changed: true, isNew: !existing };
   }
 
   // Resolve every open connect-ask card for one tool (the registry's

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -16,10 +16,11 @@ import {
 
 // A fully-injected card harness: real in-memory card store, engine-state,
 // ledger and a clock we control. No real fs — pure behavior.
-function makeHarness({ pendingBlockers = [] } = {}) {
+function makeHarness({ pendingBlockers = [], fireNotify = false } = {}) {
   const clock = { ms: 1_000_000 };
   let cardPayload = { v: 1, cards: [] };
   const ledgerRows = [];
+  const notified = [];
   let engineState = { v: 1, pendingBlockers: [...pendingBlockers] };
 
   const cards = createCtoCards({
@@ -36,6 +37,7 @@ function makeHarness({ pendingBlockers = [] } = {}) {
       },
     },
     ledger: { append: async (row) => ledgerRows.push(row) },
+    ...(fireNotify ? { fireNotify: async (a) => notified.push(a) } : {}),
     now: () => clock.ms,
   });
 
@@ -43,6 +45,7 @@ function makeHarness({ pendingBlockers = [] } = {}) {
     cards,
     clock,
     ledgerRows,
+    notified,
     store: () => cardPayload,
     setCardPayload(p) {
       cardPayload = p;
@@ -247,66 +250,36 @@ test("countOpen reflects only open cards", async () => {
 });
 
 test("BET-1397 source 3: an inbox blocker fires the blocking-tier notify exactly once and promotes a card", async () => {
-  const clock = { ms: 1_000_000 };
-  let cardPayload = { v: 1, cards: [] };
-  const ledgerRows = [];
-  const notified = [];
-  const cards = createCtoCards({
-    cardStore: {
-      load: async () => cardPayload,
-      save: async (p) => {
-        cardPayload = p;
-      },
-    },
-    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
-    ledger: { append: async (row) => ledgerRows.push(row) },
-    fireNotify: async (a) => notified.push(a),
-    now: () => clock.ms,
-  });
-
-  const r = await cards.onInboxBlocker({
+  const h = makeHarness({ fireNotify: true });
+  const r = await h.cards.onInboxBlocker({
     message: "build is red",
     title: "CI broken",
     refs: ["BET-777"],
     tag: "ci",
     sessionID: "ses-9",
-    ts: clock.ms,
+    ts: h.clock.ms,
   });
   assert.equal(r.notified, true);
   // Exactly ONE notification, blocking tier, via the shared router.
-  assert.equal(notified.length, 1);
-  assert.equal(notified[0].message, "build is red");
-  assert.equal(notified[0].title, "CI broken");
-  assert.equal(notified[0].urgent, true);
-  assert.equal(notified[0].sessionID, "ses-9");
+  assert.equal(h.notified.length, 1);
+  assert.equal(h.notified[0].message, "build is red");
+  assert.equal(h.notified[0].title, "CI broken");
+  assert.equal(h.notified[0].urgent, true);
+  assert.equal(h.notified[0].sessionID, "ses-9");
 
   // The inbox blocker becomes a card at > 10 min like any ask.
-  clock.ms += BLOCKER_AFTER_MS;
-  const p = await cards.promoteDue();
+  h.advance(BLOCKER_AFTER_MS);
+  const p = await h.cards.promoteDue();
   assert.equal(p.changed, true);
-  const open = cardPayload.cards.filter((c) => c.state === "open");
+  const open = h.store().cards.filter((c) => c.state === "open");
   assert.equal(open.length, 1);
   assert.equal(open[0].sourceKind, "inbox");
   assert.deepEqual(open[0].refs, ["BET-777"]);
 });
 
 test("upsertDecision: writes a decision card, and regenerating the same id upserts (no duplicate)", async () => {
-  const clock = { ms: 1_000_000 };
-  let cardPayload = { v: 1, cards: [] };
-  const ledgerRows = [];
-  const cards = createCtoCards({
-    cardStore: {
-      load: async () => cardPayload,
-      save: async (p) => {
-        cardPayload = p;
-      },
-    },
-    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
-    ledger: { append: async (row) => ledgerRows.push(row) },
-    now: () => clock.ms,
-  });
-
-  const first = await cards.upsertDecision({
+  const h = makeHarness();
+  const first = await h.cards.upsertDecision({
     id: "sugg-1",
     title: "Restart the stuck build",
     why: "Start-job: the build has been red for hours.",
@@ -318,11 +291,11 @@ test("upsertDecision: writes a decision card, and regenerating the same id upser
   });
   assert.equal(first.changed, true);
   assert.equal(first.isNew, true);
-  assert.equal(openCardCount({ store: () => cardPayload }), 1);
+  assert.equal(openCardCount(h), 1);
 
   // regeneration with the same stable id — updates in place, no second card
-  clock.ms += 1000;
-  const regen = await cards.upsertDecision({
+  h.advance(1000);
+  const regen = await h.cards.upsertDecision({
     id: "sugg-1",
     title: "Restart the stuck build (still red)",
     why: "Updated why.",
@@ -334,8 +307,8 @@ test("upsertDecision: writes a decision card, and regenerating the same id upser
   });
   assert.equal(regen.changed, true);
   assert.equal(regen.isNew, false);
-  assert.equal(openCardCount({ store: () => cardPayload }), 1);
-  const open = cardPayload.cards.filter((c) => c.state === "open");
+  assert.equal(openCardCount(h), 1);
+  const open = h.store().cards.filter((c) => c.state === "open");
   assert.equal(open[0].title, "Restart the stuck build (still red)");
   assert.equal(open[0].created, 1_000_000); // created preserved across regeneration
   assert.equal(open[0].variant, "decision");

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -383,3 +383,60 @@ test("upsertVeto: refuses a missing id", async () => {
   assert.equal(r.changed, false);
   assert.equal(openCardCount(h), 0);
 });
+
+// ---------------------------------------------------------------------------
+// BET-1395 connect-ask cards (§7.4 / §10.3 connect variant)
+// ---------------------------------------------------------------------------
+
+test("upsertConnect: writes a variant=connect card with the three bound answers", async () => {
+  const h = makeHarness();
+  const r = await h.cards.upsertConnect({
+    toolId: "vercel",
+    title: "Connect Vercel (read-only)?",
+    body: "Vercel showed up 3× across 2 week(s) of agent work",
+    evidence: ["transcript: cli:vercel", "secret: VERCEL_TOKEN"],
+    refs: ["vercel"],
+  });
+  assert.equal(r.changed, true);
+  assert.equal(r.isNew, true);
+  const card = h.store().cards.find((c) => c.variant === "connect");
+  assert.ok(card);
+  assert.equal(card.sourceKind, "tool");
+  assert.equal(card.sourceId, "vercel");
+  assert.deepEqual(card.refs, ["vercel"]);
+  assert.deepEqual(
+    card.options.map((o) => o.answer),
+    ["connect", "not-now", "never"],
+  );
+  for (const o of card.options) {
+    assert.equal(o.action.type, "tool-connect");
+    assert.deepEqual(o.action.payload, { tool: "vercel", answer: o.answer });
+  }
+  assert.ok(h.ledgerRows.some((row) => row.kind === CARD_CREATED && row.variant === "connect"));
+});
+
+test("upsertConnect: re-raising the same tool upserts in place (no dup)", async () => {
+  const h = makeHarness();
+  await h.cards.upsertConnect({ toolId: "vercel", title: "first", refs: ["vercel"] });
+  h.advance(1000);
+  const r = await h.cards.upsertConnect({ toolId: "vercel", title: "second", refs: ["vercel"] });
+  assert.equal(r.isNew, false);
+  const open = h.store().cards.filter((c) => c.variant === "connect" && c.state === "open");
+  assert.equal(open.length, 1);
+  assert.equal(open[0].title, "second");
+});
+
+test("resolveConnectCards: resolves the open card for the tool and writes the ledger row", async () => {
+  const h = makeHarness();
+  await h.cards.upsertConnect({ toolId: "vercel", title: "t", refs: ["vercel"] });
+  await h.cards.upsertConnect({ toolId: "stripe", title: "t2", refs: ["stripe"] });
+  const r = await h.cards.resolveConnectCards("vercel", "connect answer: connect");
+  assert.equal(r.changed, true);
+  const open = h.store().cards.filter((c) => c.state === "open");
+  assert.equal(open.length, 1);
+  assert.equal(open[0].sourceId, "stripe");
+  assert.ok(h.ledgerRows.some((row) => row.kind === CARD_RESOLVED && row.sourceId === "vercel"));
+  // Resolving an absent tool changes nothing.
+  const r2 = await h.cards.resolveConnectCards("ghost", "no-op");
+  assert.equal(r2.changed, false);
+});

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1092,7 +1092,6 @@ export function createCtoEngine(deps = {}) {
   async function toolsTick() {
     const day = new Date(now()).toISOString().slice(0, 10);
     if (lastToolScanDay === day) return;
-    lastToolScanDay = day;
     let backfillStartInstant = null;
     try {
       const es = (await engineState.load()) ?? {};
@@ -1101,6 +1100,10 @@ export function createCtoEngine(deps = {}) {
       /* best-effort — the registry falls back to its own 30-day window */
     }
     await getTools({ backfillStartInstant }).dailyScan();
+    // Stamp the day only AFTER a successful scan — a failed scan retries on
+    // the next tick instead of waiting until tomorrow (the registry's own
+    // watermarks keep the retry idempotent).
+    lastToolScanDay = day;
   }
 
   // Load the last `windowDays` (default 7, §13.4) day rollups so the watcher

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -119,6 +119,10 @@ import {
 import { createOvernightScheduler, normalizeWindow, scheduleCountdown } from "./ctoOvernight.mjs";
 import { resolveForgeOwner } from "./delegate.mjs";
 
+// BET-1395 tool discovery (§7): the registry engine — fusion of the four
+// evidence channels, the two lifecycle bars, and the connect-ask gate.
+import { createToolRegistry } from "./ctoToolRegistry.mjs";
+
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
 
@@ -368,6 +372,16 @@ export function createCtoEngine(deps = {}) {
     listDelegateJobs = null,
     pauseDelegateJob = null,
     listProjects = null,
+    // BET-1395 tool discovery (§7): optional pre-built registry engine (else
+    // one is constructed below from the shared tool stores + cards).
+    // `toolsRunEphemeral` is the classifier's LLM seam, PRE-GATED by
+    // index.mjs through the §3.3 ephemeral rate gate (like the suggest
+    // engine's runSuggest); `toolsGetSurfaces` is the channel-3 seam (the
+    // already-read config surfaces). Defaults null → no LLM fallback and no
+    // config evidence; channel 1 (secret ledger) still fuses.
+    tools = null,
+    toolsRunEphemeral = null,
+    toolsGetSurfaces = null,
   } = deps;
 
   let disposed = false;
@@ -392,6 +406,8 @@ export function createCtoEngine(deps = {}) {
   let verdictsEngine = null;
   let trustEngine = null;
   let watcherEngine = null;
+  let toolEngine = null;
+  let lastToolScanDay = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
   // open, user prompt). The desktop heartbeat is read live via
@@ -541,6 +557,9 @@ export function createCtoEngine(deps = {}) {
         await watcherTick();
         // §11 overnight: window state machine + plan dispatch (BET-1419).
         await overnightTick();
+        // §7 tool discovery: the daily evidence scan + lifecycle + connect
+        // asks (BET-1395). Once per UTC day; self-paced inside the registry.
+        await toolsTick();
       }
       // §10.6-4 cold-start backfill — also ambient, gated on enabled. Its own
       // drained state marker makes it run at most once per box.
@@ -1027,6 +1046,61 @@ export function createCtoEngine(deps = {}) {
       },
     });
     return watcherEngine;
+  }
+
+  // BET-1395 tool discovery (§7): lazy single instance over the shared tool
+  // registry/usage stores + the A1 card machinery. `runEphemeral` is the
+  // rate-gated LLM seam (wired by index.mjs) — the LLM fallback classification
+  // rides the §3.3 ephemeral rate gate exactly like a digest compose. The
+  // db/surface collection seams are injected (index.mjs supplies the live
+  // opencodeDb read handle + config readers); defaults null → channels 2/3
+  // contribute nothing, channel 1 (secret ledger) still fuses.
+  function getTools({ backfillStartInstant = null } = {}) {
+    if (toolEngine) return toolEngine;
+    toolEngine =
+      tools ??
+      createToolRegistry({
+        cards,
+        ledger,
+        now,
+        runEphemeral: toolsRunEphemeral ?? runEphemeral,
+        collectDb: toolsCollectDb,
+        collectSurfaces: toolsGetSurfaces,
+        backfillStartInstant,
+        recordVerdict: (input) => getVerdictsEngine().recordVerdict(input),
+      });
+    return toolEngine;
+  }
+
+  // §7.1-2: the daily batch's db seam — tool-call part rows in the scan
+  // window, via the injected opencodeDb read handle (same async supplier the
+  // backfill uses; a missing handle yields no rows, never a throw).
+  async function toolsCollectDb({ sinceTs, untilTs, cap }) {
+    if (typeof getDb !== "function") return [];
+    const db = await getDb().catch(() => null);
+    if (!db) return [];
+    const { collectDbRows } = await import("./ctoToolScan.mjs");
+    return collectDbRows(db, { sinceTs, untilTs, cap });
+  }
+
+  // The daily tool scan (§7.3): once per UTC day, inside the tick's enabled
+  // gate. Restart-safe — the registry's own watermarks (lastScanTs/lastAskDay)
+  // make a repeat scan idempotent and keep ask pacing ≤1/day durable. The
+  // first scan after install runs over the cold-start backfill range
+  // (engine-state backfillStartInstant), satisfying §7.1-2's "also runs over
+  // the backfill range once".
+  async function toolsTick() {
+    const day = new Date(now()).toISOString().slice(0, 10);
+    if (lastToolScanDay === day) return;
+    lastToolScanDay = day;
+    let backfillStartInstant = null;
+    try {
+      const es = (await engineState.load()) ?? {};
+      if (Number.isFinite(es.backfillStartInstant)) backfillStartInstant = es.backfillStartInstant;
+    } catch {
+      /* best-effort — the registry falls back to its own 30-day window */
+    }
+    await getTools({ backfillStartInstant }).dailyScan();
   }
 
   // Load the last `windowDays` (default 7, §13.4) day rollups so the watcher
@@ -2175,6 +2249,13 @@ export function createCtoEngine(deps = {}) {
     get watchers() {
       return getWatchers();
     },
+    // BET-1395 tool discovery (§7): the registry engine (resolveConnect feeds
+    // the /api/cto/tools/connect route; listTools the §10.5 surfaces) plus the
+    // manual dailyScan trigger for diagnostics/tests.
+    get tools() {
+      return getTools();
+    },
+    toolsScan: () => toolsTick(),
     get cards() {
       return cards;
     },

--- a/src/server/ctoToolCatalog.mjs
+++ b/src/server/ctoToolCatalog.mjs
@@ -1,0 +1,297 @@
+// ctoToolCatalog.mjs — the §7 pattern catalog (BET-1395).
+//
+// The Adaptive CTO discovers the user's external tools generically: NO tool
+// list ships with the system. This module ships the small *pattern catalog*
+// the spec allows — "domain → tool-identity heuristics, issue-key regex
+// shapes, CLI name list" — purely to LABEL evidence. The catalog labels; it
+// never assumes presence (an entry here does not create a registry row; only
+// observed evidence does). Anything the catalog doesn't recognize stays raw
+// and goes through the LLM-classification fallback once (ctoToolRegistry).
+//
+// Pure data + pure matchers — no fs, no clock, no I/O.
+
+// ---------------------------------------------------------------------------
+// CLI catalog (channel 2). Keys are the FIRST token of a bash command; values
+// are canonical tool identities (the registry's `tool` field). Only
+// external-service CLIs are listed: plain dev-environment commands (git, npm,
+// cargo, python …) are the user's own local toolchain, not external tools,
+// and would drown the registry in noise — they live in LOCAL_CLIS and are
+// never collected as evidence.
+// ---------------------------------------------------------------------------
+
+export const CLIS = Object.freeze({
+  gh: "github",
+  glab: "gitlab",
+  aws: "aws",
+  gcloud: "gcp",
+  az: "azure",
+  doctl: "digitalocean",
+  flyctl: "flyio",
+  fly: "flyio",
+  vercel: "vercel",
+  netlify: "netlify",
+  wrangler: "cloudflare",
+  railway: "railway",
+  render: "render",
+  heroku: "heroku",
+  supabase: "supabase",
+  firebase: "firebase",
+  stripe: "stripe",
+  sentry: "sentry-cli",
+  linear: "linear",
+  slack: "slack",
+  notion: "notion",
+  twilio: "twilio",
+  shopify: "shopify",
+  atlas: "mongodb-atlas",
+  psql: "postgres",
+  mysql: "mysql",
+  redis: "redis",
+});
+
+// First tokens that are the user's own local environment — never external
+// evidence, never LLM-classified.
+export const LOCAL_CLIS = Object.freeze(
+  new Set([
+    "ls", "cd", "pwd", "cat", "echo", "grep", "rg", "sed", "awk", "head", "tail",
+    "wc", "sort", "uniq", "find", "mkdir", "touch", "cp", "mv", "rm", "rmdir",
+    "chmod", "chown", "ln", "tar", "zip", "unzip", "curl", "wget",
+    "git", "npm", "npx", "pnpm", "yarn", "bun", "node", "deno", "python",
+    "python3", "pip", "pip3", "uv", "cargo", "rustc", "go", "java", "javac",
+    "make", "cmake", "gcc", "clang", "tsc", "eslint", "prettier", "vitest",
+    "jest", "pytest", "sh", "bash", "zsh", "fish", "which", "env", "export",
+    "set", "source", "man", "less", "more", "diff", "patch", "date", "sleep",
+    "true", "false", "test", "printf", "xargs", "tee", "basename", "dirname",
+    "readlink", "stat", "du", "df", "ps", "kill", "killall", "nohup", "history",
+    "apt", "apt-get", "brew", "ssh", "scp", "rsync", "tmux", "systemctl",
+    "journalctl", "sudo", "crontab", "nc", "netstat", "ss", "ping", "dig",
+  ]),
+);
+
+// ---------------------------------------------------------------------------
+// Domain catalog (channels 2+3). Keys are DNS suffixes (matched on exact host
+// or dot-suffix); values are canonical identities.
+// ---------------------------------------------------------------------------
+
+export const DOMAINS = Object.freeze({
+  "github.com": "github",
+  "githubusercontent.com": "github",
+  "githubassets.com": "github",
+  "gitlab.com": "gitlab",
+  "amazonaws.com": "aws",
+  "aws.amazon.com": "aws",
+  "azure.com": "azure",
+  "azurewebsites.net": "azure",
+  "googleapis.com": "gcp",
+  "firebaseio.com": "firebase",
+  "firebaseapp.com": "firebase",
+  "cloud.google.com": "gcp",
+  "digitaloceanspaces.com": "digitalocean",
+  "fly.io": "flyio",
+  "vercel.com": "vercel",
+  "vercel.app": "vercel",
+  "api.vercel.com": "vercel",
+  "netlify.com": "netlify",
+  "netlify.app": "netlify",
+  "workers.dev": "cloudflare",
+  "railway.app": "railway",
+  "onrender.com": "render",
+  "herokuapp.com": "heroku",
+  "supabase.co": "supabase",
+  "supabase.com": "supabase",
+  "stripe.com": "stripe",
+  "glitch.com": "glitch",
+  "linear.app": "linear",
+  "api.linear.app": "linear",
+  "slack.com": "slack",
+  "hooks.slack.com": "slack",
+  "notion.so": "notion",
+  "api.notion.com": "notion",
+  "sentry.io": "sentry",
+  "sentry.dev": "sentry",
+  "twilio.com": "twilio",
+  "shopify.com": "shopify",
+  "myshopify.com": "shopify",
+  "mongodb.net": "mongodb-atlas",
+  "planetscale.com": "planetscale",
+  "neon.tech": "neon",
+  "cloud.mongodb.com": "mongodb-atlas",
+  "atlassian.net": "atlassian",
+  "jira.com": "jira",
+  "figma.com": "figma",
+  "npmjs.com": "npm",
+  "pypi.org": "pypi",
+  "docker.io": "docker",
+  "ghcr.io": "github",
+  "anthropic.com": "anthropic",
+  "openai.com": "openai",
+  "groq.com": "groq",
+  "deepseek.com": "deepseek",
+  "mistral.ai": "mistral",
+  "x.ai": "xai",
+  "huggingface.co": "huggingface",
+  "upstash.io": "upstash",
+  "pusher.com": "pusher",
+  "ably.com": "ably",
+  "auth0.com": "auth0",
+  "clerk.dev": "clerk",
+  "resend.com": "resend",
+  "sendgrid.net": "sendgrid",
+  "mailgun.org": "mailgun",
+  "postmarkapp.com": "postmark",
+  "tiptap.dev": "tiptap",
+  "sanity.io": "sanity",
+  "contentful.com": "contentful",
+  "prisma.io": "prisma",
+  "turso.tech": "turso",
+  "xata.io": "xata",
+});
+
+// This box's own infrastructure (gateway/DNS/etc.) — never external evidence.
+export const BOX_DOMAINS = Object.freeze(new Set(["mantaui.com", "antoinedc.com", "localhost"]));
+
+// Hosts that are not evidence even in raw form: loopback, RFC1918, link-local,
+// bare IPs, and dotless names.
+const IP_SHAPE = /^\d{1,3}(?:\.\d{1,3}){3}$/;
+
+// ---------------------------------------------------------------------------
+// Issue-key shape (channel 2). One regex SHAPE per the spec ("issue-key regex
+// shapes"): TEAM-123 tokens as they appear in branch names and commit
+// subjects. Which tracker a specific prefix belongs to (Linear, Jira, this
+// Multica workspace …) is exactly what the catalog CANNOT know — the raw
+// keys are collected as evidence and the LLM fallback classifies the source
+// at most once. §7 intro: "The catalog labels; it never assumes presence."
+// ---------------------------------------------------------------------------
+
+export const KEY_SHAPE = /\b[A-Z][A-Z0-9]{1,5}-\d{1,6}\b/g;
+
+// Human display names for identities we catalog (§7.2 displayName). Anything
+// absent falls back to capitalize-first-letter of the identity.
+export const DISPLAY = Object.freeze({
+  github: "GitHub",
+  gitlab: "GitLab",
+  aws: "AWS",
+  gcp: "Google Cloud",
+  azure: "Azure",
+  digitalocean: "DigitalOcean",
+  flyio: "Fly.io",
+  vercel: "Vercel",
+  netlify: "Netlify",
+  cloudflare: "Cloudflare",
+  railway: "Railway",
+  render: "Render",
+  heroku: "Heroku",
+  supabase: "Supabase",
+  firebase: "Firebase",
+  stripe: "Stripe",
+  "sentry-cli": "Sentry",
+  sentry: "Sentry",
+  linear: "Linear",
+  slack: "Slack",
+  notion: "Notion",
+  twilio: "Twilio",
+  shopify: "Shopify",
+  "mongodb-atlas": "MongoDB Atlas",
+  postgres: "Postgres",
+  mysql: "MySQL",
+  redis: "Redis",
+  atlassian: "Atlassian",
+  jira: "Jira",
+  figma: "Figma",
+  npm: "npm",
+  pypi: "PyPI",
+  docker: "Docker Hub",
+  anthropic: "Anthropic API",
+  openai: "OpenAI API",
+  groq: "Groq API",
+  deepseek: "DeepSeek API",
+  mistral: "Mistral API",
+  xai: "xAI API",
+  huggingface: "Hugging Face",
+  planetscale: "Planetscale",
+  neon: "Neon",
+  auth0: "Auth0",
+  clerk: "Clerk",
+  resend: "Resend",
+  sendgrid: "SendGrid",
+  mailgun: "Mailgun",
+  postmark: "Postmark",
+  sanity: "Sanity",
+  contentful: "Contentful",
+  prisma: "Prisma Data",
+  turso: "Turso",
+  xata: "Xata",
+  upstash: "Upstash",
+  pusher: "Pusher",
+  ably: "Ably",
+});
+
+// ---------------------------------------------------------------------------
+// Matchers (pure)
+// ---------------------------------------------------------------------------
+
+// First-token CLI match → identity string (catalog), null (unknown → raw
+// candidate for the LLM fallback), or the sentinel "local" (never evidence).
+export function matchCliIdentity(firstToken) {
+  const t = String(firstToken ?? "").toLowerCase();
+  if (!t) return null;
+  if (LOCAL_CLIS.has(t)) return "local";
+  const id = CLIS[t];
+  return id ?? null;
+}
+
+function isPrivateHost(host) {
+  const h = String(host ?? "").toLowerCase();
+  if (!h || !h.includes(".")) return true; // dotless = localhost-ish
+  if (IP_SHAPE.test(h)) return true;
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  if (
+    h.endsWith(".local") ||
+    h.endsWith(".internal") ||
+    h.endsWith(".home.arpa")
+  ) {
+    return true;
+  }
+  // RFC1918 / loopback / link-local via the IP shape above is exact; also
+  // reject the .svc/.cluster.local k8s shapes.
+  if (h.endsWith(".svc") || h.endsWith(".cluster.local")) return true;
+  return false;
+}
+
+// Host match → identity string (catalog suffix match), null (unknown host →
+// raw candidate), or undefined (host must NOT be collected at all).
+export function matchDomainIdentity(host) {
+  const h = String(host ?? "").toLowerCase().trim().replace(/\.$/, "");
+  if (!h || isPrivateHost(h)) return undefined;
+  for (const [suffix, id] of Object.entries(DOMAINS)) {
+    if (h === suffix || h.endsWith(`.${suffix}`)) return id;
+  }
+  for (const box of BOX_DOMAINS) {
+    if (h === box || h.endsWith(`.${box}`)) return undefined;
+  }
+  return null;
+}
+
+// Issue-key tokens found in free text (branch names, commit subjects).
+// Deduplicated, order-preserved.
+export function matchIssueKeys(text) {
+  const t = String(text ?? "");
+  if (!t) return [];
+  const out = [];
+  const seen = new Set();
+  for (const m of t.matchAll(KEY_SHAPE)) {
+    if (!seen.has(m[0])) {
+      seen.add(m[0]);
+      out.push(m[0]);
+    }
+  }
+  return out;
+}
+
+// Human display name for a canonical identity (§7.2 displayName).
+export function displayName(identity) {
+  const id = String(identity ?? "").trim();
+  if (!id) return "";
+  if (DISPLAY[id]) return DISPLAY[id];
+  return id.charAt(0).toUpperCase() + id.slice(1);
+}

--- a/src/server/ctoToolCatalog.test.mjs
+++ b/src/server/ctoToolCatalog.test.mjs
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CLIS,
+  DOMAINS,
+  LOCAL_CLIS,
+  matchCliIdentity,
+  matchDomainIdentity,
+  matchIssueKeys,
+  displayName,
+} from "./ctoToolCatalog.mjs";
+
+test("catalog CLI match labels known external tools", () => {
+  assert.equal(matchCliIdentity("gh"), "github");
+  assert.equal(matchCliIdentity("GH"), "github"); // case-insensitive
+  assert.equal(matchCliIdentity("aws"), "aws");
+  assert.equal(matchCliIdentity("flyctl"), "flyio");
+  assert.equal(matchCliIdentity("supabase"), "supabase");
+});
+
+test("catalog CLI match marks local toolchain as never-evidence", () => {
+  for (const t of ["git", "npm", "node", "ls", "grep", "curl", "cargo"]) {
+    assert.equal(matchCliIdentity(t), "local", t);
+  }
+  assert.equal(LOCAL_CLIS.has("git"), true);
+});
+
+test("catalog CLI match returns null for unknown tokens (raw evidence)", () => {
+  assert.equal(matchCliIdentity("totally-unknown-cli"), null);
+  assert.equal(matchCliIdentity(""), null);
+});
+
+test("catalog domain match is suffix-aware", () => {
+  assert.equal(matchDomainIdentity("github.com"), "github");
+  assert.equal(matchDomainIdentity("api.github.com"), "github");
+  assert.equal(matchDomainIdentity("hooks.slack.com"), "slack");
+  assert.equal(matchDomainIdentity("api.stripe.com"), "stripe");
+  assert.equal(matchDomainIdentity("unknown-crm.example.com"), null);
+});
+
+test("catalog domain match refuses private / own-box hosts", () => {
+  assert.equal(matchDomainIdentity("localhost"), undefined);
+  assert.equal(matchDomainIdentity("127.0.0.1"), undefined);
+  assert.equal(matchDomainIdentity("192.168.1.4"), undefined);
+  assert.equal(matchDomainIdentity("10.0.0.7"), undefined);
+  assert.equal(matchDomainIdentity("mybox.local"), undefined);
+  assert.equal(matchDomainIdentity("gateway.mantaui.com"), undefined);
+  assert.equal(matchDomainIdentity("mantaui.com"), undefined);
+  assert.equal(matchDomainIdentity("host.internal"), undefined);
+});
+
+test("catalog issue-key shape collects TEAM-123 tokens, deduped", () => {
+  const text = "git checkout -b multica/BET-1395-tool-discovery && git commit -m 'BET-1395: scan' (fixes BET-42)";
+  assert.deepEqual(matchIssueKeys(text), ["BET-1395", "BET-42"]);
+  assert.deepEqual(matchIssueKeys("no keys here"), []);
+  assert.deepEqual(matchIssueKeys(""), []);
+});
+
+test("catalog shapes are non-empty (a shipped list)", () => {
+  assert.ok(Object.keys(CLIS).length >= 20);
+  assert.ok(Object.keys(DOMAINS).length >= 40);
+});
+
+test("displayName humanizes identities", () => {
+  assert.equal(displayName("github"), "GitHub");
+  assert.equal(displayName("gcp"), "Google Cloud");
+  assert.equal(displayName("some_unknown"), "Some_unknown");
+  assert.equal(displayName(""), "");
+});

--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -1,0 +1,606 @@
+// ctoToolRegistry.mjs — §7.2 registry + fusion + lifecycle + connect asks
+// (BET-1395).
+//
+// The registry fuses the four §7.1 evidence channels into ONE row per tool
+// identity ("one identity, one row"), derives engagement, runs the two
+// lifecycle bars, and raises §7.4 connect asks as needs-you decision cards:
+//
+//   observed (evidence accumulates) → candidate (either axis crosses its bar:
+//     engagement ≥3 uses across ≥2 weeks; OR the vitality path — a credential
+//     exists at all) → ONE connect ask (Connect read-only / Not now / Never)
+//     → integrated (probes run — §7.5, a later issue; this module only grants
+//     the metadata consent ring).
+//
+// Raw evidence (unknown CLIs/hosts/keys) is classified by the LLM fallback at
+// most ONCE per identity — the model's judgment is cached in the registry
+// entry and never re-asked (§7.1-4). Near-duplicates fold: a host that is a
+// subdomain of an already-known identity's domain is not a new tool; git
+// remotes are collected at host granularity so slug-covered hosts never
+// become rows in the first place (§7.3 near-duplicate suppression).
+//
+// All I/O is injected; pure helpers are exported for tests.
+
+import { toolRegistryStore, toolUsageStore, ledgerStore } from "./ctoStores.mjs";
+import { displayName as catalogDisplayName } from "./ctoToolCatalog.mjs";
+import {
+  CHANNEL_TRANSCRIPT,
+  CHANNEL_CONFIG,
+  extractFromDbRows,
+  collectConfigEvidence,
+  SCAN_ROW_CAP,
+} from "./ctoToolScan.mjs";
+
+export const TOOL_REGISTRY_VERSION = 1;
+export const ACTOR = "cto";
+
+// Evidence-log cap (all channels) — the usage log is a bounded FIFO.
+export const USAGE_ROWS_CAP = 4000;
+// Per-tool evidence trail cap (§7.2 `evidence: [{channel, detail, ts}]`).
+export const EVIDENCE_CAP = 20;
+// Raw evidence must appear this many times before ONE LLM classification is
+// spent on it (junk singletons are never classified).
+export const RAW_CLASSIFY_MIN_USES = 2;
+// The engagement bar (§7.4): ≥3 uses across ≥2 distinct weeks.
+export const ENGAGEMENT_MIN_USES = 3;
+export const ENGAGEMENT_MIN_WEEKS = 2;
+// "Not now" re-arms after 30 days (§7.4 ring semantics).
+export const NOT_NOW_REARM_MS = 30 * 24 * 3_600_000;
+// Max connect asks per tool (§7.4: askRound < 3).
+export const MAX_ASK_ROUNDS = 3;
+// A fresh bar crossing re-arms a declined ask early: this many uses beyond
+// the snapshot taken at ask time counts as fresh engagement (§7.4
+// "a fresh axis-bar crossing"; the vitality path's bar cannot re-cross, so
+// for credentials only the 30-day timer re-arms).
+export const REARM_FRESH_USES = 2;
+// The classification task class (§12.1 — cheapest nano tier).
+export const TOOL_CLASSIFY_TASK_CLASS = "ambient-summarize";
+
+const DAY_MS = 24 * 3_600_000;
+const EWMA_TAU_DAYS = 7; // engagement EWMA decay constant (1-week τ)
+
+export function emptyConsent() {
+  return { metadata: null, deep_read: null, write: null };
+}
+
+// ISO week bucket (year-Www) — the ≥2-weeks engagement bar's unit.
+export function weekKey(ts) {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return null;
+  const utc = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  const day = (new Date(utc).getUTCDay() + 6) % 7; // Mon=0
+  const monday = new Date(utc - day * DAY_MS);
+  const jan1 = Date.UTC(monday.getUTCFullYear(), 0, 1);
+  const week = Math.floor((monday.getTime() - jan1) / (7 * DAY_MS)) + 1;
+  return `${monday.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+function humanize(identity) {
+  return catalogDisplayName(identity);
+}
+
+function baseTool(identity, ts) {
+  return {
+    tool: identity,
+    displayName: humanize(identity),
+    source: "catalog",
+    raw: false,
+    unclassifiable: false,
+    firstSeenTs: ts,
+    lastSeenTs: ts,
+    ewmaAt: ts,
+    uses: 0,
+    weeksActive: 0,
+    weeks: [],
+    perProject: {},
+    ewmaPerWeek: 0,
+    evidence: [],
+    status: "observed",
+    role: null, // §7.3 quadrants need vitality probes (§7.5) — derived later
+    consent: emptyConsent(),
+    askRound: 0,
+    askAtUses: 0,
+    reArmAt: null,
+    llmAt: null,
+    relevance: {}, // §7.6 blackboard match — refreshed weekly (later issue)
+    as_source: { reports: 0, accepted: 0 }, // §7.2 counters — fed by §9.5 later
+    as_workflow: { suggestions: 0, accepted: 0 },
+  };
+}
+
+// Engagement EWMA decay applied lazily (single application via the `ewmaAt`
+// watermark): `ewma *= exp(-Δdays/τ)`.
+export function decayEwma(tool, nowMs) {
+  const from = tool?.ewmaAt ?? tool?.lastSeenTs ?? nowMs;
+  const deltaDays = (nowMs - from) / DAY_MS;
+  if (!(deltaDays > 0)) return tool?.ewmaPerWeek ?? 0;
+  return (tool?.ewmaPerWeek ?? 0) * Math.exp(-deltaDays / EWMA_TAU_DAYS);
+}
+
+export function hasCredential(tool) {
+  return (tool?.evidence ?? []).some((e) => e?.channel === "secret");
+}
+
+// The engagement bar (§7.4).
+export function engagementBarMet(tool) {
+  return (tool?.uses ?? 0) >= ENGAGEMENT_MIN_USES && (tool?.weeksActive ?? 0) >= ENGAGEMENT_MIN_WEEKS;
+}
+
+// Either axis crossed its bar (§7.4 observed → candidate).
+export function barCrossed(tool) {
+  return engagementBarMet(tool) || hasCredential(tool);
+}
+
+// Near-duplicate suppression (§7.3): a host that is a subdomain of an
+// already-known tool's domain evidence folds into that tool. Git remotes are
+// recorded host-only (no per-slug rows), so slug-covered hosts never become
+// new rows in the first place.
+export function findHostParent(tools, host) {
+  const h = String(host ?? "").toLowerCase();
+  if (!h || !h.includes(".")) return null;
+  for (const t of tools) {
+    for (const e of t?.evidence ?? []) {
+      const d = typeof e?.detail === "string" ? e.detail : "";
+      if (!d.startsWith("domain:")) continue;
+      const known = d.slice("domain:".length).toLowerCase();
+      if (known && (h === known || h.endsWith(`.${known}`))) return t;
+    }
+  }
+  return null;
+}
+
+// Raw evidence without a catalog identity still becomes a registry entry,
+// keyed by the raw token itself — that is what the LLM fallback classifies
+// (at most once). Webhook/schedule labels are free text, not tool tokens:
+// they stay log-only evidence.
+const RAW_HOST_PREFIX = /^(?:www|api|app|mcp|hooks|gateway)\./;
+
+function rawIdentityFromDetail(detail) {
+  if (detail.startsWith("cli:")) return detail.slice(4);
+  if (detail.startsWith("domain:")) return detail.slice(7).replace(RAW_HOST_PREFIX, "");
+  if (detail.startsWith("mcp:")) return detail.slice(4);
+  if (detail.startsWith("secret:")) return detail.slice(7).toLowerCase();
+  if (detail.startsWith("key:")) return "issue-tracker";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Fusion: one evidence row → the registry (pure; returns a NEW array)
+// ---------------------------------------------------------------------------
+
+export function fuseRow(tools, row, { nowMs } = {}) {
+  const arr = Array.isArray(tools) ? [...tools] : [];
+  if (!row || typeof row !== "object") return arr;
+  const ts = Number(row.ts) || nowMs;
+  const project = typeof row.project === "string" && row.project ? row.project : null;
+  const detail = typeof row.detail === "string" ? row.detail : "";
+  const channel = typeof row.channel === "string" ? row.channel : "unknown";
+
+  let host = null;
+  if (detail.startsWith("domain:")) host = detail.slice("domain:".length);
+  if (detail.startsWith("git:")) host = detail.slice("git:".length);
+  // Near-dup: a raw (identity-less) host row folds into the tool that already
+  // covers its parent domain. Catalog-matched rows already share the identity.
+  if (row.identity == null && host) {
+    const parent = findHostParent(arr, host);
+    if (parent) row = { ...row, identity: parent.tool };
+  }
+
+  if (row.identity == null) {
+    // Unclassified raw evidence → a raw registry entry keyed by the token
+    // itself, for the one-shot LLM classification (§7.1-4). Labels stay
+    // log-only.
+    const rawIdentity = rawIdentityFromDetail(detail);
+    if (rawIdentity) row = { ...row, identity: rawIdentity, source: "raw" };
+  }
+
+  const identity = typeof row.identity === "string" && row.identity ? row.identity.toLowerCase() : null;
+  if (!identity) return arr; // no derivable identity — log-only evidence
+
+  let tool = arr.find((t) => t?.tool === identity);
+  if (!tool) {
+    tool = baseTool(identity, ts);
+    tool.raw = row.source === "raw";
+    tool.source = tool.raw ? "raw" : "catalog";
+    arr.push(tool);
+  }
+  const prevEwmaAt = tool.ewmaAt ?? tool.lastSeenTs ?? ts;
+  const deltaDays = Math.max(0, ts - prevEwmaAt) / DAY_MS;
+  tool.ewmaPerWeek = (tool.ewmaPerWeek ?? 0) * Math.exp(-deltaDays / EWMA_TAU_DAYS) + 1;
+  tool.ewmaAt = Math.max(prevEwmaAt, ts);
+  tool.uses += 1;
+  tool.lastSeenTs = Math.max(tool.lastSeenTs ?? ts, ts);
+  if (project) tool.perProject[project] = (tool.perProject[project] ?? 0) + 1;
+  const wk = weekKey(ts);
+  if (wk && !tool.weeks.includes(wk)) {
+    tool.weeks.push(wk);
+    if (tool.weeks.length > 120) tool.weeks.splice(0, tool.weeks.length - 120);
+  }
+  tool.weeksActive = tool.weeks.length;
+  if (detail) {
+    const exists = tool.evidence.some((e) => e?.channel === channel && e?.detail === detail);
+    if (!exists) {
+      tool.evidence.push({ channel, detail, ts });
+      if (tool.evidence.length > EVIDENCE_CAP) tool.evidence.splice(0, tool.evidence.length - EVIDENCE_CAP);
+    }
+  }
+  return arr;
+}
+
+// ---------------------------------------------------------------------------
+// LLM fallback (§7.1-4): classify an unrecognized identity at most once.
+// ---------------------------------------------------------------------------
+
+function rawEvidenceLines(tool, cap = 6) {
+  return (tool?.evidence ?? [])
+    .slice(0, cap)
+    .map((e) => `${e?.channel ?? "?"}: ${e?.detail ?? ""}`.trim())
+    .filter(Boolean);
+}
+
+// Returns a canonical kebab-case identity, or null (unclassifiable).
+export function parseClassification(text) {
+  const first = String(text ?? "").split("\n")[0]?.trim().toLowerCase() ?? "";
+  if (!first || first.startsWith("unknown") || first === "n/a") return null;
+  return /^[a-z0-9][a-z0-9_-]{1,40}$/.test(first) ? first : null;
+}
+
+// ---------------------------------------------------------------------------
+// The registry engine
+// ---------------------------------------------------------------------------
+
+export function createToolRegistry(deps = {}) {
+  const {
+    registryStore = toolRegistryStore,
+    usageStore = toolUsageStore,
+    cards = null, // { upsertConnect, resolveConnectCards, listOpen }
+    ledger = ledgerStore,
+    recordVerdict = null, // async ({subject, verdict, never?}) => {ok}
+    runEphemeral = null, // async ({taskClass, context}) => {text}
+    now = () => Date.now(),
+    // I/O seams for the daily scan (index.mjs supplies the live ones).
+    collectDb = null, // async ({sinceTs, untilTs, cap}) => db part rows
+    collectSurfaces = null, // async () => {config, forgeRepos, webhooks, gitRemotes, schedules}
+    backfillStartInstant = null, // first-scan lower bound (the backfill range)
+  } = deps;
+
+  async function loadPayload() {
+    try {
+      const p = await registryStore.load();
+      return {
+        v: TOOL_REGISTRY_VERSION,
+        tools: Array.isArray(p?.tools) ? p.tools : [],
+        lastScanTs: Number.isFinite(p?.lastScanTs) ? p.lastScanTs : null,
+        lastFusedTs: Number.isFinite(p?.lastFusedTs) ? p.lastFusedTs : null,
+        lastAskDay: typeof p?.lastAskDay === "string" ? p.lastAskDay : null,
+      };
+    } catch {
+      return { v: TOOL_REGISTRY_VERSION, tools: [], lastScanTs: null, lastFusedTs: null, lastAskDay: null };
+    }
+  }
+
+  async function savePayload(payload) {
+    await registryStore.save(payload);
+  }
+
+  async function ledgerLog(entry) {
+    try {
+      await ledger.append({ actor: ACTOR, ts: now(), ...entry });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // Append evidence rows to the bounded usage log (all channels funnel here —
+  // the §7.1 log). Returns the number of rows appended.
+  async function appendUsage(rows) {
+    if (!rows.length) return 0;
+    const payload = (await usageStore.load().catch(() => ({}))) ?? {};
+    const prev = Array.isArray(payload.rows) ? payload.rows : [];
+    await usageStore.save({ ...payload, rows: [...prev, ...rows].slice(-USAGE_ROWS_CAP) });
+    return rows.length;
+  }
+
+  // Fuse every usage row past the watermark into the registry (mutates the
+  // given payload; not saved).
+  async function fusePending(payload) {
+    const log = (await usageStore.load().catch(() => ({}))) ?? {};
+    const rows = Array.isArray(log.rows) ? log.rows : [];
+    const watermark = payload.lastFusedTs ?? 0;
+    let maxTs = payload.lastFusedTs ?? 0;
+    let tools = payload.tools;
+    for (const r of rows) {
+      const ts = Number(r?.ts) || 0;
+      if (ts <= watermark) continue;
+      tools = fuseRow(tools, r, { nowMs: now() });
+      maxTs = Math.max(maxTs, ts);
+    }
+    payload.tools = tools;
+    payload.lastFusedTs = maxTs || payload.lastFusedTs;
+    return payload;
+  }
+
+  // One LLM classification (≤1 per scan): the oldest raw identity past the
+  // uses threshold. Never re-asks a classified or unclassifiable identity.
+  async function classifyOneRaw(payload) {
+    if (typeof runEphemeral !== "function") return payload;
+    const target = payload.tools
+      .filter((t) => t?.raw && !t?.unclassifiable && t?.llmAt == null && (t?.uses ?? 0) >= RAW_CLASSIFY_MIN_USES)
+      .sort((a, b) => (a?.firstSeenTs ?? 0) - (b?.firstSeenTs ?? 0))[0];
+    if (!target) return payload;
+    const context = [
+      {
+        priority: 1,
+        text: [
+          "Classify the external tool behind this observed agent evidence into ONE canonical tool identity.",
+          `Identity token: ${target.tool}`,
+          "Evidence:",
+          ...rawEvidenceLines(target).map((l) => `- ${l}`),
+          'Reply with exactly one line: a kebab-case tool id (e.g. "github", "stripe") or the word "unknown" if it is not an external tool.',
+        ].join("\n"),
+      },
+    ];
+    target.llmAt = now();
+    try {
+      const res = await runEphemeral({ taskClass: TOOL_CLASSIFY_TASK_CLASS, context });
+      const canonical = parseClassification(res?.text);
+      if (!canonical) {
+        // Unclassifiable — cached; this identity is never re-asked (§7.1-4).
+        target.unclassifiable = true;
+        return payload;
+      }
+      if (canonical === target.tool) {
+        target.raw = false;
+        target.source = "llm";
+        target.displayName = humanize(canonical);
+        return payload;
+      }
+      // Merge the raw entry into the canonical identity (or create it).
+      let canon = payload.tools.find((t) => t?.tool === canonical);
+      if (!canon) {
+        canon = baseTool(canonical, target.firstSeenTs);
+        canon.source = "llm";
+        payload.tools.push(canon);
+      }
+      canon.uses += target.uses;
+      canon.lastSeenTs = Math.max(canon.lastSeenTs ?? 0, target.lastSeenTs ?? 0);
+      canon.firstSeenTs = Math.min(canon.firstSeenTs ?? Infinity, target.firstSeenTs ?? Infinity);
+      canon.ewmaPerWeek = (canon.ewmaPerWeek ?? 0) + (target.ewmaPerWeek ?? 0);
+      for (const [p, n] of Object.entries(target.perProject ?? {})) {
+        canon.perProject[p] = (canon.perProject[p] ?? 0) + n;
+      }
+      for (const wk of target.weeks ?? []) {
+        if (!canon.weeks.includes(wk)) canon.weeks.push(wk);
+      }
+      canon.weeksActive = canon.weeks.length;
+      for (const e of target.evidence ?? []) {
+        if (!canon.evidence.some((x) => x?.channel === e?.channel && x?.detail === e?.detail)) {
+          canon.evidence.push(e);
+        }
+      }
+      canon.evidence = canon.evidence.slice(-EVIDENCE_CAP);
+      canon.llmAt = target.llmAt;
+      payload.tools = payload.tools.filter((t) => t !== target);
+      return payload;
+    } catch {
+      // The call failed after being spent — cache "unclassifiable" (§7.1-4:
+      // at most once, never re-asked for the same identity).
+      target.unclassifiable = true;
+      return payload;
+    }
+  }
+
+  // Lifecycle (§7.3/§7.4): EWMA decay, observed→candidate promotion, and at
+  // most one new connect ask per day. Returns `{changed, asked}`.
+  async function lifecycleStep(payload) {
+    const nowMs = now();
+    let changed = false;
+    let asked = null;
+
+    // Decay every tool's engagement EWMA to now (single lazy application).
+    for (const t of payload.tools) {
+      const deltaDays = (nowMs - (t?.ewmaAt ?? t?.lastSeenTs ?? nowMs)) / DAY_MS;
+      if (deltaDays > 0) {
+        t.ewmaPerWeek = (t?.ewmaPerWeek ?? 0) * Math.exp(-deltaDays / EWMA_TAU_DAYS);
+        t.ewmaAt = nowMs;
+        changed = true;
+      }
+    }
+
+    // Promote observed → candidate when either axis crosses its bar.
+    for (const t of payload.tools) {
+      if (t?.status === "observed" && barCrossed(t)) {
+        t.status = "candidate";
+        changed = true;
+        await ledgerLog({ kind: "cto.tool.candidate", tool: t.tool, uses: t.uses, weeksActive: t.weeksActive });
+      }
+    }
+
+    // Connect-ask gate (§7.4): candidate + no consent yet + askRound < 3 +
+    // re-armed + no open connect card + ≤1 new ask/day.
+    if (cards && typeof cards.upsertConnect === "function") {
+      let open = [];
+      try {
+        open = (typeof cards.listOpen === "function" ? await cards.listOpen() : []) ?? [];
+      } catch {
+        open = [];
+      }
+      const openConnectTools = new Set(
+        open.flatMap((c) => (c?.variant === "connect" && Array.isArray(c?.refs) ? c.refs : [])),
+      );
+      const today = new Date(nowMs).toISOString().slice(0, 10);
+      const eligible = payload.tools
+        .filter((t) => {
+          if (t?.status !== "candidate") return false;
+          const consent = t?.consent ?? {};
+          if (consent.metadata === "yes" || consent.metadata === "never") return false;
+          if ((t?.askRound ?? 0) >= MAX_ASK_ROUNDS) return false;
+          if (consent.metadata === "no") {
+            const fresh = (t?.uses ?? 0) > (t?.askAtUses ?? 0) + REARM_FRESH_USES;
+            const timer = t?.reArmAt != null && nowMs >= t.reArmAt;
+            if (!timer && !fresh) return false;
+          }
+          if (openConnectTools.has(t.tool)) return false;
+          return barCrossed(t);
+        })
+        .sort((a, b) => (b?.uses ?? 0) - (a?.uses ?? 0));
+
+      if (eligible.length && payload.lastAskDay !== today) {
+        const t = eligible[0];
+        if (t.consent?.metadata === "no") t.consent.metadata = null; // re-armed
+        const ev = (t?.evidence ?? []).slice(-4).map((e) => `${e?.channel}: ${e?.detail}`);
+        const why = [
+          `${t.displayName ?? t.tool} showed up ${t.uses}× across ${t.weeksActive} week(s) of agent work`,
+          hasCredential(t) ? "and a credential for it exists on this box" : "",
+          "— grant read-only metadata access so the CTO can keep it in its model, or decline.",
+        ]
+          .filter(Boolean)
+          .join(" ");
+        await cards.upsertConnect({
+          toolId: t.tool,
+          title: `Connect ${t.displayName ?? t.tool} (read-only)?`,
+          body: why,
+          evidence: ev,
+          refs: [t.tool],
+          ts: nowMs,
+        });
+        t.askRound = (t.askRound ?? 0) + 1;
+        t.askAtUses = t.uses ?? 0;
+        t.reArmAt = null;
+        payload.lastAskDay = today;
+        asked = t.tool;
+        changed = true;
+        await ledgerLog({ kind: "cto.tool.ask", tool: t.tool, askRound: t.askRound });
+      }
+    }
+
+    return { changed, asked };
+  }
+
+  // The daily batch (§7.1-2/3 + §7.3). First scan after install runs over the
+  // cold-start backfill range; later scans run since the previous watermark.
+  // Returns `{ok, scanned, asked}`.
+  async function dailyScan() {
+    const nowMs = now();
+    const untilTs = nowMs;
+    const payload = await loadPayload();
+    const sinceTs =
+      payload.lastScanTs ??
+      (Number.isFinite(backfillStartInstant) ? backfillStartInstant : nowMs - 30 * DAY_MS);
+
+    const rows = [];
+    try {
+      if (typeof collectDb === "function") {
+        const dbRows = await collectDb({ sinceTs, untilTs, cap: SCAN_ROW_CAP });
+        rows.push(...extractFromDbRows(dbRows));
+      }
+      if (typeof collectSurfaces === "function") {
+        const surfaces = (await collectSurfaces()) ?? {};
+        rows.push(...collectConfigEvidence(surfaces, { ts: nowMs }));
+      }
+    } catch {
+      /* channel failures never take the scan down */
+    }
+    await appendUsage(rows);
+    await fusePending(payload);
+    await classifyOneRaw(payload);
+    const { changed, asked } = await lifecycleStep(payload);
+    payload.lastScanTs = untilTs;
+    await savePayload(payload);
+    if (changed || asked) {
+      await ledgerLog({ kind: "cto.tool.scan", asked: asked ?? null });
+    }
+    return { ok: true, scanned: rows.length, asked: asked ?? null };
+  }
+
+  // Resolve a connect ask (§7.4 three-way). Writes the consent ring, the
+  // §9.5 verdict (accept / dismiss / never), and resolves the open card.
+  async function resolveConnect({ tool, answer } = {}) {
+    const id = typeof tool === "string" ? tool.trim().toLowerCase() : "";
+    if (!id) return { ok: false, error: "missing tool" };
+    if (answer !== "connect" && answer !== "not-now" && answer !== "never") {
+      return { ok: false, error: `invalid answer "${answer}"` };
+    }
+    const payload = await loadPayload();
+    const t = payload.tools.find((x) => x?.tool === id);
+    if (!t) return { ok: false, error: `unknown tool "${id}"` };
+    const nowMs = now();
+    t.consent = t.consent ?? emptyConsent();
+    if (answer === "connect") {
+      // The metadata ring is granted. Status stays `candidate` until probes
+      // actually run (§7.5 flips it to `integrated` in a later issue).
+      t.consent.metadata = "yes";
+      t.reArmAt = null;
+      await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "yes" });
+    } else if (answer === "not-now") {
+      t.consent.metadata = "no";
+      t.reArmAt = nowMs + NOT_NOW_REARM_MS;
+      t.askAtUses = t.uses ?? 0;
+      await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "no" });
+    } else {
+      // Never: kills ALL rings and suppresses future asks (revocable only in
+      // the §10.5 tool drill-down).
+      t.consent = { metadata: "never", deep_read: "never", write: "never" };
+      await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "never" });
+    }
+    await savePayload(payload);
+
+    // §9.5: every UI control that expresses a judgment writes exactly one
+    // verdict. Connect → accept; Not now → dismiss; Never → never.
+    if (typeof recordVerdict === "function") {
+      try {
+        if (answer === "connect") {
+          await recordVerdict({ subject: { type: "tool", id, class: "tool-metadata" }, verdict: "accept" });
+        } else if (answer === "not-now") {
+          await recordVerdict({ subject: { type: "tool", id, class: "tool-metadata" }, verdict: "dismiss" });
+        } else {
+          await recordVerdict({ subject: { type: "tool", id, class: "tool-metadata" }, verdict: "never", never: true });
+        }
+      } catch {
+        /* best-effort — the consent ring is the source of truth */
+      }
+    }
+
+    // Close the open connect card for this tool (best-effort).
+    if (cards && typeof cards.resolveConnectCards === "function") {
+      try {
+        await cards.resolveConnectCards(id, `connect answer: ${answer}`);
+      } catch {
+        /* best-effort */
+      }
+    }
+    return { ok: true, tool: id, answer };
+  }
+
+  // Read a consent ring for the future probe / tool-write gates (§7.4:
+  // "metadata consent ≠ deep-read consent ≠ write").
+  async function consentFor(tool, ring = "metadata") {
+    const id = typeof tool === "string" ? tool.trim().toLowerCase() : "";
+    if (!id) return null;
+    const payload = await loadPayload();
+    const t = payload.tools.find((x) => x?.tool === id);
+    return t ? (t.consent?.[ring] ?? null) : null;
+  }
+
+  // Registry view for the §10.5 tool surfaces (read-only, stable shape).
+  async function listTools() {
+    const payload = await loadPayload();
+    return payload.tools.map((t) => ({
+      tool: t.tool,
+      displayName: t.displayName ?? humanize(t.tool),
+      status: t.status ?? "observed",
+      role: t.role ?? null,
+      uses: t.uses ?? 0,
+      weeksActive: t.weeksActive ?? 0,
+      ewmaPerWeek: Math.round((t.ewmaPerWeek ?? 0) * 100) / 100,
+      lastSeenTs: t.lastSeenTs ?? null,
+      firstSeenTs: t.firstSeenTs ?? null,
+      consent: { ...emptyConsent(), ...(t.consent ?? {}) },
+      askRound: t.askRound ?? 0,
+    }));
+  }
+
+  return { dailyScan, resolveConnect, consentFor, listTools, appendUsage };
+}
+
+// Re-exported for callers that build rows by hand (tests, index.mjs wiring).
+export { CHANNEL_TRANSCRIPT, CHANNEL_CONFIG, SCAN_ROW_CAP };

--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -78,6 +78,10 @@ function humanize(identity) {
   return catalogDisplayName(identity);
 }
 
+// §7.2 schema (verbatim axes) + the lifecycle bookkeeping the engine needs
+// on top: engagement/vitality are the spec'd axes; uses/weeksActive/weeks are
+// derived counters (the bar's inputs); askRound/askAtUses/reArmAt/
+// unneverAtUses drive the §7.4 ask gate.
 function baseTool(identity, ts) {
   return {
     tool: identity,
@@ -86,13 +90,14 @@ function baseTool(identity, ts) {
     raw: false,
     unclassifiable: false,
     firstSeenTs: ts,
-    lastSeenTs: ts,
-    ewmaAt: ts,
+    // §7.2 engagement axis.
+    engagement: { ewma_per_week: 0, last_used: ts, per_project: {} },
+    // §7.2 vitality axis — §7.5 probes are the only writer; empty until then.
+    vitality: { last_event: null, inflow_rate: null, ewma: null, last_probed: null },
+    ewmaAt: ts, // EWMA decay watermark (internal, single-application)
     uses: 0,
     weeksActive: 0,
     weeks: [],
-    perProject: {},
-    ewmaPerWeek: 0,
     evidence: [],
     status: "observed",
     role: null, // §7.3 quadrants need vitality probes (§7.5) — derived later
@@ -100,6 +105,7 @@ function baseTool(identity, ts) {
     askRound: 0,
     askAtUses: 0,
     reArmAt: null,
+    unneverAtUses: null,
     llmAt: null,
     relevance: {}, // §7.6 blackboard match — refreshed weekly (later issue)
     as_source: { reports: 0, accepted: 0 }, // §7.2 counters — fed by §9.5 later
@@ -110,10 +116,10 @@ function baseTool(identity, ts) {
 // Engagement EWMA decay applied lazily (single application via the `ewmaAt`
 // watermark): `ewma *= exp(-Δdays/τ)`.
 export function decayEwma(tool, nowMs) {
-  const from = tool?.ewmaAt ?? tool?.lastSeenTs ?? nowMs;
+  const from = tool?.ewmaAt ?? tool?.engagement?.last_used ?? nowMs;
   const deltaDays = (nowMs - from) / DAY_MS;
-  if (!(deltaDays > 0)) return tool?.ewmaPerWeek ?? 0;
-  return (tool?.ewmaPerWeek ?? 0) * Math.exp(-deltaDays / EWMA_TAU_DAYS);
+  if (!(deltaDays > 0)) return tool?.engagement?.ewma_per_week ?? 0;
+  return (tool?.engagement?.ewma_per_week ?? 0) * Math.exp(-deltaDays / EWMA_TAU_DAYS);
 }
 
 export function hasCredential(tool) {
@@ -203,13 +209,14 @@ export function fuseRow(tools, row, { nowMs } = {}) {
     tool.source = tool.raw ? "raw" : "catalog";
     arr.push(tool);
   }
-  const prevEwmaAt = tool.ewmaAt ?? tool.lastSeenTs ?? ts;
+  const prevEwmaAt = tool.ewmaAt ?? tool.engagement?.last_used ?? ts;
   const deltaDays = Math.max(0, ts - prevEwmaAt) / DAY_MS;
-  tool.ewmaPerWeek = (tool.ewmaPerWeek ?? 0) * Math.exp(-deltaDays / EWMA_TAU_DAYS) + 1;
+  tool.engagement = tool.engagement ?? { ewma_per_week: 0, last_used: ts, per_project: {} };
+  tool.engagement.ewma_per_week = (tool.engagement.ewma_per_week ?? 0) * Math.exp(-deltaDays / EWMA_TAU_DAYS) + 1;
+  tool.engagement.last_used = Math.max(tool.engagement.last_used ?? ts, ts);
   tool.ewmaAt = Math.max(prevEwmaAt, ts);
   tool.uses += 1;
-  tool.lastSeenTs = Math.max(tool.lastSeenTs ?? ts, ts);
-  if (project) tool.perProject[project] = (tool.perProject[project] ?? 0) + 1;
+  if (project) tool.engagement.per_project[project] = (tool.engagement.per_project[project] ?? 0) + 1;
   const wk = weekKey(ts);
   if (wk && !tool.weeks.includes(wk)) {
     tool.weeks.push(wk);
@@ -280,6 +287,25 @@ export function createToolRegistry(deps = {}) {
 
   async function savePayload(payload) {
     await registryStore.save(payload);
+  }
+
+  // Serializes the registry's mutating writers (dailyScan / resolveConnect /
+  // unNever) — all load→mutate→save the same whole-payload store, and the
+  // scan holds its snapshot across seconds-long awaits (db batch, LLM
+  // classification). Without the guard, a connect answer landing mid-scan is
+  // silently overwritten by the scan's stale save — the user's explicit
+  // "never" reverting (lost update; the same snapshot-spreading-writer class
+  // BET-1425 fixed for engine-state). Writers queue behind the in-flight one
+  // (the established in-flight-guard pattern); each mutation is short except
+  // the scan, whose internal failures never leave the queue stuck.
+  let writeChain = Promise.resolve();
+  function serialized(fn) {
+    const run = writeChain.then(fn, fn);
+    writeChain = run.then(
+      () => {},
+      () => {},
+    );
+    return run;
   }
 
   async function ledgerLog(entry) {
@@ -362,11 +388,11 @@ export function createToolRegistry(deps = {}) {
         payload.tools.push(canon);
       }
       canon.uses += target.uses;
-      canon.lastSeenTs = Math.max(canon.lastSeenTs ?? 0, target.lastSeenTs ?? 0);
+      canon.engagement.last_used = Math.max(canon.engagement?.last_used ?? 0, target.engagement?.last_used ?? 0);
       canon.firstSeenTs = Math.min(canon.firstSeenTs ?? Infinity, target.firstSeenTs ?? Infinity);
-      canon.ewmaPerWeek = (canon.ewmaPerWeek ?? 0) + (target.ewmaPerWeek ?? 0);
-      for (const [p, n] of Object.entries(target.perProject ?? {})) {
-        canon.perProject[p] = (canon.perProject[p] ?? 0) + n;
+      canon.engagement.ewma_per_week = (canon.engagement?.ewma_per_week ?? 0) + (target.engagement?.ewma_per_week ?? 0);
+      for (const [p, n] of Object.entries(target.engagement?.per_project ?? {})) {
+        canon.engagement.per_project[p] = (canon.engagement.per_project[p] ?? 0) + n;
       }
       for (const wk of target.weeks ?? []) {
         if (!canon.weeks.includes(wk)) canon.weeks.push(wk);
@@ -398,21 +424,26 @@ export function createToolRegistry(deps = {}) {
 
     // Decay every tool's engagement EWMA to now (single lazy application).
     for (const t of payload.tools) {
-      const deltaDays = (nowMs - (t?.ewmaAt ?? t?.lastSeenTs ?? nowMs)) / DAY_MS;
+      const deltaDays = (nowMs - (t?.ewmaAt ?? t?.engagement?.last_used ?? nowMs)) / DAY_MS;
       if (deltaDays > 0) {
-        t.ewmaPerWeek = (t?.ewmaPerWeek ?? 0) * Math.exp(-deltaDays / EWMA_TAU_DAYS);
+        t.engagement.ewma_per_week = (t?.engagement?.ewma_per_week ?? 0) * Math.exp(-deltaDays / EWMA_TAU_DAYS);
         t.ewmaAt = nowMs;
         changed = true;
       }
     }
 
-    // Promote observed → candidate when either axis crosses its bar.
+    // Promote observed → candidate when either axis crosses its bar. After an
+    // un-never (§7.4: "returns the tool to observed; a new ask still requires
+    // a fresh bar crossing") the promotion needs NEW engagement beyond the
+    // un-never snapshot — barCrossed is monotone in uses, so without the
+    // snapshot a just-un-never'd tool would instantly re-promote and re-ask.
     for (const t of payload.tools) {
-      if (t?.status === "observed" && barCrossed(t)) {
-        t.status = "candidate";
-        changed = true;
-        await ledgerLog({ kind: "cto.tool.candidate", tool: t.tool, uses: t.uses, weeksActive: t.weeksActive });
-      }
+      if (t?.status !== "observed" || !barCrossed(t)) continue;
+      if (t.unneverAtUses != null && (t?.uses ?? 0) <= t.unneverAtUses + REARM_FRESH_USES) continue;
+      t.unneverAtUses = null;
+      t.status = "candidate";
+      changed = true;
+      await ledgerLog({ kind: "cto.tool.candidate", tool: t.tool, uses: t.uses, weeksActive: t.weeksActive });
     }
 
     // Connect-ask gate (§7.4): candidate + no consent yet + askRound < 3 +
@@ -435,7 +466,11 @@ export function createToolRegistry(deps = {}) {
           if (consent.metadata === "yes" || consent.metadata === "never") return false;
           if ((t?.askRound ?? 0) >= MAX_ASK_ROUNDS) return false;
           if (consent.metadata === "no") {
-            const fresh = (t?.uses ?? 0) > (t?.askAtUses ?? 0) + REARM_FRESH_USES;
+            // §7.4 re-arm semantics: 30 days, or a fresh axis-bar crossing —
+            // BUT the fresh-crossing path exists only on the engagement axis
+            // (a credential-exists bar cannot re-cross, so on the vitality
+            // path the 30-day timer is the only re-arm).
+            const fresh = engagementBarMet(t) && (t?.uses ?? 0) > (t?.askAtUses ?? 0) + REARM_FRESH_USES;
             const timer = t?.reArmAt != null && nowMs >= t.reArmAt;
             if (!timer && !fresh) return false;
           }
@@ -571,6 +606,30 @@ export function createToolRegistry(deps = {}) {
     return { ok: true, tool: id, answer };
   }
 
+  // §7.4 "Un-never" (the tool drill-down, B11, calls this): returns the tool
+  // to `observed`, clears the never-suppression on every ring, and requires a
+  // FRESH bar crossing before the next ask — enforced by the `unneverAtUses`
+  // snapshot the promotion gate checks (barCrossed is monotone in uses, so
+  // without the snapshot the tool would instantly re-promote and re-ask,
+  // exactly the immediate re-prompt the spec's fresh-crossing requirement
+  // exists to prevent). The server rule ships here; the drill-down UI/route
+  // is B11's.
+  async function unNever(toolId) {
+    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
+    if (!id) return { ok: false, error: "missing tool" };
+    const payload = await loadPayload();
+    const t = payload.tools.find((x) => x?.tool === id);
+    if (!t) return { ok: false, error: `unknown tool "${id}"` };
+    if (t.consent?.metadata !== "never") return { ok: false, error: `tool "${id}" is not never'd` };
+    t.consent = emptyConsent();
+    t.status = "observed";
+    t.unneverAtUses = t.uses ?? 0;
+    t.reArmAt = null;
+    await savePayload(payload);
+    await ledgerLog({ kind: "cto.tool.unnever", tool: id, uses: t.uses });
+    return { ok: true, tool: id };
+  }
+
   // Read a consent ring for the future probe / tool-write gates (§7.4:
   // "metadata consent ≠ deep-read consent ≠ write").
   async function consentFor(tool, ring = "metadata") {
@@ -591,15 +650,22 @@ export function createToolRegistry(deps = {}) {
       role: t.role ?? null,
       uses: t.uses ?? 0,
       weeksActive: t.weeksActive ?? 0,
-      ewmaPerWeek: Math.round((t.ewmaPerWeek ?? 0) * 100) / 100,
-      lastSeenTs: t.lastSeenTs ?? null,
+      ewmaPerWeek: Math.round((t.engagement?.ewma_per_week ?? 0) * 100) / 100,
+      lastSeenTs: t.engagement?.last_used ?? null,
       firstSeenTs: t.firstSeenTs ?? null,
       consent: { ...emptyConsent(), ...(t.consent ?? {}) },
       askRound: t.askRound ?? 0,
     }));
   }
 
-  return { dailyScan, resolveConnect, consentFor, listTools, appendUsage };
+  return {
+    dailyScan: () => serialized(dailyScan),
+    resolveConnect: (input) => serialized(() => resolveConnect(input)),
+    unNever: (toolId) => serialized(() => unNever(toolId)),
+    consentFor,
+    listTools,
+    appendUsage,
+  };
 }
 
 // Re-exported for callers that build rows by hand (tests, index.mjs wiring).

--- a/src/server/ctoToolRegistry.test.mjs
+++ b/src/server/ctoToolRegistry.test.mjs
@@ -1,0 +1,451 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createToolRegistry,
+  fuseRow,
+  weekKey,
+  barCrossed,
+  engagementBarMet,
+  hasCredential,
+  parseClassification,
+  findHostParent,
+  RAW_CLASSIFY_MIN_USES,
+  ENGAGEMENT_MIN_USES,
+  ENGAGEMENT_MIN_WEEKS,
+} from "./ctoToolRegistry.mjs";
+
+const DAY = 24 * 3_600_000;
+const W0 = 1_700_000_000_000; // a fixed epoch
+
+function memStore(initial = {}) {
+  let state = { ...initial };
+  return {
+    load: async () => ({ ...state }),
+    save: async (next) => {
+      state = { ...next };
+    },
+    _state: () => state,
+  };
+}
+
+function fakeCards() {
+  const calls = { upserts: [], resolved: [] };
+  const open = [];
+  return {
+    calls,
+    open,
+    async upsertConnect(input) {
+      calls.upserts.push(input);
+      open.push({ id: `card-${input.toolId}`, variant: "connect", state: "open", refs: input.refs });
+      return { changed: true, isNew: true };
+    },
+    async listOpen() {
+      return open.filter((c) => c.state === "open");
+    },
+    async resolveConnectCards(toolId, reason) {
+      const hit = open.some((c) => c.state === "open" && c.refs?.includes(toolId));
+      for (const c of open) if (c.refs?.includes(toolId)) c.state = "resolved";
+      calls.resolved.push({ toolId, reason, hit });
+      return { changed: hit };
+    },
+  };
+}
+
+function fakeLedger() {
+  const rows = [];
+  return {
+    rows,
+    async append(entry) {
+      rows.push(entry);
+    },
+  };
+}
+
+function makeRegistry({ usageRows = [], cards = fakeCards(), runEphemeral = null, nowMs = W0, collectDb = null, collectSurfaces = null } = {}) {
+  const registryStore = memStore();
+  const usageStore = memStore({ rows: [...usageRows] });
+  const ledger = fakeLedger();
+  const registry = createToolRegistry({
+    registryStore,
+    usageStore,
+    cards,
+    ledger,
+    runEphemeral,
+    now: () => nowMs,
+    collectDb,
+    collectSurfaces,
+  });
+  return { registry, registryStore, usageStore, ledger, cards };
+}
+
+// ---------------------------------------------------------------------------
+// pure fusion helpers
+// ---------------------------------------------------------------------------
+
+test("weekKey buckets timestamps into ISO weeks", () => {
+  assert.match(weekKey(W0), /^\d{4}-W\d{2}$/);
+  assert.equal(weekKey("not-a-number"), null);
+});
+
+test("fuseRow creates one row per identity and accumulates uses/weeks", () => {
+  let tools = [];
+  tools = fuseRow(tools, { channel: "transcript", identity: "github", detail: "cli:gh", ts: W0 });
+  tools = fuseRow(tools, { channel: "transcript", identity: "github", detail: "cli:gh", ts: W0 + 3 * DAY });
+  tools = fuseRow(tools, { channel: "secret", identity: "github", detail: "secret:GITHUB_PAT", ts: W0 + 8 * DAY });
+  assert.equal(tools.length, 1);
+  const t = tools[0];
+  assert.equal(t.tool, "github");
+  assert.equal(t.uses, 3);
+  assert.equal(t.weeksActive, 2);
+  assert.equal(t.status, "observed");
+  assert.equal(hasCredential(t), true); // channel-1 evidence = vitality path
+  assert.equal(barCrossed(t), true); // credential alone crosses the bar
+  // Evidence trail dedups by channel+detail and caps.
+  assert.equal(t.evidence.length, 2);
+});
+
+test("raw evidence without a catalog identity becomes a raw entry (LLM-classifiable); labels stay log-only", () => {
+  let tools = fuseRow([], { channel: "transcript", identity: null, detail: "cli:weird", ts: W0, source: "raw" });
+  assert.equal(tools.length, 1);
+  assert.equal(tools[0].tool, "weird");
+  assert.equal(tools[0].raw, true);
+  assert.equal(tools[0].status, "observed");
+  // Free-text labels (webhooks/schedules) are not tool tokens — log-only.
+  tools = fuseRow(tools, { channel: "config", identity: null, detail: "webhook:some label", ts: W0 });
+  assert.equal(tools.length, 1);
+});
+
+test("engagement bar needs uses AND distinct weeks", () => {
+  const t = { uses: 10, weeksActive: 1, evidence: [] };
+  assert.equal(engagementBarMet(t), false);
+  assert.equal(barCrossed(t), false);
+  const t2 = { uses: 3, weeksActive: 2, evidence: [] };
+  assert.equal(engagementBarMet(t2), true);
+  assert.equal(barCrossed(t2), true);
+});
+
+test("near-duplicate suppression folds a subdomain host into the known tool", () => {
+  let tools = fuseRow([], { channel: "transcript", identity: "github", detail: "domain:github.com", ts: W0 });
+  const parent = findHostParent(tools, "api.github.com");
+  assert.equal(parent?.tool, "github");
+  // A raw row for the subdomain folds into the parent by identity.
+  const merged = fuseRow(tools, { channel: "transcript", identity: null, detail: "domain:api.github.com", ts: W0 + 1 });
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].uses, 2);
+  // An unrelated host does NOT fold.
+  assert.equal(findHostParent(tools, "api.stripe.com"), null);
+});
+
+test("EWMA decays toward zero with inactivity (single application)", () => {
+  let tools = [];
+  tools = fuseRow(tools, { channel: "transcript", identity: "x", detail: "cli:x", ts: W0 });
+  tools = fuseRow(tools, { channel: "transcript", identity: "x", detail: "cli:x", ts: W0 + 1 * DAY });
+  const before = tools[0].ewmaPerWeek;
+  tools = fuseRow(tools, { channel: "transcript", identity: "x", detail: "cli:x", ts: W0 + 8 * DAY });
+  const after = tools[0].ewmaPerWeek;
+  assert.ok(after < before, "a week-old gap must decay the EWMA");
+  assert.ok(after >= 1, "each use adds exactly 1 after decay");
+});
+
+test("parseClassification accepts one kebab-case line, rejects junk", () => {
+  assert.equal(parseClassification("github\nextra"), "github");
+  assert.equal(parseClassification("  Stripe-API \n"), "stripe-api");
+  assert.equal(parseClassification("unknown"), null);
+  assert.equal(parseClassification("I think it is github"), null);
+  assert.equal(parseClassification(""), null);
+});
+
+// ---------------------------------------------------------------------------
+// the engine: scan → fusion → classification → lifecycle → asks → resolve
+// ---------------------------------------------------------------------------
+
+test("dailyScan fuses channel 2+3 rows, classifies raw once, promotes and asks", async () => {
+  const cards = fakeCards();
+  const dbRows = [
+    { session_id: "s1", data: JSON.stringify({ type: "tool", tool: "bash", state: { input: { command: "gh pr list" } } }), time_created: W0 },
+    { session_id: "s1", data: JSON.stringify({ type: "tool", tool: "bash", state: { input: { command: "gh pr view" } } }), time_created: W0 + 8 * DAY },
+  ];
+  const { registry, registryStore, usageStore } = makeRegistry({
+    cards,
+    nowMs: W0 + 9 * DAY,
+    collectDb: async ({ sinceTs, untilTs }) => {
+      assert.ok(sinceTs < W0);
+      assert.ok(untilTs >= W0 + 9 * DAY);
+      return dbRows;
+    },
+    collectSurfaces: async () => ({
+      config: { mcp: { linear: { url: "https://mcp.linear.app/sse" } } },
+      gitRemotes: [{ project: "manta", url: "https://github.com/antoinedc/MantaUI.git" }],
+    }),
+    runEphemeral: async () => ({ text: "unknown" }), // nothing raw here — never called
+  });
+
+  const r = await registry.dailyScan();
+  assert.equal(r.ok, true);
+  const state = registryStore._state();
+  const tools = Object.fromEntries(state.tools.map((t) => [t.tool, t]));
+
+  // Channel 2 (gh 2×) + channel 3 (git:github.com) fuse into ONE github row:
+  // 3 uses across 2 distinct weeks → the engagement bar → candidate + the
+  // first connect ask. The mcp row is its own identity, 1 use → observed.
+  assert.equal(tools.github.uses, 3);
+  assert.equal(tools.github.status, "candidate");
+  assert.equal(tools.linear.status, "observed");
+  assert.equal(r.asked, "github");
+  assert.equal(cards.calls.upserts.length, 1);
+  // The usage log holds every evidence row (channels 2+3).
+  const logRows = usageStore._state().rows;
+  assert.equal(logRows.length, 4);
+  // First scan consumed the whole window → the backfill range ran once.
+  assert.ok(state.lastScanTs >= W0 + 9 * DAY);
+});
+
+test("engagement-bar tool becomes a candidate and raises ONE connect ask; the answer writes consent + verdict + resolves the card", async () => {
+  const cards = fakeCards();
+  const usageRows = [
+    { channel: "transcript", identity: "vercel", detail: "cli:vercel", ts: W0, source: "catalog" },
+    { channel: "transcript", identity: "vercel", detail: "cli:vercel", ts: W0 + 2 * DAY, source: "catalog" },
+    { channel: "transcript", identity: "vercel", detail: "cli:vercel", ts: W0 + 8 * DAY, source: "catalog" },
+  ];
+  const { registry, registryStore, ledger } = makeRegistry({ cards, usageRows, nowMs: W0 + 9 * DAY });
+
+  const r = await registry.dailyScan();
+  assert.equal(r.asked, "vercel");
+  assert.equal(cards.calls.upserts.length, 1);
+  const ask = cards.calls.upserts[0];
+  assert.equal(ask.toolId, "vercel");
+  assert.match(ask.title, /Connect Vercel \(read-only\)\?/);
+  assert.ok(ask.body.includes("3×"));
+  const state = registryStore._state();
+  const t = state.tools.find((x) => x.tool === "vercel");
+  assert.equal(t.status, "candidate");
+  assert.equal(t.askRound, 1);
+  assert.equal(state.lastAskDay, new Date(W0 + 9 * DAY).toISOString().slice(0, 10));
+
+  // The ask is recorded on the activity ledger.
+  assert.ok(ledger.rows.some((row) => row.kind === "cto.tool.ask" && row.tool === "vercel"));
+
+  // Resolve: connect → consent.metadata=yes, accept verdict, card closed.
+  const res = await registry.resolveConnect({ tool: "vercel", answer: "connect" });
+  assert.equal(res.ok, true);
+  const after = registryStore._state().tools.find((x) => x.tool === "vercel");
+  assert.equal(after.consent.metadata, "yes");
+  assert.ok(ledger.rows.some((row) => row.kind === "cto.tool.consent" && row.value === "yes"));
+  assert.equal(cards.calls.resolved.length, 1);
+  assert.equal(cards.calls.resolved[0].hit, true);
+  assert.equal(cards.open.every((c) => c.state === "resolved"), true);
+});
+
+test("ask pacing: at most one NEW ask per day, and askRound < 3 forever", async () => {
+  const cards = fakeCards();
+  const mk = (identity, ts) => ({ channel: "transcript", identity, detail: `cli:${identity}`, ts, source: "catalog" });
+  const usageRows = [
+    mk("vercel", W0), mk("vercel", W0 + 2 * DAY), mk("vercel", W0 + 8 * DAY),
+    mk("stripe", W0), mk("stripe", W0 + 2 * DAY), mk("stripe", W0 + 8 * DAY),
+  ];
+  const { registry, registryStore } = makeRegistry({ cards, usageRows, nowMs: W0 + 9 * DAY });
+  await registry.dailyScan();
+  assert.equal(cards.calls.upserts.length, 1); // ≤1/day
+  assert.equal(cards.calls.upserts[0].toolId, "vercel"); // highest uses first — tie → deterministic order
+
+  // Next day: the second tool asks (round 1 each) — vercel's ask card is
+  // still open, so the gate skips it and picks stripe.
+  const day2 = W0 + 10 * DAY;
+  const reg2 = createToolRegistry({
+    registryStore,
+    usageStore: memStore({ rows: [...usageRows, mk("vercel", day2), mk("stripe", day2)] }),
+    cards,
+    ledger: fakeLedger(),
+    now: () => day2,
+  });
+  await reg2.dailyScan();
+  assert.equal(cards.calls.upserts.length, 2);
+  assert.equal(cards.calls.upserts[1].toolId, "stripe");
+
+  // After 3 ask rounds with no answers, no more asks for that tool.
+  const state = registryStore._state();
+  for (const t of state.tools) t.askRound = 3;
+  await registryStore.save(state);
+  const day3 = W0 + 11 * DAY;
+  const reg3 = createToolRegistry({
+    registryStore,
+    usageStore: memStore({ rows: [...usageRows, mk("vercel", day3), mk("stripe", day3)] }),
+    cards,
+    ledger: fakeLedger(),
+    now: () => day3,
+  });
+  const res3 = await reg3.dailyScan();
+  assert.equal(res3.asked, null);
+  assert.equal(cards.calls.upserts.length, 2);
+});
+
+test("not-now declines with a 30-day re-arm; a fresh bar crossing re-arms early", async () => {
+  const cards = fakeCards();
+  const mk = (ts) => ({ channel: "transcript", identity: "stripe", detail: "cli:stripe", ts, source: "catalog" });
+  const usageRows = [mk(W0), mk(W0 + 2 * DAY), mk(W0 + 8 * DAY)];
+  const { registry, registryStore } = makeRegistry({ cards, usageRows, nowMs: W0 + 9 * DAY });
+  await registry.dailyScan();
+  await registry.resolveConnect({ tool: "stripe", answer: "not-now" });
+  let t = registryStore._state().tools.find((x) => x.tool === "stripe");
+  assert.equal(t.consent.metadata, "no");
+  assert.equal(t.reArmAt, W0 + 9 * DAY + 30 * DAY);
+
+  // Same day again → no new ask (reArmAt in the future, no fresh uses).
+  const day2 = W0 + 10 * DAY;
+  const reg2 = createToolRegistry({
+    registryStore,
+    usageStore: memStore({ rows: [mk(day2)] }),
+    cards,
+    ledger: fakeLedger(),
+    now: () => day2,
+  });
+  const res2 = await reg2.dailyScan();
+  assert.equal(res2.asked, null);
+
+  // Fresh engagement (2+ uses beyond the ask-time snapshot) re-arms early.
+  const day3 = W0 + 11 * DAY;
+  const reg3 = createToolRegistry({
+    registryStore,
+    usageStore: memStore({ rows: [mk(day3), mk(day3 + 1000)] }),
+    cards,
+    ledger: fakeLedger(),
+    now: () => day3,
+  });
+  const res3 = await reg3.dailyScan();
+  assert.equal(res3.asked, "stripe");
+  t = registryStore._state().tools.find((x) => x.tool === "stripe");
+  assert.equal(t.consent.metadata, null); // re-armed
+  assert.equal(t.askRound, 2);
+});
+
+test("never kills every ring and suppresses future asks", async () => {
+  const cards = fakeCards();
+  const mk = (ts) => ({ channel: "transcript", identity: "aws", detail: "cli:aws", ts, source: "catalog" });
+  const { registry, registryStore } = makeRegistry({ cards, usageRows: [mk(W0), mk(W0 + 2 * DAY), mk(W0 + 8 * DAY)], nowMs: W0 + 9 * DAY });
+  await registry.dailyScan();
+  const res = await registry.resolveConnect({ tool: "aws", answer: "never" });
+  assert.equal(res.ok, true);
+  const t = registryStore._state().tools.find((x) => x.tool === "aws");
+  assert.deepEqual(t.consent, { metadata: "never", deep_read: "never", write: "never" });
+
+  // Even with fresh evidence, never a new ask.
+  const day2 = W0 + 40 * DAY;
+  const reg2 = createToolRegistry({
+    registryStore,
+    usageStore: memStore({ rows: [mk(day2), mk(day2 + 1000), mk(day2 + 2000)] }),
+    cards,
+    ledger: fakeLedger(),
+    now: () => day2,
+  });
+  const res2 = await reg2.dailyScan();
+  assert.equal(res2.asked, null);
+  assert.equal(cards.calls.upserts.length, 1);
+});
+
+test("LLM fallback classifies an unknown identity at most once and merges it", async () => {
+  const cards = fakeCards();
+  const calls = [];
+  const runEphemeral = async (opts) => {
+    calls.push(opts);
+    return { text: "graphite\n(other text ignored)" };
+  };
+  const raw1 = { channel: "transcript", identity: null, detail: "cli:gt", ts: W0, source: "raw" };
+  const raw2 = { channel: "transcript", identity: null, detail: "cli:gt", ts: W0 + DAY, source: "raw" };
+  const { registry, registryStore } = makeRegistry({
+    cards,
+    usageRows: [raw1, raw2],
+    nowMs: W0 + 2 * DAY,
+    runEphemeral,
+  });
+  await registry.dailyScan();
+  assert.equal(calls.length, 1, "exactly one classification call");
+  assert.equal(calls[0].taskClass, "ambient-summarize");
+  const t = registryStore._state().tools.find((x) => x.tool === "graphite");
+  assert.ok(t, "the raw evidence merged into the classified identity");
+  assert.equal(t.uses, 2);
+  assert.equal(t.source, "llm");
+  assert.equal(t.raw, false);
+  assert.equal(registryStore._state().tools.some((x) => x.tool === "gt"), false);
+
+  // A second scan never re-asks (cached).
+  await registry.dailyScan();
+  assert.equal(calls.length, 1);
+});
+
+test("LLM fallback caches 'unknown' as unclassifiable and never re-asks", async () => {
+  const cards = fakeCards();
+  let calls = 0;
+  const runEphemeral = async () => {
+    calls += 1;
+    return { text: "unknown" };
+  };
+  const raw = (ts) => ({ channel: "transcript", identity: null, detail: "cli:junktool", ts, source: "raw" });
+  const { registry, registryStore } = makeRegistry({
+    cards,
+    usageRows: [raw(W0), raw(W0 + DAY)],
+    nowMs: W0 + 2 * DAY,
+    runEphemeral,
+  });
+  await registry.dailyScan();
+  assert.equal(calls, 1);
+  assert.equal(registryStore._state().tools.some((x) => x.tool === "junktool"), true);
+  await registry.dailyScan();
+  assert.equal(calls, 1, "unclassifiable is cached — never re-asked");
+});
+
+test("channel-1 secret rows (raw keys) fuse and give the tool the vitality path", async () => {
+  const cards = fakeCards();
+  const usageRows = [
+    { channel: "secret", identity: "github_pat", detail: "secret:GITHUB_PAT", ts: W0, source: "raw" },
+  ];
+  const { registry, registryStore } = makeRegistry({ cards, usageRows, nowMs: W0 + DAY });
+  await registry.dailyScan();
+  const t = registryStore._state().tools.find((x) => x.tool === "github_pat");
+  assert.ok(t);
+  assert.equal(t.raw, true);
+  assert.equal(hasCredential(t), true);
+  assert.equal(barCrossed(t), true);
+  assert.equal(t.status, "candidate"); // vitality path promotes at ONE use
+});
+
+test("consentFor reads the rings the future probe/tool-write gates will check", async () => {
+  const cards = fakeCards();
+  const mk = (ts) => ({ channel: "transcript", identity: "stripe", detail: "cli:stripe", ts, source: "catalog" });
+  const { registry } = makeRegistry({ cards, usageRows: [mk(W0), mk(W0 + 2 * DAY), mk(W0 + 8 * DAY)], nowMs: W0 + 9 * DAY });
+  await registry.dailyScan();
+  await registry.resolveConnect({ tool: "stripe", answer: "connect" });
+  assert.equal(await registry.consentFor("stripe", "metadata"), "yes");
+  assert.equal(await registry.consentFor("stripe", "deep_read"), null);
+  assert.equal(await registry.consentFor("nope"), null);
+});
+
+test("resolveConnect rejects bad input without touching the store", async () => {
+  const cards = fakeCards();
+  const { registry, registryStore } = makeRegistry({ cards, nowMs: W0 });
+  assert.equal((await registry.resolveConnect({})).ok, false);
+  assert.equal((await registry.resolveConnect({ tool: "x", answer: "maybe" })).ok, false);
+  assert.equal((await registry.resolveConnect({ tool: "ghost", answer: "connect" })).ok, false);
+  assert.deepEqual(registryStore._state().tools ?? [], []);
+  assert.equal(cards.calls.resolved.length, 0);
+});
+
+test("listTools returns the §10.5 view shape", async () => {
+  const cards = fakeCards();
+  const mk = (ts) => ({ channel: "transcript", identity: "vercel", detail: "cli:vercel", ts, source: "catalog" });
+  const { registry } = makeRegistry({ cards, usageRows: [mk(W0), mk(W0 + 2 * DAY), mk(W0 + 8 * DAY)], nowMs: W0 + 9 * DAY });
+  await registry.dailyScan();
+  const view = await registry.listTools();
+  assert.equal(view.length, 1);
+  const row = view[0];
+  for (const k of ["tool", "displayName", "status", "role", "uses", "weeksActive", "ewmaPerWeek", "lastSeenTs", "firstSeenTs", "consent", "askRound"]) {
+    assert.ok(k in row, k);
+  }
+  assert.equal(row.displayName, "Vercel");
+  assert.deepEqual(row.consent, { metadata: null, deep_read: null, write: null });
+});
+
+test("thresholds match the spec bars", () => {
+  assert.equal(ENGAGEMENT_MIN_USES, 3);
+  assert.equal(ENGAGEMENT_MIN_WEEKS, 2);
+  assert.equal(RAW_CLASSIFY_MIN_USES, 2);
+});

--- a/src/server/ctoToolRegistry.test.mjs
+++ b/src/server/ctoToolRegistry.test.mjs
@@ -61,6 +61,19 @@ function fakeLedger() {
   };
 }
 
+// A next-day scan over the SAME persisted registry store (fresh registry
+// instance, shared state) — the common shape of the lifecycle timing tests.
+function nextDay(registryStore, cards, dayMs, rows, overrides = {}) {
+  return createToolRegistry({
+    registryStore,
+    usageStore: memStore({ rows }),
+    cards,
+    ledger: fakeLedger(),
+    now: () => dayMs,
+    ...overrides,
+  });
+}
+
 function makeRegistry({ usageRows = [], cards = fakeCards(), runEphemeral = null, nowMs = W0, collectDb = null, collectSurfaces = null } = {}) {
   const registryStore = memStore();
   const usageStore = memStore({ rows: [...usageRows] });
@@ -140,11 +153,25 @@ test("EWMA decays toward zero with inactivity (single application)", () => {
   let tools = [];
   tools = fuseRow(tools, { channel: "transcript", identity: "x", detail: "cli:x", ts: W0 });
   tools = fuseRow(tools, { channel: "transcript", identity: "x", detail: "cli:x", ts: W0 + 1 * DAY });
-  const before = tools[0].ewmaPerWeek;
+  const before = tools[0].engagement.ewma_per_week;
   tools = fuseRow(tools, { channel: "transcript", identity: "x", detail: "cli:x", ts: W0 + 8 * DAY });
-  const after = tools[0].ewmaPerWeek;
+  const after = tools[0].engagement.ewma_per_week;
   assert.ok(after < before, "a week-old gap must decay the EWMA");
   assert.ok(after >= 1, "each use adds exactly 1 after decay");
+});
+
+test("fused rows carry the §7.2 schema axes verbatim (engagement nested, vitality present)", () => {
+  const tools = fuseRow([], { channel: "transcript", identity: "vercel", detail: "cli:vercel", ts: W0, project: "manta" });
+  const t = tools[0];
+  assert.deepEqual(
+    Object.keys(t).filter((k) => ["engagement", "vitality", "evidence", "consent", "status", "role", "relevance", "as_source", "as_workflow", "tool"].includes(k)).sort(),
+    ["as_source", "as_workflow", "consent", "engagement", "evidence", "relevance", "role", "status", "tool", "vitality"],
+  );
+  assert.equal(t.engagement.ewma_per_week, 1);
+  assert.equal(t.engagement.last_used, W0);
+  assert.deepEqual(t.engagement.per_project, { manta: 1 });
+  // Vitality is the §7.5 probes' axis — present but empty until they run.
+  assert.deepEqual(t.vitality, { last_event: null, inflow_rate: null, ewma: null, last_probed: null });
 });
 
 test("parseClassification accepts one kebab-case line, rejects junk", () => {
@@ -251,13 +278,7 @@ test("ask pacing: at most one NEW ask per day, and askRound < 3 forever", async 
   // Next day: the second tool asks (round 1 each) — vercel's ask card is
   // still open, so the gate skips it and picks stripe.
   const day2 = W0 + 10 * DAY;
-  const reg2 = createToolRegistry({
-    registryStore,
-    usageStore: memStore({ rows: [...usageRows, mk("vercel", day2), mk("stripe", day2)] }),
-    cards,
-    ledger: fakeLedger(),
-    now: () => day2,
-  });
+  const reg2 = nextDay(registryStore, cards, day2, [...usageRows, mk("vercel", day2), mk("stripe", day2)]);
   await reg2.dailyScan();
   assert.equal(cards.calls.upserts.length, 2);
   assert.equal(cards.calls.upserts[1].toolId, "stripe");
@@ -267,19 +288,13 @@ test("ask pacing: at most one NEW ask per day, and askRound < 3 forever", async 
   for (const t of state.tools) t.askRound = 3;
   await registryStore.save(state);
   const day3 = W0 + 11 * DAY;
-  const reg3 = createToolRegistry({
-    registryStore,
-    usageStore: memStore({ rows: [...usageRows, mk("vercel", day3), mk("stripe", day3)] }),
-    cards,
-    ledger: fakeLedger(),
-    now: () => day3,
-  });
+  const reg3 = nextDay(registryStore, cards, day3, [...usageRows, mk("vercel", day3), mk("stripe", day3)]);
   const res3 = await reg3.dailyScan();
   assert.equal(res3.asked, null);
   assert.equal(cards.calls.upserts.length, 2);
 });
 
-test("not-now declines with a 30-day re-arm; a fresh bar crossing re-arms early", async () => {
+test("not-now declines with a 30-day re-arm; a fresh bar crossing re-arms early — engagement path only", async () => {
   const cards = fakeCards();
   const mk = (ts) => ({ channel: "transcript", identity: "stripe", detail: "cli:stripe", ts, source: "catalog" });
   const usageRows = [mk(W0), mk(W0 + 2 * DAY), mk(W0 + 8 * DAY)];
@@ -292,25 +307,14 @@ test("not-now declines with a 30-day re-arm; a fresh bar crossing re-arms early"
 
   // Same day again → no new ask (reArmAt in the future, no fresh uses).
   const day2 = W0 + 10 * DAY;
-  const reg2 = createToolRegistry({
-    registryStore,
-    usageStore: memStore({ rows: [mk(day2)] }),
-    cards,
-    ledger: fakeLedger(),
-    now: () => day2,
-  });
+  const reg2 = nextDay(registryStore, cards, day2, [mk(day2)]);
   const res2 = await reg2.dailyScan();
   assert.equal(res2.asked, null);
 
-  // Fresh engagement (2+ uses beyond the ask-time snapshot) re-arms early.
+  // Fresh engagement (2+ uses beyond the ask-time snapshot) re-arms early —
+  // this tool crossed the ENGAGEMENT bar, so the fresh-crossing path applies.
   const day3 = W0 + 11 * DAY;
-  const reg3 = createToolRegistry({
-    registryStore,
-    usageStore: memStore({ rows: [mk(day3), mk(day3 + 1000)] }),
-    cards,
-    ledger: fakeLedger(),
-    now: () => day3,
-  });
+  const reg3 = nextDay(registryStore, cards, day3, [mk(day3), mk(day3 + 1000)]);
   const res3 = await reg3.dailyScan();
   assert.equal(res3.asked, "stripe");
   t = registryStore._state().tools.find((x) => x.tool === "stripe");
@@ -318,10 +322,50 @@ test("not-now declines with a 30-day re-arm; a fresh bar crossing re-arms early"
   assert.equal(t.askRound, 2);
 });
 
-test("never kills every ring and suppresses future asks", async () => {
+test("§7.4 carve-out: a credential-only tool declined 'not now' re-arms ONLY at the 30-day timer", async () => {
+  const cards = fakeCards();
+  const secret = (ts) => ({ channel: "secret", identity: "github_pat", detail: "secret:GITHUB_PAT", ts, source: "raw" });
+  const { registry, registryStore } = makeRegistry({ cards, usageRows: [secret(W0)], nowMs: W0 + DAY });
+  await registry.dailyScan();
+  await registry.resolveConnect({ tool: "github_pat", answer: "not-now" });
+  let t = registryStore._state().tools.find((x) => x.tool === "github_pat");
+  assert.equal(t.consent.metadata, "no");
+  assert.equal(t.reArmAt, W0 + DAY + 30 * DAY);
+  assert.equal(engagementBarMet(t), false, "the tool is vitality-path only");
+
+  // Fresh CLI uses arrive well inside the 30 days — the vitality path's bar
+  // (a credential exists) cannot re-cross, so NO early re-arm.
+  const day5 = W0 + 5 * DAY;
+  const reg2 = nextDay(registryStore, cards, day5, [secret(day5), secret(day5 + 1000), secret(day5 + 2000)]);
+  const res2 = await reg2.dailyScan();
+  assert.equal(res2.asked, null, "fresh uses must not re-arm a vitality-path decline");
+  t = registryStore._state().tools.find((x) => x.tool === "github_pat");
+  assert.equal(t.consent.metadata, "no");
+
+  // Only the 30-day timer re-arms.
+  const day32 = W0 + 32 * DAY;
+  const reg3 = createToolRegistry({
+    registryStore,
+    usageStore: memStore({ rows: [] }),
+    cards,
+    ledger: fakeLedger(),
+    now: () => day32,
+  });
+  const res3 = await reg3.dailyScan();
+  assert.equal(res3.asked, "github_pat");
+});
+
+// The aws fixture: a tool at the engagement bar (3 uses across 2 weeks),
+// scanned at day 9 — the common setup of the never/un-never lifecycle tests.
+function awsSetup() {
   const cards = fakeCards();
   const mk = (ts) => ({ channel: "transcript", identity: "aws", detail: "cli:aws", ts, source: "catalog" });
   const { registry, registryStore } = makeRegistry({ cards, usageRows: [mk(W0), mk(W0 + 2 * DAY), mk(W0 + 8 * DAY)], nowMs: W0 + 9 * DAY });
+  return { cards, mk, registry, registryStore };
+}
+
+test("never kills every ring and suppresses future asks", async () => {
+  const { cards, mk, registry, registryStore } = awsSetup();
   await registry.dailyScan();
   const res = await registry.resolveConnect({ tool: "aws", answer: "never" });
   assert.equal(res.ok, true);
@@ -330,16 +374,82 @@ test("never kills every ring and suppresses future asks", async () => {
 
   // Even with fresh evidence, never a new ask.
   const day2 = W0 + 40 * DAY;
-  const reg2 = createToolRegistry({
-    registryStore,
-    usageStore: memStore({ rows: [mk(day2), mk(day2 + 1000), mk(day2 + 2000)] }),
-    cards,
-    ledger: fakeLedger(),
-    now: () => day2,
-  });
+  const reg2 = nextDay(registryStore, cards, day2, [mk(day2), mk(day2 + 1000), mk(day2 + 2000)]);
   const res2 = await reg2.dailyScan();
   assert.equal(res2.asked, null);
   assert.equal(cards.calls.upserts.length, 1);
+});
+
+test("§7.4 un-never: returns the tool to observed; a fresh bar crossing is required before the next ask", async () => {
+  const { cards, mk, registry, registryStore } = awsSetup();
+  await registry.dailyScan();
+  await registry.resolveConnect({ tool: "aws", answer: "never" });
+
+  // Un-never (what B11's drill-down will call): back to observed, rings cleared.
+  const un = await registry.unNever("aws");
+  assert.equal(un.ok, true);
+  let t = registryStore._state().tools.find((x) => x.tool === "aws");
+  assert.deepEqual(t.consent, { metadata: null, deep_read: null, write: null });
+  assert.equal(t.status, "observed");
+  assert.equal(t.unneverAtUses, t.uses);
+
+  // The bar is still crossed (monotone uses) — but the next scan must NOT
+  // immediately re-promote + re-ask: no fresh crossing since the snapshot.
+  const day2 = W0 + 10 * DAY;
+  const reg2 = nextDay(registryStore, cards, day2, [mk(day2)]);
+  const res2 = await reg2.dailyScan();
+  assert.equal(res2.asked, null, "an un-never'd tool must not re-ask without a fresh bar crossing");
+  t = registryStore._state().tools.find((x) => x.tool === "aws");
+  assert.equal(t.status, "observed", "still observed — the fresh-crossing gate holds");
+
+  // Fresh engagement beyond the snapshot (2+ new uses) re-promotes → re-asks.
+  const day3 = W0 + 11 * DAY;
+  const reg3 = nextDay(registryStore, cards, day3, [mk(day3), mk(day3 + 1000)]);
+  const res3 = await reg3.dailyScan();
+  assert.equal(res3.asked, "aws");
+  t = registryStore._state().tools.find((x) => x.tool === "aws");
+  assert.equal(t.status, "candidate");
+  assert.equal(t.unneverAtUses, null);
+
+  // Un-nevering a tool that was never never'd is a clean error.
+  assert.equal((await registry.unNever("ghost")).ok, false);
+});
+
+test("a connect answer landing mid-scan is not lost (writers serialized)", async () => {
+  const cards = fakeCards();
+  const mk = (ts) => ({ channel: "transcript", identity: "vercel", detail: "cli:vercel", ts, source: "catalog" });
+  // One registry instance — the writer mutex is per-instance, matching
+  // production (the engine owns one registry). The db seam blocks on its
+  // SECOND call (the seconds-long await window where the stale-save clobber
+  // used to happen).
+  let blockSecond = null;
+  let releaseDb = () => {};
+  const { registry, registryStore } = makeRegistry({
+    cards,
+    usageRows: [mk(W0), mk(W0 + 2 * DAY), mk(W0 + 8 * DAY)],
+    nowMs: W0 + 9 * DAY,
+    collectDb: async () => {
+      if (blockSecond) await blockSecond;
+      return [];
+    },
+  });
+  await registry.dailyScan(); // scan 1: raises the ask (candidate)
+  await registry.resolveConnect({ tool: "vercel", answer: "connect" });
+
+  // Scan 2 starts and blocks inside its db batch.
+  blockSecond = new Promise((resolve) => (releaseDb = resolve));
+  const scanDone = registry.dailyScan();
+  await new Promise((r) => setTimeout(r, 25)); // let the scan reach the blocked await
+  // The user answers "never" DURING the scan. With serialized writers it
+  // queues behind the scan and its save lands LAST.
+  const answerDone = registry.resolveConnect({ tool: "vercel", answer: "never" });
+  releaseDb();
+  const [scanRes, answerRes] = await Promise.all([scanDone, answerDone]);
+  assert.equal(scanRes.ok, true);
+  assert.equal(answerRes.ok, true);
+  const t = registryStore._state().tools.find((x) => x.tool === "vercel");
+  assert.equal(t.consent.metadata, "never", "the mid-scan answer must survive the scan's save");
+  assert.deepEqual(t.consent, { metadata: "never", deep_read: "never", write: "never" });
 });
 
 test("LLM fallback classifies an unknown identity at most once and merges it", async () => {

--- a/src/server/ctoToolScan.mjs
+++ b/src/server/ctoToolScan.mjs
@@ -1,0 +1,280 @@
+// ctoToolScan.mjs — §7.1 evidence channels 2 + 3 (BET-1395).
+//
+// Channel 2 (deterministic transcript extractors): batched extraction over
+// opencode db `part` rows whose data parses to a tool-call — CLI invocations
+// (first token of bash command segments against the catalog), API domains in
+// network calls (curl/fetch URLs + webfetch input), and issue-key patterns in
+// branch names + commit subjects. Pure row→evidence functions are exported
+// for tests; the db query is a thin injected-handle call.
+//
+// Channel 3 (existing config reads): MCP servers in opencode config, forge
+// rules repos, inbound webhooks, git remotes, schedule targets — all passed
+// in already-read by the caller (the registry/engine owns I/O); the module
+// only reshapes them into evidence rows.
+//
+// An evidence row is what the §7.2 registry fuses:
+//   { channel, identity, detail, ts, sessionID?, project? }
+// `identity` is a canonical tool identity from the catalog, or null when the
+// evidence is raw (kept for the LLM fallback; never fused until classified).
+
+import {
+  matchCliIdentity,
+  matchDomainIdentity,
+  matchIssueKeys,
+} from "./ctoToolCatalog.mjs";
+
+export const CHANNEL_SECRET = "secret";
+export const CHANNEL_TRANSCRIPT = "transcript";
+export const CHANNEL_CONFIG = "config";
+
+// Cap on part rows scanned per batch — a runaway range can never wedge a tick.
+export const SCAN_ROW_CAP = 20_000;
+
+// ---------------------------------------------------------------------------
+// Channel 2 — transcript extractors
+// ---------------------------------------------------------------------------
+
+// Parse one opencode `part.data` JSON blob → { tool, input } when it is a
+// tool-call part, else null. Defensive: any malformed row yields null.
+export function parseToolPart(data) {
+  let p;
+  if (typeof data === "string") {
+    try {
+      p = JSON.parse(data);
+    } catch {
+      return null;
+    }
+  } else {
+    p = data;
+  }
+  if (!p || typeof p !== "object" || p.type !== "tool") return null;
+  const tool = typeof p.tool === "string" ? p.tool : "";
+  if (!tool) return null;
+  const state = p.state && typeof p.state === "object" ? p.state : {};
+  const input = state.input !== undefined ? state.input : null;
+  return { tool, input };
+}
+
+// Command-string → first tokens of each segment. A bash command is usually
+// one pipeline, but compounds (`a && b`, `a; b`, `a | b`, newlines) carry
+// several invocations — each segment's first token is the CLI that ran.
+const SEGMENT_SPLIT = /(?:&&|\|\||;|\||\n)+/;
+
+export function cliTokens(command) {
+  const text = String(command ?? "");
+  if (!text) return [];
+  const out = [];
+  for (const seg of text.split(SEGMENT_SPLIT)) {
+    const token = seg.trim().split(/\s+/)[0] ?? "";
+    const cleaned = token.replace(/^\$\(\)?/, "").replace(/^\-+/, "");
+    if (cleaned) out.push(cleaned);
+  }
+  return out;
+}
+
+// Free text → https URL hosts (deduped). Anything from curl/fetch/webfetch
+// command strings or tool inputs lands here.
+const URL_SHAPE = /https:\/\/[A-Za-z0-9._~-]+/g;
+
+export function extractUrlHosts(text) {
+  const t = String(text ?? "");
+  if (!t) return [];
+  const out = [];
+  const seen = new Set();
+  for (const m of t.matchAll(URL_SHAPE)) {
+    const host = m[0].slice("https://".length).toLowerCase().replace(/[.,;)\]]+$/, "");
+    if (!host || seen.has(host)) continue;
+    seen.add(host);
+    out.push(host);
+  }
+  return out;
+}
+
+// One tool-call part → evidence rows. `project` is resolved by the caller
+// (session-directory cache), may be null.
+export function extractFromToolPart({ data, ts, sessionID = null, project = null } = {}) {
+  const parsed = parseToolPart(data);
+  if (!parsed) return [];
+  const rows = [];
+  const base = { channel: CHANNEL_TRANSCRIPT, ts, sessionID, project };
+
+  if (parsed.tool === "bash" || parsed.tool === "terminal" || parsed.tool === "shell") {
+    const command =
+      typeof parsed.input === "string"
+        ? parsed.input
+        : parsed.input && typeof parsed.input.command === "string"
+          ? parsed.input.command
+          : "";
+    if (command) {
+      // CLI invocations: first token of each segment against the catalog.
+      for (const token of cliTokens(command)) {
+        const identity = matchCliIdentity(token);
+        if (identity === "local") continue;
+        rows.push({ ...base, identity, source: identity ? "catalog" : "raw", detail: `cli:${token}` });
+      }
+      // API domains in network calls: hosts of https URLs in the command.
+      for (const host of extractUrlHosts(command)) {
+        const identity = matchDomainIdentity(host);
+        if (identity === undefined) continue; // private/own — not evidence
+        rows.push({ ...base, identity, source: identity ? "catalog" : "raw", detail: `domain:${host}` });
+      }
+      // Issue-key patterns in branch names + commit subjects (both appear in
+      // the command string — `git checkout -b BET-123-x`, `git commit -m "…"`).
+      for (const key of matchIssueKeys(command)) {
+        rows.push({ ...base, identity: null, source: "raw", detail: `key:${key}` });
+      }
+    }
+  } else if (parsed.tool === "webfetch" || parsed.tool === "fetch" || parsed.tool === "web_fetch") {
+    const url = parsed.input && typeof parsed.input === "object" ? String(parsed.input.url ?? "") : "";
+    for (const host of extractUrlHosts(url)) {
+      const identity = matchDomainIdentity(host);
+      if (identity === undefined) continue;
+      rows.push({ ...base, identity, source: identity ? "catalog" : "raw", detail: `domain:${host}` });
+    }
+  }
+  return rows;
+}
+
+// The daily/db batch: opencode db rows → evidence rows. `rows` come from
+// collectDbRows (already filtered to the time range); each row is
+// { data, time_created, session_id }.
+export function extractFromDbRows(rows) {
+  const out = [];
+  for (const r of Array.isArray(rows) ? rows : []) {
+    const ts = Number(r?.time_created);
+    if (!Number.isFinite(ts) || ts <= 0) continue;
+    out.push(
+      ...extractFromToolPart({
+        data: r.data,
+        ts,
+        sessionID: typeof r.session_id === "string" ? r.session_id : null,
+      }),
+    );
+  }
+  return out;
+}
+
+// Query the read-only opencode db handle (the same one the backfill and
+// ⌘F search use). Returns part rows in the half-open (sinceTs, untilTs] range.
+export async function collectDbRows(db, { sinceTs, untilTs, cap = SCAN_ROW_CAP } = {}) {
+  if (!db || typeof db.prepare !== "function") return [];
+  try {
+    const stmt = db.prepare(
+      `SELECT p.session_id AS session_id, p.data AS data, p.time_created AS time_created
+       FROM part p
+       WHERE p.time_created > ? AND p.time_created <= ?
+       ORDER BY p.time_created ASC
+       LIMIT ?`,
+    );
+    return stmt.all(sinceTs, untilTs, cap) ?? [];
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Channel 3 — config surfaces (all inputs already-read by the caller; the
+// module only reshapes). Unknown shapes yield zero rows, never throws.
+// ---------------------------------------------------------------------------
+
+// opencode config → MCP server evidence. `mcp` is {name: {url?}|{command?}}
+// — remote servers have a URL (host catalog-matched); local ones are labeled
+// by name.
+export function extractMcpEvidence(config, { ts } = {}) {
+  const mcp = config && typeof config === "object" ? config.mcp : null;
+  if (!mcp || typeof mcp !== "object") return [];
+  const rows = [];
+  for (const [name, def] of Object.entries(mcp)) {
+    if (!def || typeof def !== "object") continue;
+    const base = { channel: CHANNEL_CONFIG, ts, detail: `mcp:${name}` };
+    const url = typeof def.url === "string" ? def.url : "";
+    if (url) {
+      for (const host of extractUrlHosts(url)) {
+        const identity = matchDomainIdentity(host);
+        if (identity === undefined) continue;
+        rows.push({ ...base, identity, source: identity ? "catalog" : "raw", detail: `mcp:${name}:${host}` });
+        break;
+      }
+    } else {
+      rows.push({ ...base, identity: null, source: "raw" });
+    }
+  }
+  return rows;
+}
+
+// Forge-rules repos (box-side `~/.manta/forge-rules/<host>/<owner>/<repo>.yaml`
+// stems) → evidence for the forge host itself.
+export function extractForgeEvidence(repoStems, { ts } = {}) {
+  const rows = [];
+  for (const stem of Array.isArray(repoStems) ? repoStems : []) {
+    if (typeof stem !== "string" || !stem) continue;
+    // stem shape: "<host>/<owner>/<repo>" — the host is the identity.
+    const host = stem.split("/")[0]?.toLowerCase() ?? "";
+    if (!host) continue;
+    const identity = matchDomainIdentity(host);
+    if (identity === undefined) continue;
+    rows.push({ channel: CHANNEL_CONFIG, identity, source: identity ? "catalog" : "raw", detail: `forge:${stem}`, ts });
+  }
+  return rows;
+}
+
+// Inbound webhooks (labels from the webhooks store) → raw evidence (labels
+// are user-named; the LLM fallback may classify, at most once).
+export function extractWebhookEvidence(hooks, { ts } = {}) {
+  const rows = [];
+  for (const h of Array.isArray(hooks) ? hooks : []) {
+    const label = typeof h?.label === "string" ? h.label.trim() : "";
+    if (!label) continue;
+    rows.push({ channel: CHANNEL_CONFIG, identity: null, source: "raw", detail: `webhook:${label}`, ts });
+  }
+  return rows;
+}
+
+// Git remotes per project ([{project, url}]) → domain evidence (e.g.
+// github.com → github).
+export function extractGitRemoteEvidence(remotes, { ts } = {}) {
+  const rows = [];
+  for (const r of Array.isArray(remotes) ? remotes : []) {
+    const url = typeof r?.url === "string" ? r.url : "";
+    const project = typeof r?.project === "string" ? r.project : null;
+    if (!url) continue;
+    const host = String(extractUrlHosts(url)[0] ?? url).toLowerCase();
+    // scp-ish git remotes: git@github.com:owner/repo.git
+    const scp = /^[\w.-]+@([\w.-]+):/.exec(url);
+    const hostname = scp ? scp[1].toLowerCase() : host;
+    const identity = matchDomainIdentity(hostname);
+    if (identity === undefined) continue;
+    rows.push({
+      channel: CHANNEL_CONFIG,
+      identity,
+      source: identity ? "catalog" : "raw",
+      detail: `git:${hostname}`,
+      ts,
+      project,
+    });
+  }
+  return rows;
+}
+
+// Schedule targets (labels from the schedule store) → raw evidence.
+export function extractScheduleEvidence(schedules, { ts } = {}) {
+  const rows = [];
+  for (const s of Array.isArray(schedules) ? schedules : []) {
+    const label = typeof s?.label === "string" ? s.label.trim() : "";
+    if (!label) continue;
+    rows.push({ channel: CHANNEL_CONFIG, identity: null, source: "raw", detail: `schedule:${label}`, ts });
+  }
+  return rows;
+}
+
+// The whole channel-3 batch from already-read surfaces. Unknown/missing
+// surfaces are skipped (undefined), never throwing.
+export function collectConfigEvidence(surfaces = {}, { ts } = {}) {
+  return [
+    ...extractMcpEvidence(surfaces.config, { ts }),
+    ...extractForgeEvidence(surfaces.forgeRepos, { ts }),
+    ...extractWebhookEvidence(surfaces.webhooks, { ts }),
+    ...extractGitRemoteEvidence(surfaces.gitRemotes, { ts }),
+    ...extractScheduleEvidence(surfaces.schedules, { ts }),
+  ];
+}

--- a/src/server/ctoToolScan.test.mjs
+++ b/src/server/ctoToolScan.test.mjs
@@ -1,6 +1,5 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { DatabaseSync } from "node:sqlite";
 import {
   parseToolPart,
   cliTokens,
@@ -139,8 +138,27 @@ test("extractFromDbRows maps part rows → evidence, skipping malformed rows", (
   );
 });
 
-test("collectDbRows queries the part table in the half-open window", async () => {
+// A memory-backed SQLite fixture (node:sqlite). Returns { db, close } or null
+// when node:sqlite is unavailable (degrade the db tests to skip) — same
+// pattern as ctoBackfill.test.mjs. CI's Node 20 lacks node:sqlite.
+async function openFixture() {
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import("node:sqlite"));
+  } catch {
+    return null;
+  }
   const db = new DatabaseSync(":memory:");
+  return { db, close: () => db.close() };
+}
+
+test("collectDbRows queries the part table in the half-open window", async () => {
+  const fx = await openFixture();
+  if (!fx) {
+    test.skip("node:sqlite unavailable on this runtime");
+    return;
+  }
+  const { db } = fx;
   db.exec(
     "CREATE TABLE part (id TEXT, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT)",
   );

--- a/src/server/ctoToolScan.test.mjs
+++ b/src/server/ctoToolScan.test.mjs
@@ -1,0 +1,217 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import {
+  parseToolPart,
+  cliTokens,
+  extractUrlHosts,
+  extractFromToolPart,
+  extractFromDbRows,
+  collectDbRows,
+  extractMcpEvidence,
+  extractForgeEvidence,
+  extractWebhookEvidence,
+  extractGitRemoteEvidence,
+  extractScheduleEvidence,
+  collectConfigEvidence,
+} from "./ctoToolScan.mjs";
+
+const TS = 1_700_000_000_000;
+
+function partData(tool, input) {
+  return JSON.stringify({ type: "tool", tool, callID: "c1", state: { status: "completed", input } });
+}
+
+// ---------------------------------------------------------------------------
+// parseToolPart / cliTokens / extractUrlHosts
+// ---------------------------------------------------------------------------
+
+test("parseToolPart reads a tool-call part and rejects other shapes", () => {
+  const p = parseToolPart(partData("bash", { command: "ls" }));
+  assert.equal(p.tool, "bash");
+  assert.deepEqual(p.input, { command: "ls" });
+  assert.equal(parseToolPart(JSON.stringify({ type: "text", text: "hi" })), null);
+  assert.equal(parseToolPart("not json"), null);
+  assert.equal(parseToolPart(null), null);
+});
+
+test("cliTokens takes the first token of every command segment", () => {
+  assert.deepEqual(cliTokens("git status"), ["git"]);
+  assert.deepEqual(cliTokens("cd /x && gh pr view 12 ; npm test | head"), ["cd", "gh", "npm", "head"]);
+  assert.deepEqual(cliTokens("echo one\necho two"), ["echo", "echo"]);
+  assert.deepEqual(cliTokens(""), []);
+});
+
+test("extractUrlHosts pulls https hosts, deduped, trimmed", () => {
+  assert.deepEqual(extractUrlHosts("curl https://api.github.com/repos and https://api.github.com/x"), [
+    "api.github.com",
+  ]);
+  assert.deepEqual(extractUrlHosts("see https://Example.COM./a"), ["example.com"]);
+  assert.deepEqual(extractUrlHosts("no urls"), []);
+});
+
+// ---------------------------------------------------------------------------
+// extractFromToolPart — the §7.1-2 transcript extractors
+// ---------------------------------------------------------------------------
+
+test("bash tool part → catalog CLI evidence, locals skipped, unknowns raw", () => {
+  const rows = extractFromToolPart({
+    data: partData("bash", { command: "git status && gh pr list && weird-cli deploy" }),
+    ts: TS,
+    sessionID: "s1",
+    project: "proj",
+  });
+  const cli = rows.filter((r) => r.detail.startsWith("cli:"));
+  // git → local (skipped); gh → catalog github; weird-cli → raw.
+  assert.deepEqual(
+    cli.map((r) => [r.identity, r.detail, r.source]),
+    [
+      ["github", "cli:gh", "catalog"],
+      [null, "cli:weird-cli", "raw"],
+    ],
+  );
+  assert.equal(cli[0].channel, "transcript");
+  assert.equal(cli[0].ts, TS);
+  assert.equal(cli[0].sessionID, "s1");
+  assert.equal(cli[0].project, "proj");
+});
+
+test("bash curl command → domain evidence; own-box and private hosts dropped", () => {
+  const rows = extractFromToolPart({
+    data: partData("bash", {
+      command: "curl -s https://api.github.com/x > /dev/null && curl https://internal.thing.io/y && curl http://169.254.1.1/z",
+    }),
+    ts: TS,
+  });
+  const domains = rows.filter((r) => r.detail.startsWith("domain:"));
+  assert.deepEqual(
+    domains.map((r) => [r.identity, r.detail]),
+    [["github", "domain:api.github.com"], [null, "domain:internal.thing.io"]],
+  );
+  // The bare-IP curl is https-less → no row; private hosts never match.
+  assert.equal(domains.some((r) => r.detail.includes("169.254")), false);
+});
+
+test("issue-key evidence from branch names + commit subjects is raw", () => {
+  const rows = extractFromToolPart({
+    data: partData("bash", { command: "git checkout -b multica/BET-1395-x && git commit -m 'BET-42: fix'" }),
+    ts: TS,
+  });
+  const keys = rows.filter((r) => r.detail.startsWith("key:"));
+  assert.deepEqual(
+    keys.map((r) => r.detail),
+    ["key:BET-1395", "key:BET-42"],
+  );
+  for (const k of keys) {
+    assert.equal(k.identity, null);
+    assert.equal(k.source, "raw");
+  }
+});
+
+test("webfetch tool part → domain evidence from input.url", () => {
+  const rows = extractFromToolPart({ data: partData("webfetch", { url: "https://linear.app/issue" }), ts: TS });
+  assert.deepEqual(rows.map((r) => [r.identity, r.detail]), [["linear", "domain:linear.app"]]);
+});
+
+test("non-tool parts and non-command tools produce no rows", () => {
+  assert.deepEqual(extractFromToolPart({ data: JSON.stringify({ type: "text", text: "x" }), ts: TS }), []);
+  assert.deepEqual(extractFromToolPart({ data: partData("read", { path: "/x" }), ts: TS }), []);
+});
+
+// ---------------------------------------------------------------------------
+// db batch
+// ---------------------------------------------------------------------------
+
+test("extractFromDbRows maps part rows → evidence, skipping malformed rows", () => {
+  const rows = extractFromDbRows([
+    { session_id: "s1", data: partData("bash", { command: "gh pr list" }), time_created: TS },
+    { session_id: "s2", data: "garbage{", time_created: TS + 1 },
+    { session_id: "s3", data: partData("bash", { command: "aws s3 ls" }), time_created: TS + 2 },
+    { session_id: "s4", data: partData("bash", { command: "vercel deploy" }), time_created: Number.NaN },
+    { session_id: "s5", data: null, time_created: TS + 3 },
+  ]);
+  assert.deepEqual(
+    rows.map((r) => [r.identity, r.detail, r.sessionID]),
+    [
+      ["github", "cli:gh", "s1"],
+      ["aws", "cli:aws", "s3"],
+    ],
+  );
+});
+
+test("collectDbRows queries the part table in the half-open window", async () => {
+  const db = new DatabaseSync(":memory:");
+  db.exec(
+    "CREATE TABLE part (id TEXT, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT)",
+  );
+  const ins = db.prepare(
+    "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?,?,?,?,?,?)",
+  );
+  ins.run("p1", "m1", "s1", 100, 100, partData("bash", { command: "gh pr list" }));
+  ins.run("p2", "m2", "s2", 200, 200, partData("bash", { command: "aws s3 ls" }));
+  ins.run("p3", "m3", "s3", 300, 300, partData("bash", { command: "vercel deploy" }));
+
+  const rows = await collectDbRows(db, { sinceTs: 100, untilTs: 299 });
+  assert.equal(rows.length, 1); // (100, 299] — p2 only
+  assert.equal(JSON.parse(rows[0].data).state.input.command, "aws s3 ls");
+
+  const all = await collectDbRows(db, { sinceTs: 0, untilTs: 1000 });
+  assert.equal(all.length, 3);
+
+  // A missing/handle-less db yields no rows, never a throw.
+  assert.deepEqual(await collectDbRows(null, { sinceTs: 0, untilTs: 10 }), []);
+  const bad = { prepare() { throw new Error("boom"); } };
+  assert.deepEqual(await collectDbRows(bad, { sinceTs: 0, untilTs: 10 }), []);
+});
+
+// ---------------------------------------------------------------------------
+// channel 3 — config surfaces
+// ---------------------------------------------------------------------------
+
+test("MCP config → catalog-matched remote + raw local evidence", () => {
+  const rows = extractMcpEvidence(
+    { mcp: { linear: { url: "https://mcp.linear.app/sse" }, files: { command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem"] } } },
+    { ts: TS },
+  );
+  assert.deepEqual(
+    rows.map((r) => [r.identity, r.detail, r.source]),
+    [["linear", "mcp:linear:mcp.linear.app", "catalog"], [null, "mcp:files", "raw"]],
+  );
+  assert.equal(rows[0].channel, "config");
+});
+
+test("forge rules / webhooks / git remotes / schedules → config evidence", () => {
+  const forge = extractForgeEvidence(["github.com/antoinedc/MantaUI"], { ts: TS });
+  assert.deepEqual(forge.map((r) => [r.identity, r.detail]), [["github", "forge:github.com/antoinedc/MantaUI"]]);
+
+  const hooks = extractWebhookEvidence([{ label: "multica BET-1395 done" }, { label: "" }], { ts: TS });
+  assert.deepEqual(hooks.map((r) => [r.identity, r.detail]), [[null, "webhook:multica BET-1395 done"]]);
+
+  const remotes = extractGitRemoteEvidence(
+    [{ project: "manta", url: "git@github.com:antoinedc/MantaUI.git" }, { project: "other", url: "https://gitlab.com/x/y.git" }],
+    { ts: TS },
+  );
+  assert.deepEqual(
+    remotes.map((r) => [r.identity, r.detail, r.project]),
+    [["github", "git:github.com", "manta"], ["gitlab", "git:gitlab.com", "other"]],
+  );
+
+  const scheds = extractScheduleEvidence([{ label: "deploy check" }], { ts: TS });
+  assert.deepEqual(scheds.map((r) => [r.identity, r.detail]), [[null, "schedule:deploy check"]]);
+});
+
+test("collectConfigEvidence gathers all surfaces and never throws", () => {
+  const rows = collectConfigEvidence(
+    {
+      config: { mcp: { linear: { url: "https://mcp.linear.app/sse" } } },
+      forgeRepos: ["github.com/o/r"],
+      webhooks: [{ label: "ci" }],
+      gitRemotes: [{ project: "p", url: "https://github.com/o/p.git" }],
+      schedules: [{ label: "nightly" }],
+    },
+    { ts: TS },
+  );
+  assert.equal(rows.length, 5);
+  assert.deepEqual(collectConfigEvidence(undefined, { ts: TS }), []);
+  assert.deepEqual(collectConfigEvidence({ config: null }, { ts: TS }), []);
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -161,7 +161,12 @@ import {
 } from "./media.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
 import { createPromptDelivery } from "./promptDelivery.mjs";
-import { ensureMantaPlanAgent, ensureCtoAgent, readCacheTtl as readProvidersCacheTtl } from "./providers.mjs";
+import {
+  ensureMantaPlanAgent,
+  ensureCtoAgent,
+  readCacheTtl as readProvidersCacheTtl,
+  readOpencodeConfig,
+} from "./providers.mjs";
 import {
   createWebhookEngine,
   createHook,
@@ -1963,6 +1968,33 @@ const adaptiveCtoOvernight = ctoOvernight.createOvernightScheduler({
   },
 });
 
+// BET-1395 (§7.1-3): one git remote per tmux project → [{project, url}].
+// Best-effort (a 5s timeout, non-git dirs skipped) — channel-3 evidence only.
+async function collectGitRemotes() {
+  let projects = [];
+  try {
+    projects = await tmux.listProjects();
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const p of Array.isArray(projects) ? projects : []) {
+    const cwd = typeof p?.cwd === "string" ? p.cwd : "";
+    const name = typeof p?.tmuxSession === "string" ? p.tmuxSession : null;
+    if (!cwd || !name) continue;
+    try {
+      const { stdout } = await promisify(execFile)("git", ["-C", cwd, "remote", "get-url", "origin"], {
+        timeout: 5000,
+      });
+      const url = String(stdout).trim();
+      if (url) out.push({ project: name, url });
+    } catch {
+      /* non-git or no origin — skip */
+    }
+  }
+  return out;
+}
+
 const adaptiveCto = ctoEngine.createCtoEngine({
   configGet: () => local.configGet(),
   ledger: ledgerStore,
@@ -2031,6 +2063,44 @@ const adaptiveCto = ctoEngine.createCtoEngine({
   // watches into the standing-query engine (idempotent, marker-guarded).
   legacyWatchesLoader: async () =>
     Array.isArray(cto.loadCtoStore()?.watches) ? cto.loadCtoStore().watches : [],
+  // BET-1395 tool discovery (§7). The LLM fallback classifier rides the
+  // §3.3 ephemeral rate gate exactly like the suggest engine's runners; the
+  // channel-3 surfaces are the already-read config shapes (mcp/forge/
+  // webhooks/git remotes/schedules) — each surface best-effort, failures
+  // yield empty, never a throw into the scan.
+  toolsRunEphemeral: async (opts) => {
+    const gate = await adaptiveCto.beginEphemeral();
+    if (!gate?.ok) return { ok: false, gated: true, error: gate?.error };
+    try {
+      return await runEphemeral({
+        ...opts,
+        deps: {
+          configGet: () => local.configGet(),
+          oc: { runEphemeralSession: oc.runSynchronousSession },
+        },
+      });
+    } finally {
+      gate.release?.();
+    }
+  },
+  toolsGetSurfaces: async () => {
+    const [config, rules, hooks, jobs, gitRemotes] = await Promise.all([
+      readOpencodeConfig().catch(() => ({})),
+      forgeListRules().catch(() => []),
+      listHooks(null).catch(() => []),
+      loadJobs().catch(() => []),
+      collectGitRemotes().catch(() => []),
+    ]);
+    return {
+      config: config ?? {},
+      forgeRepos: (Array.isArray(rules) ? rules : []).map((r) => r?.repoKey).filter(Boolean),
+      webhooks: Array.isArray(hooks) ? hooks : [],
+      schedules: (Array.isArray(jobs) ? jobs : [])
+        .map((j) => ({ label: j?.label ?? j?.name ?? "" }))
+        .filter((s) => s.label),
+      gitRemotes,
+    };
+  },
 });
 adaptiveCto.start();
 
@@ -4571,6 +4641,31 @@ const handleRequest = async (req, res) => {
           }
         }
         respondJson(res, result.ok ? 200 : 400, result);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Tool discovery (BET-1395, §7) ----------
+  // POST /api/cto/tools/connect {tool, answer} — the connect-ask three-way
+  // (§7.4): "connect" grants the metadata consent ring, "not-now" declines
+  // with a 30-day re-arm, "never" kills every ring for that tool. The
+  // registry writes the consent + the §9.5 verdict and resolves the open
+  // connect card. Invalid input → 400; never throws.
+  if (path === "/api/cto/tools/connect") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const result = await adaptiveCto.tools.resolveConnect({
+          tool: body?.tool,
+          answer: body?.answer,
+        });
+        if (result?.ok) void bus.publish({ kind: "ctoState" });
+        respondJson(res, result?.ok ? 200 : 400, result);
         return;
       }
       respondJson(res, 405, { error: "method not allowed" });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -2064,25 +2064,12 @@ const adaptiveCto = ctoEngine.createCtoEngine({
   legacyWatchesLoader: async () =>
     Array.isArray(cto.loadCtoStore()?.watches) ? cto.loadCtoStore().watches : [],
   // BET-1395 tool discovery (§7). The LLM fallback classifier rides the
-  // §3.3 ephemeral rate gate exactly like the suggest engine's runners; the
-  // channel-3 surfaces are the already-read config shapes (mcp/forge/
-  // webhooks/git remotes/schedules) — each surface best-effort, failures
-  // yield empty, never a throw into the scan.
-  toolsRunEphemeral: async (opts) => {
-    const gate = await adaptiveCto.beginEphemeral();
-    if (!gate?.ok) return { ok: false, gated: true, error: gate?.error };
-    try {
-      return await runEphemeral({
-        ...opts,
-        deps: {
-          configGet: () => local.configGet(),
-          oc: { runEphemeralSession: oc.runSynchronousSession },
-        },
-      });
-    } finally {
-      gate.release?.();
-    }
-  },
+  // §3.3 ephemeral rate gate through the SAME gated runner the suggest engine
+  // uses (one gate implementation); the channel-3 surfaces are the
+  // already-read config shapes (mcp/forge/webhooks/git remotes/schedules) —
+  // each surface best-effort, failures yield empty, never a throw into the
+  // scan.
+  toolsRunEphemeral: (opts) => gatedSuggestionEphemeral(opts?.taskClass ?? "ambient-summarize", opts),
   toolsGetSurfaces: async () => {
     const [config, rules, hooks, jobs, gitRemotes] = await Promise.all([
       readOpencodeConfig().catch(() => ({})),

--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -268,6 +268,13 @@ async function readRemoteConfig() {
   return parsed;
 }
 
+// BET-1395 (Adaptive CTO §7.1-3): the tool scan's config-surface seam reads
+// opencode.jsonc for MCP servers — same reader, exported so the scan doesn't
+// grow a second jsonc parser.
+export async function readOpencodeConfig() {
+  return readRemoteConfig();
+}
+
 /**
  * Read opencode.jsonc from the box and project it into the ProviderEndpoint[]
  * shape the Settings ProvidersCard form expects. This is the config-reading

--- a/src/server/secrets.mjs
+++ b/src/server/secrets.mjs
@@ -33,6 +33,7 @@ import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { statePath, secretsRoot } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { toolUsageStore } from "./ctoStores.mjs";
 
 const STORE_PATH = statePath("secrets.json");
 // Where `secret_provide` writes the materialized value files. Shared secrets go
@@ -254,9 +255,15 @@ export function listSecrets({ sessionID, project, includeAll = false } = {}, { l
 // ~/.manta-secrets/, and return { ok, path, key, hint }. The VALUE IS NEVER
 // RETURNED — only the path, so nothing secret reaches the transcript. The
 // caller (secret_provide tool) instructs the agent to use $(cat <path>).
+//
+// BET-1395 (Adaptive CTO §7.1 channel 1): every successful provide appends
+// `{channel:"secret", key, sessionID, project, ts}` to the CTO tool-usage
+// store (`~/.manta/cto/tool-usage.json`) — exact credential usage, zero
+// parsing, zero value exposure (the key NAME is not secret). Best-effort: a
+// ledger failure never blocks or breaks a provide.
 export async function provideSecret(
   { key, sessionID, project, dir = SECRETS_DIR },
-  { load = loadSecrets } = {},
+  { load = loadSecrets, recordUsage = recordSecretUsage } = {},
 ) {
   if (!isValidKey(key)) {
     return { ok: false, error: `Invalid key "${key}".` };
@@ -272,5 +279,30 @@ export async function provideSecret(
   await chmod(dir, 0o700).catch(() => {});
   await writeFile(path, entry.value, { mode: 0o600 });
   await chmod(path, 0o600).catch(() => {});
+  if (typeof recordUsage === "function") {
+    await recordUsage({ key: entry.key, sessionID: sessionID ?? null, project: project ?? null }).catch(() => {});
+  }
   return { ok: true, path, key: entry.key, hint: entry.hint ?? "" };
+}
+
+// The §7.1 channel-1 writer: append one usage row to the A1 tool-usage store
+// (ctoStores' toolUsageStore — the same store the daily tool scan fuses from).
+// Injected as the default `recordUsage` dep so tests can swap it.
+export async function recordSecretUsage({ key, sessionID, project, ts = Date.now() } = {}) {
+  try {
+    const payload = (await toolUsageStore.load()) ?? {};
+    const rows = Array.isArray(payload.rows) ? payload.rows : [];
+    rows.push({
+      channel: "secret",
+      identity: typeof key === "string" ? key.toLowerCase() : null,
+      source: "raw",
+      detail: `secret:${key}`,
+      ts,
+      sessionID: sessionID ?? null,
+      project: project ?? null,
+    });
+    await toolUsageStore.save({ ...payload, rows: rows.slice(-4000) });
+  } catch {
+    /* best-effort — usage bookkeeping never breaks a provide */
+  }
 }

--- a/src/server/secrets.test.mjs
+++ b/src/server/secrets.test.mjs
@@ -15,6 +15,7 @@ import {
   deleteSecret,
   listSecrets,
   provideSecret,
+  recordSecretUsage,
 } from "./secrets.mjs";
 
 // ----------------------------------------------------------------------------
@@ -371,6 +372,49 @@ test("provideSecret fails for a key not visible to the session", async () => {
   const r = await provideSecret({ key: "OTHER", sessionID: "ses_1", dir }, { load });
   assert.equal(r.ok, false);
   await rm(dir, { recursive: true, force: true });
+});
+
+// BET-1395 (Adaptive CTO §7.1 channel 1): every successful provide appends a
+// {channel:"secret", key, sessionID, project, ts} row to the tool-usage
+// store — exact usage, zero parsing, zero value exposure. Best-effort: a
+// failing usage writer never breaks or blocks the provide.
+test("provideSecret records usage on the tool-usage ledger (channel 1)", async () => {
+  const { dir } = await tmpStore();
+  const store = [
+    { id: "1", key: "STRIPE_KEY", value: "sk_live_x", scope: "shared", sessionID: null, hint: "" },
+  ];
+  const load = () => store;
+  const recorded = [];
+  const recordUsage = async (input) => {
+    recorded.push(input);
+  };
+
+  const r = await provideSecret({ key: "STRIPE_KEY", sessionID: "ses_1", project: "manta", dir }, { load, recordUsage });
+  assert.equal(r.ok, true);
+  assert.deepEqual(recorded, [{ key: "STRIPE_KEY", sessionID: "ses_1", project: "manta" }]);
+
+  // The value never reaches the usage row (the writer decides what to store;
+  // the provide hands over only non-secret fields).
+  const r2 = await provideSecret({ key: "STRIPE_KEY", sessionID: "ses_2", dir }, { load, recordUsage: async () => { throw new Error("ledger down"); } });
+  assert.equal(r2.ok, true, "a failing usage writer must not break the provide");
+  assert.equal(recorded.length, 1);
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("recordSecretUsage appends to the A1 tool-usage store (never the value)", async () => {
+  const { toolUsageStore } = await import("./ctoStores.mjs");
+  await recordSecretUsage({ key: "GITHUB_PAT", sessionID: "ses_a", project: "p", ts: 123 });
+  await recordSecretUsage({ key: "has space?", sessionID: null, project: null, ts: 124 });
+  const payload = await toolUsageStore.load();
+  const rows = (payload?.rows ?? []).slice(-2);
+  assert.deepEqual(
+    rows.map((r) => [r.channel, r.identity, r.detail, r.ts, r.project]),
+    [
+      ["secret", "github_pat", "secret:GITHUB_PAT", 123, "p"],
+      ["secret", "has space?", "secret:has space?", 124, null],
+    ],
+  );
+  for (const r of rows) assert.equal(r.value, undefined, "the secret value must never be recorded");
 });
 
 // --- tiny file-backed helpers for the round-trip tests above ---

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1290,6 +1290,14 @@ export interface Api {
     id?: string;
     ids?: string[];
   }): Promise<{ ok: boolean; error?: string; task?: CtoTonightTask; pinned?: string[] }>;
+  // POST /api/cto/tools/connect — BET-1395 (§7.4): the connect-ask three-way.
+  // "connect" grants the tool's metadata consent ring (read-only), "not-now"
+  // declines with a 30-day re-arm, "never" suppresses every ring for the
+  // tool. Also closes the open connect card + writes the §9.5 verdict.
+  ctoToolConnect(input: {
+    tool: string;
+    answer: "connect" | "not-now" | "never";
+  }): Promise<{ ok: boolean; error?: string; tool?: string; answer?: string }>;
 }
 
 /**


### PR DESCRIPTION
## BET-1395 — Tool discovery: evidence channels, registry, connect asks (Adaptive CTO §7)

Closes the §7 deliverable: the CTO discovers the user's external tools from four evidence channels, fuses them into one row per identity, and asks ONCE — in plain language, with a read-only default — before any tool access. No tool list ships with the system; discovery is generic by construction.

**Base:** origin/main @ `ece348b0`

### What ships

| Deliverable (issue) | Where |
|---|---|
| c) Channel 1 — credential ledger | `secrets.mjs` — every `provideSecret` appends `{channel:"secret", key, sessionID, project, ts}` to the A1 `tool-usage.json` store. Zero parsing, zero value exposure; best-effort (a ledger failure never blocks a provide). |
| a) Channel 2 — transcript extractors | `ctoToolScan.mjs` — daily batch over opencode db tool-call parts: CLI names (first token per bash segment against the catalog), API domains (curl/fetch/webfetch hosts), issue-key patterns (`[A-Z]{2,6}-\d+` over branch names + commit subjects). Pure row→evidence functions; db seam injected. |
| b) Channel 3 — config surfaces | `ctoToolScan.mjs` — MCP servers (opencode.jsonc), forge-rules repos, inbound webhooks, git remotes per project, schedule targets — all already-read shapes passed in; the module only reshapes. |
| Channel 4 — LLM fallback | `ctoToolRegistry.mjs` — classifies an unrecognized identity AT MOST ONCE (`ambient-summarize` class through the §3.3 ephemeral rate gate, wired in `index.mjs`); the judgment is cached in the registry entry and never re-asked. Junk singletons (uses < 2) are never classified. |
| d) Registry + fusion | `ctoToolRegistry.mjs` — one identity one row; EWMA engagement (τ = 1 week, lazily decayed via an `ewmaAt` watermark); the two §7.4 bars (engagement ≥3 uses across ≥2 weeks; vitality = credential exists); near-duplicate suppression (subdomain of a known identity folds in; git remotes are host-granularity so slug-covered hosts never become rows); `askRound < 3`; ≤1 new ask/day (durable `lastAskDay`). |
| Daily scan + lifecycle | `ctoEngine.mjs` — `toolsTick()` inside the tick's enabled gate, once per UTC day, restart-safe (registry watermarks); the first scan after install runs over the cold-start backfill range (`backfillStartInstant` from engine state). |
| Connect-ask card | `ctoCards.mjs` — `upsertConnect`/`resolveConnectCards` (§10.3 connect variant, three bound `tool-connect` answers, upsert by tool id, ledger rows). |
| Connect card UI | `ctoSections.tsx` `ConnectSection` + `CtoPanel.tsx` — tool name, why (usage evidence + credential presence), three-way answer (Connect read-only / Not now / Never), evidence expander; §10.7 tokens. |
| Consent + verdict plumbing | `POST /api/cto/tools/connect` → `registry.resolveConnect` — writes the §7.2 consent ring (`metadata`/`deep_read`/`write`), the §9.5 verdict (connect→accept, not-now→dismiss, never→never), and closes the open card. "Not now" re-arms after 30 days or a fresh bar crossing. |

### Design notes
- **The catalog labels; it never assumes presence** (§7 intro): an entry in `ctoToolCatalog.mjs` creates no registry row — only observed evidence does. Raw evidence (unknown CLIs/hosts/keys) becomes a raw entry keyed by the token itself, which is what the one-shot LLM classification resolves; webhook/schedule labels are free text and stay log-only.
- **Status enum**: `observed` → `candidate` (bars) → ask. This PR stops at the metadata consent ring; `integrated` requires probes (§7.5, separate issue) — deliberately not claimed here.
- **Anti-spaghetti**: reused A1's card machinery, jsonStore, ledger, verdict engine and rate gate; the only new exported reader is `providers.readOpencodeConfig` (same jsonc parser, no second one).

### Verification results
- PR branch (`multica/BET-1395-tool-discovery` @ `75c066d8`):
  - typecheck: exit 0, no errors. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - vitest: 198 files, 3851 pass / 0 fail (7 skipped). log sha256: `fb1de34b5e5b22264c9b84bdc7cc55d4ba2619d543bdde69e1657381368e74c6`
  - node:test: 2454 pass / 0 fail (45 of these are the new BET-1395 tests). log sha256: `bf09252619564cdc0bd87894c3820f3e36f44db4138ca9edb76fbe3f460778f2`
- Base (`main` @ `ece348b0`):
  - typecheck: exit 0, no errors. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - vitest: 198 files, 3851 pass / 0 fail (7 skipped). log sha256: `57e908ed633935bdd23c0c71c5939b35f27d43f9005bada135c579eb184d000e`
  - node:test: 2409 pass / 0 fail
- **Conclusion:** 0 new failures, 0 pre-existing failures; the +45 node tests are this PR's own.
