### PR TITLE
refactor(server): one shared running-CTO-row predicate for act cap + engine counts (BET-1427)

### DIFF
--- a/src/server/ctoAct.mjs
+++ b/src/server/ctoAct.mjs
@@ -34,7 +34,7 @@
 //
 // Pure over injected I/O — testable without a live tmux/opencode/delegate.
 
-import { ACTOR, RATE_LIMITS } from "./ctoEngine.mjs";
+import { ACTOR, RATE_LIMITS, isRunningCtoRow } from "./ctoEngine.mjs";
 import { resolveForgeOwner } from "./delegate.mjs";
 
 // ---------------------------------------------------------------------------
@@ -172,14 +172,15 @@ export function createCtoActExecutor(deps = {}) {
       const p = normalizeStartJobPayload(payload);
       if (!p) return { ok: false, reason: "incomplete-payload" };
       // §3.3 concurrent delegate sub-cap: count RUNNING cto-actor rows — the
-      // persistent source the overnight dispatch counts too. The gate's
-      // transient tracker only spans the start call itself, so the running
-      // rows are the real concurrency bound; the gate below still supplies
-      // the kill switch / pause checks + the cto.delegate_begin ledger row.
+      // shared isRunningCtoRow definition the overnight dispatch counts too
+      // (BET-1427). The gate's transient tracker only spans the start call
+      // itself, so the running rows are the real concurrency bound; the gate
+      // below still supplies the kill switch / pause checks + the
+      // cto.delegate_begin ledger row.
       let running = 0;
       try {
         const jobs = await listDelegateJobs();
-        running = (Array.isArray(jobs) ? jobs : []).filter((j) => j?.actor === ACTOR && j?.status === "running").length;
+        running = (Array.isArray(jobs) ? jobs : []).filter(isRunningCtoRow).length;
       } catch {
         running = 0;
       }

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -122,6 +122,14 @@ import { resolveForgeOwner } from "./delegate.mjs";
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
 
+// The single definition of a "running CTO job row" (BET-1427): the persisted
+// delegate-job rows the §3.3 concurrent cap (act path) and the overnight
+// dispatch / preemption counts (engine path) must agree on. If the definition
+// of "running" ever changes (new status, grace window), change it HERE only.
+export function isRunningCtoRow(row) {
+  return row?.actor === ACTOR && row?.status === "running";
+}
+
 // Rate limits (spec §3.3): exceed any one and the engine pauses itself and
 // raises a health warning (§10.6-7).
 export const RATE_LIMITS = Object.freeze({
@@ -1225,7 +1233,7 @@ export function createCtoEngine(deps = {}) {
     if (typeof listDelegateJobs !== "function") return [];
     try {
       const jobs = await listDelegateJobs();
-      return (Array.isArray(jobs) ? jobs : []).filter((j) => j?.actor === "cto" && j?.status === "running");
+      return (Array.isArray(jobs) ? jobs : []).filter(isRunningCtoRow);
     } catch {
       return [];
     }

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -9,6 +9,7 @@ import {
   DOT,
   HOUR_MS,
   RATE_LIMITS,
+  isRunningCtoRow,
   buildFactsContext,
 } from "./ctoEngine.mjs";
 import { createSegmenter } from "./ctoSegments.mjs";
@@ -799,4 +800,16 @@ test("drainInbox folds unread notes into high-salience B1-weighted evidence and 
   assert.ok(Math.abs(rowB.senderReliability - 1 / 2) < 1e-9, "neutral sender weighted 1/2");
   // No evidence for the already-read entry.
   assert.ok(!rows.some((row) => row.message === "already seen"));
+});
+
+test("isRunningCtoRow: single shared definition of a running CTO job row (BET-1427)", () => {
+  assert.equal(isRunningCtoRow({ actor: "cto", status: "running" }), true);
+  assert.equal(isRunningCtoRow({ actor: "cto", status: "paused" }), false);
+  assert.equal(isRunningCtoRow({ actor: "cto", status: "done" }), false);
+  assert.equal(isRunningCtoRow({ actor: "user", status: "running" }), false);
+  assert.equal(isRunningCtoRow({ status: "running" }), false);
+  assert.equal(isRunningCtoRow({ actor: "cto" }), false);
+  assert.equal(isRunningCtoRow(null), false);
+  assert.equal(isRunningCtoRow(undefined), false);
+  assert.equal(isRunningCtoRow("cto/running"), false);
 });


### PR DESCRIPTION
Closes BET-1427 (follow-up from PR #1413 review, nit 1).

## What

One shared definition of a "running CTO job row":

- `src/server/ctoEngine.mjs` — exports a pure predicate `isRunningCtoRow(row)` (next to `ACTOR`, which the act path already imports).
- `runningCtoJobs()` (engine overnight-dispatch / preemption counts) now filters with it.
- `src/server/ctoAct.mjs` start-job §3.3 concurrent cap replaces its inline copy with the same predicate.

If the definition of "running" ever changes (new status, grace window), there is now exactly one place to change it, so the act-path cap and the overnight-dispatch count cannot silently diverge.

## Scope discipline

- No behavior change in either path. No cap/race-semantics changes (narrow count→start race remains as accepted in PR #1413 nit 2).
- Duplicate-site audit: grepped `src/` for other `actor === "cto" && status === "running"` filters — only the two named sites existed; both now route through the predicate. No third site.
- Kept the act path's injected-I/O design: the predicate is pure, `listDelegateJobs` stays injected.
- Added a characterization test pinning the shared definition (ctoEngine.test.mjs) so the duplication can't silently regress.

## Verification results

- typecheck: exit 0, no errors. (`tsc --noEmit` node + web configs)
- test: vitest 3851 passed / 7 skipped (198 files); node:test 3506 passed / 0 failed (base `main`: 3505 passed / 0 failed — the +1 is the new predicate test). 0 failures on either side; nothing new, nothing resolved.

Base: origin/main @ e922febc
