### PR TITLE
BET-1428: watcher candidates carry the hit's project; overnight skip rows deduped per window

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1211,6 +1211,10 @@ export function createCtoEngine(deps = {}) {
         id: hit.id,
         name: hit.text,
         category: "watcher",
+        // BET-1428: the project whose evidence produced the hit — without it
+        // the §11.5 dispatch can never host the job and re-skips the hit on
+        // every tick of the open window.
+        project: typeof hit.project === "string" ? hit.project : undefined,
         value: 2,
         confidence: 0.8,
         predictedCost: 1,
@@ -1269,15 +1273,25 @@ export function createCtoEngine(deps = {}) {
   // the entry queued for the next tick/night. Candidates whose job already
   // started in this window are skipped (the ledger's job_started rows are the
   // dedupe record — a watcher hit stays in the ledger and would otherwise
-  // re-run every tick of the same window). Each job_started row carries
-  // `estTokens` (the prompt-size estimate, §12.1 metering style) so the
-  // windowless night-cap bound can price tonight's spend from the ledger.
+  // re-run every tick of the same window). BET-1428: the same ledger records
+  // the skip dedupe — a candidate whose dispatch already logged a skip row in
+  // this window re-runs silently (a freed cap or a newly opened project
+  // session can still start it), it just stops re-writing the row. Each
+  // job_started row carries `estTokens` (the prompt-size estimate, §12.1
+  // metering style) so the windowless night-cap bound can price tonight's
+  // spend from the ledger.
   async function dispatchPlan({ plan, trough, projects, ledgerRows, windowOpenedMs }) {
     let started = 0;
+    const inWindow = (r) =>
+      typeof r?.ts === "number" && (windowOpenedMs == null ? true : r.ts >= windowOpenedMs);
     const startedIds = new Set(
       (Array.isArray(ledgerRows) ? ledgerRows : [])
-        .filter((r) => r?.kind === "cto.overnight.job_started" && typeof r?.ts === "number")
-        .filter((r) => (windowOpenedMs == null ? true : r.ts >= windowOpenedMs))
+        .filter((r) => r?.kind === "cto.overnight.job_started" && inWindow(r))
+        .map((r) => r.id),
+    );
+    const skippedIds = new Set(
+      (Array.isArray(ledgerRows) ? ledgerRows : [])
+        .filter((r) => r?.kind === "cto.overnight.skip" && inWindow(r))
         .map((r) => r.id),
     );
     const runningCto = (await runningCtoJobs()).length;
@@ -1287,12 +1301,17 @@ export function createCtoEngine(deps = {}) {
         if (!cand || typeof cand.id !== "string" || startedIds.has(cand.id)) continue;
         if (typeof startDelegateJob !== "function") break;
         if (runningCto + startedThisDispatch >= rateLimits.concurrentDelegate) {
-          await ledgerLog({
-            kind: "cto.overnight.skip",
-            id: cand.id,
-            reason: "rate_limit:concurrentDelegate",
-            running: runningCto + startedThisDispatch,
-          });
+          // BET-1428: one skip row per candidate per window — the retry stays
+          // live (a freed slot starts it on a later tick), only the repeated
+          // row is suppressed.
+          if (!skippedIds.has(cand.id)) {
+            await ledgerLog({
+              kind: "cto.overnight.skip",
+              id: cand.id,
+              reason: "rate_limit:concurrentDelegate",
+              running: runningCto + startedThisDispatch,
+            });
+          }
           continue;
         }
         const task = (await tonightQueueRows()).find((r) => r?.id === cand.id) ?? null;
@@ -1330,12 +1349,19 @@ export function createCtoEngine(deps = {}) {
               `Tonight task "${task.name ?? cand.id}" was removed — no tracked project session could host it.`,
             );
           } else {
-            await ledgerLog({
-              kind: "cto.overnight.skip",
-              id: cand.id,
-              reason: "no tracked project session to host the job",
-              project,
-            });
+            // BET-1428: a candidate with no queue row to remove (a watcher
+            // hit) or no readable project list stays in play, but its skip row
+            // is written once per window, not once per tick — the retry stays
+            // live (a project session opened mid-window starts it), only the
+            // repeated row is suppressed.
+            if (!skippedIds.has(cand.id)) {
+              await ledgerLog({
+                kind: "cto.overnight.skip",
+                id: cand.id,
+                reason: "no tracked project session to host the job",
+                project,
+              });
+            }
           }
           continue;
         }
@@ -1351,7 +1377,11 @@ export function createCtoEngine(deps = {}) {
           sweepAllowanceMs: trough ? Math.max(0, trough.endMs - now()) : undefined,
         });
         if (res?.ok === false) {
-          await ledgerLog({ kind: "cto.overnight.skip", id: cand.id, reason: res.error ?? "delegate start refused", project });
+          // BET-1428: same per-window dedupe — the refusal is retried on the
+          // next tick, only the repeated row is suppressed.
+          if (!skippedIds.has(cand.id)) {
+            await ledgerLog({ kind: "cto.overnight.skip", id: cand.id, reason: res.error ?? "delegate start refused", project });
+          }
           continue;
         }
         started += 1;

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -251,6 +251,131 @@ test("overnight: a queue entry with no tracked project session is removed on the
   );
 });
 
+// A watcher hit ledger row as the standing-query engine writes it (the
+// BET-1428 shape carries the hosting project; older rows don't).
+function watcherHitRow(overrides = {}) {
+  return {
+    kind: "watcher.hit",
+    salience: "high",
+    watcherId: "w1",
+    predicateKind: "event-pattern",
+    text: "P0 cluster in the deploy logs",
+    refs: [],
+    ts: 0,
+    ...overrides,
+  };
+}
+
+test("overnight: a watcher hit with a tracked project hosts the investigation there and runs once per window (BET-1428)", async () => {
+  const h = makeHarness({ trough: TROUGH, projects: [PROJECT_ROW] });
+  h.ledgerRows.push(watcherHitRow({ ts: h.now() - 60_000, project: "/repo" }));
+  await h.engine.tick();
+
+  assert.equal(h.startedJobs.length, 1, "the watcher-driven investigation starts");
+  assert.equal(h.startedJobs[0].parentSessionID, "sess-1", "hosted in the project that produced the hit");
+  assert.equal(h.startedJobs[0].parentDirectory, "/repo");
+  assert.match(h.startedJobs[0].prompt, /P0 cluster/, "the hit text becomes the investigation prompt");
+  const startedRow = h.ledgerRows.find((r) => r.kind === "cto.overnight.job_started" && r.id === "wh:w1");
+  assert.ok(startedRow, "the job_started row is keyed by the watcher-hit id");
+  assert.equal(startedRow.project, "/repo");
+  assert.equal(startedRow.category, "watcher");
+
+  // The hit stays in the trailing-24h ledger — the startedIds dedupe keeps
+  // the next tick of the open window from re-running it.
+  h.advance(60 * 1000);
+  await h.engine.tick();
+  assert.equal(h.startedJobs.length, 1, "no re-run on the next tick");
+  assert.equal(
+    h.ledgerRows.filter((r) => r.kind === "cto.overnight.job_started" && r.id === "wh:w1").length,
+    1,
+  );
+});
+
+test("overnight: a watcher hit with no hostable project skips ONCE per window, not per tick (BET-1428)", async () => {
+  const h = makeHarness({ trough: TROUGH, projects: [PROJECT_ROW] });
+  h.ledgerRows.push(watcherHitRow({ watcherId: "w2", ts: h.now() - 60_000 }));
+  await h.engine.tick();
+  assert.equal(h.startedJobs.length, 0);
+  assert.equal(
+    h.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.id === "wh:w2").length,
+    1,
+    "one skip row for the unhostable hit",
+  );
+
+  // The hit remains a candidate for the whole 24h collection window; the
+  // per-window skip dedupe keeps the ledger quiet while the retry stays live.
+  h.advance(60 * 1000);
+  await h.engine.tick();
+  h.advance(60 * 1000);
+  await h.engine.tick();
+  assert.equal(
+    h.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.id === "wh:w2").length,
+    1,
+    "still one skip row after two more ticks",
+  );
+  assert.equal(h.startedJobs.length, 0);
+});
+
+test("overnight: a hit whose project no longer resolves skips once per window, and a mid-window session opens the retry (BET-1428)", async () => {
+  const h = makeHarness({ trough: TROUGH, projects: [PROJECT_ROW] });
+  h.ledgerRows.push(watcherHitRow({ watcherId: "w3", ts: h.now() - 60_000, project: "/gone" }));
+  await h.engine.tick();
+  assert.equal(h.startedJobs.length, 0);
+  assert.equal(
+    h.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.id === "wh:w3").length,
+    1,
+  );
+  h.advance(60 * 1000);
+  await h.engine.tick();
+  assert.equal(
+    h.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.id === "wh:w3").length,
+    1,
+    "no repeated row while /gone stays untracked",
+  );
+
+  // A project session for /gone opens → the retry starts it; the dedupe
+  // suppressed rows, never the candidate.
+  const grown = makeHarness({ trough: TROUGH, projects: [PROJECT_ROW, { tmuxSession: "s2", defaultCwd: "/gone", windows: [{ opencodeSessionId: "sess-2" }] }] });
+  grown.ledgerRows.push(watcherHitRow({ watcherId: "w3", ts: grown.now() - 60_000, project: "/gone" }));
+  await grown.engine.tick();
+  assert.equal(grown.startedJobs.length, 1, "the retry runs once the project resolves");
+  assert.equal(grown.startedJobs[0].parentDirectory, "/gone");
+});
+
+test("overnight: cap-blocked candidates re-skip silently — one row per candidate per window, retries stay live (BET-1428)", async () => {
+  const tasks = [];
+  for (let i = 0; i < 4; i++) tasks.push({ ...QUEUE_TASK, id: `tq:${i}`, project: `/repo${i}` });
+  const projects = tasks.map((t, i) => ({
+    tmuxSession: `s${i}`,
+    defaultCwd: `/repo${i}`,
+    windows: [{ opencodeSessionId: `sess-${i}` }],
+  }));
+  const h = makeHarness({ trough: TROUGH, queue: tasks, projects, budgetPlan: { spendableFrac: 4 } });
+  h.listedJobs.push({ id: "r1", actor: "cto", status: "running" }, { id: "r2", actor: "cto", status: "running" });
+  await h.engine.tick();
+  assert.equal(h.startedJobs.length, 0, "the sub-cap of 2 is already full");
+  assert.equal(
+    h.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.reason === "rate_limit:concurrentDelegate").length,
+    4,
+    "one cap-skip row per candidate",
+  );
+
+  h.advance(60 * 1000);
+  await h.engine.tick();
+  assert.equal(
+    h.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.reason === "rate_limit:concurrentDelegate").length,
+    4,
+    "retries are silent while the cap stays full",
+  );
+
+  // A freed slot starts the retried candidate — the dedupe suppressed rows,
+  // never the retry.
+  h.listedJobs.length = 0;
+  h.advance(60 * 1000);
+  await h.engine.tick();
+  assert.equal(h.startedJobs.length, 2, "a freed sub-cap slot starts candidates on a later tick");
+});
+
 test("overnight: dispatch enforces the §3.3 concurrent sub-cap (2) by counting running cto jobs + accepted starts", async () => {
   const tasks = [];
   for (let i = 0; i < 5; i++) {

--- a/src/server/ctoWatchers.mjs
+++ b/src/server/ctoWatchers.mjs
@@ -419,6 +419,11 @@ export function watcherHitPayload(watch, event = {}, { now = Date.now } = {}) {
         ? event.text.slice(0, 512)
         : `Watcher ${watch?.id} matched`,
     refs: Array.isArray(event?.refs) ? event.refs : [],
+    // BET-1428: keep the evidence event's project — the overnight dispatcher
+    // hosts a watcher-driven investigation in the project that produced the
+    // hit. Omitted when the event carries none so existing rows stay
+    // shape-identical.
+    ...(typeof event?.project === "string" && event.project ? { project: event.project } : {}),
     ts: now(),
   };
 }
@@ -443,6 +448,9 @@ export function collectWatcherHitsFromLedger(rows) {
       ts: typeof r.ts === "number" ? r.ts : 0,
       watcherId: r.watcherId,
       patternSignature: r.patternSignature,
+      // BET-1428: the hosting project captured at hit time (undefined when the
+      // hit row predates it or the evidence event had no project).
+      project: typeof r.project === "string" && r.project ? r.project : undefined,
     });
   }
   return out;

--- a/src/server/ctoWatchers.test.mjs
+++ b/src/server/ctoWatchers.test.mjs
@@ -286,6 +286,14 @@ test("watcherHitPayload carries predicate-kind → sourceKind mapping", () => {
   assert.equal(watcherHitPayload(rt, {}).sourceKind, "watcher-hit-rate");
 });
 
+test("watcherHitPayload keeps the evidence event's project (BET-1428), omits it when absent", () => {
+  const ep = makeWatcher({ predicate: { kind: EVENT_PATTERN, params: { pattern: "x" } }, now: () => 1 }).watch;
+  assert.equal(watcherHitPayload(ep, { project: "/repo" }).project, "/repo");
+  assert.equal("project" in watcherHitPayload(ep, {}), false, "no project → no key (existing rows stay shape-identical)");
+  assert.equal("project" in watcherHitPayload(ep, { project: "" }), false);
+  assert.equal("project" in watcherHitPayload(ep, { project: 7 }), false);
+});
+
 test("collectWatcherHitsFromLedger produces B4 findings (rate-threshold → watcher-hit-rate)", () => {
   const rows = [
     { kind: "watcher.hit", salience: "high", watcherId: "w1", predicateKind: RATE_THRESHOLD, text: "burst of failures", ts: 1 },
@@ -296,6 +304,28 @@ test("collectWatcherHitsFromLedger produces B4 findings (rate-threshold → watc
   assert.equal(findings.length, 2);
   assert.deepEqual(findings.map((f) => f.sourceKind).sort(), ["watcher-hit", "watcher-hit-rate"]);
   assert.deepEqual(findings.map((f) => f.id).sort(), ["wh:w1", "wh:w2"]);
+});
+
+test("collectWatcherHitsFromLedger passes the hit row's hosting project through (BET-1428)", () => {
+  const rows = [
+    { kind: "watcher.hit", salience: "high", watcherId: "w1", predicateKind: RATE_THRESHOLD, text: "burst", project: "/repo", ts: 1 },
+    { kind: "watcher.hit", salience: "high", watcherId: "w2", predicateKind: EVENT_PATTERN, text: "theme", ts: 2 },
+    { kind: "watcher.hit", salience: "high", watcherId: "w3", predicateKind: EVENT_PATTERN, text: "bad", project: 42, ts: 3 },
+  ];
+  const findings = collectWatcherHitsFromLedger(rows);
+  assert.equal(findings[0].project, "/repo");
+  assert.equal(findings[1].project, undefined);
+  assert.equal(findings[2].project, undefined, "non-string project degrades to undefined");
+});
+
+test("an evidence event's project rides the hit into the ledger (BET-1428)", async () => {
+  const deps = makeEngineDeps();
+  const eng = createStandingQueryEngine(deps);
+  await eng.register({ predicate: { kind: EVENT_PATTERN, params: { pattern: "boom" } } });
+  await eng.evaluateEvent({ text: "boom", kind: "prompt", project: "/repo" });
+  const hit = deps.ledgerRows.find((r) => r.kind === "watcher.hit");
+  assert.ok(hit, "one hit row");
+  assert.equal(hit.project, "/repo", "the hosting project is captured at hit time");
 });
 
 test("the steep-decay notify rule set gained watcher-hit-rate", () => {


### PR DESCRIPTION
## BET-1428 — watcher candidates carry no project → re-skip per tick

Base: origin/main @ `9f937c80`

## Root cause

The evidence event that triggers a watcher hit carries `project` (resolved
from the live session at ingestion, `normalizeEvidence`), but
`watcherHitPayload` dropped it when writing the `watcher.hit` ledger row.
`watcherCandidatesFromRows` therefore built candidates with no `project`, and
`dispatchPlan` resolved `project = cand.project ?? task?.project` → undefined →
`resolveForgeOwner` null → a `cto.overnight.skip` row per 1-min tick of the
open window (the hit is re-collected from the trailing-24h ledger every tick).
Watcher-driven work selected by the portfolio never ran.

## Fix (options a + c from the issue triage)

1. **(a) Resolvable project — the root cause.** `watcherHitPayload` keeps the
   evidence event's `project` on the hit row (omitted when absent so existing
   rows stay shape-identical); `collectWatcherHitsFromLedger` passes it
   through (shared with the B4 suggest source — additive field);
   `watcherCandidatesFromRows` maps it onto the candidate. A hit produced by
   project P now dispatches into P, and the existing `startedIds` dedupe
   bounds it to one run per window.
2. **(c) Skip-row dedupe per candidate per window.** `dispatchPlan` builds
   `skippedIds` from the window's `cto.overnight.skip` rows (mirroring
   `startedIds`) and guards every non-terminal skip row: rate-limit,
   unresolvable-project (the watcher/no-queue-row branch), and
   delegate-start-refused. The retry is never suppressed — a freed sub-cap
   slot or a project session opened mid-window still starts the candidate on
   a later tick; only the repeated rows are gone. The BET-1426 removal row
   stays unguarded (one-time terminal event by construction — queue ids are
   fresh per add).

## Duplicate-site check

All four skip-row writes live in `dispatchPlan`; three are guarded, the
removal branch deliberately not. The hit row has exactly one writer
(`watcherHitPayload`) and one shared reader (`collectWatcherHitsFromLedger`,
used by ctoEngine + ctoSuggest) — extended in place, no parallel copy.

## Residual (parked)

A hit with no project at all (usage-burn fires with an empty event; hit rows
written before this change) still can't be hosted — it now costs one skip row
per window instead of one per tick. Auto-resolving such hits to a single
hostable project session (tonightAdd-style) would be a product decision not
written in the spec — parked as a follow-up rather than decided here.

**Files changed:** 4 — `src/server/ctoWatchers.mjs`, `src/server/ctoEngine.mjs`, `src/server/ctoWatchers.test.mjs`, `src/server/ctoEngine.overnight.test.mjs`

**Verification results:**
- PR branch (`multica/BET-1428-watcher-candidate-project` @ `e81fb73a`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0. vitest: 3851 pass / 0 fail / 7 skip (198 files); node:test: 3518 pass / 0 fail. Failures: none. log sha256: `238e4fe19b53fe613dd968193d6bf945e8ba12aa6a8a57c5bf3233e7f4c78266`
- Base (`main` @ `9f937c80`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0. vitest: 3851 pass / 0 fail / 7 skip; node:test: 3511 pass / 0 fail. Failures: none. log sha256: `ec9f91e7d4393d60bd4917d4ac6d041cea02f72687ef06c748e9c2948ee77bd6`
- **Conclusion:** 0 pre-existing failures, 0 new failures; the PR adds 7 tests (3 watchers, 4 overnight).
