### PR TITLE
BET-1435: refactor(server): dedup facts-engine fixture wiring in ctoEngine.test.mjs

### DIFF
--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -625,7 +625,10 @@ test("rollups do not run while paused", async () => {
 // store is touched.
 // ---------------------------------------------------------------------------
 
-test("engine exposes .facts and pumps proposals on tick (%40 enabled)", async () => {
+// Local facts-engine fixture: in-memory stores for facts + archive and a
+// persisted engineState, so no real store is touched. Returns the engine plus
+// the raw inmemory map for assertions.
+function makeFactsFixture() {
   const inmemory = new Map();
   const fstate = { v: 1 };
   const facts = createFactsEngine({
@@ -639,6 +642,11 @@ test("engine exposes .facts and pumps proposals on tick (%40 enabled)", async ()
     facts: { load: async (p) => inmemory.get(p) ?? { v: 1, facts: [] }, save: async (p, d) => inmemory.set(p, d), dir: "x" },
     archive: { load: async (p) => inmemory.get("a" + p) ?? { v: 1, entries: [] }, save: async (p, d) => inmemory.set("a" + p, d) },
   });
+  return { facts, inmemory, fstate };
+}
+
+test("engine exposes .facts and pumps proposals on tick (%40 enabled)", async () => {
+  const { facts, inmemory } = makeFactsFixture();
   const harness = makeHarness({ ctoEnabled: true, facts });
   // Enable + a proposal for alpha, then a tick should drain it into the store.
   await harness.engine.resume();
@@ -650,19 +658,7 @@ test("engine exposes .facts and pumps proposals on tick (%40 enabled)", async ()
 });
 
 test("proposeFact enqueues, resolves via the gatekeeper, and reports the verdict", async () => {
-  const inmemory = new Map();
-  const fstate = { v: 1 };
-  const facts = createFactsEngine({
-    engineState: {
-      load: async () => ({ ...fstate }),
-      save: async (s) => {
-        Object.keys(fstate).forEach((k) => delete fstate[k]);
-        Object.assign(fstate, s);
-      },
-    },
-    facts: { load: async (p) => inmemory.get(p) ?? { v: 1, facts: [] }, save: async (p, d) => inmemory.set(p, d), dir: "x" },
-    archive: { load: async (p) => inmemory.get("a" + p) ?? { v: 1, entries: [] }, save: async (p, d) => inmemory.set("a" + p, d) },
-  });
+  const { facts } = makeFactsFixture();
   const harness = makeHarness({ ctoEnabled: true, facts });
   await harness.engine.resume();
 


### PR DESCRIPTION
Closes BET-1435. Test-fixture dedup only — no production code changes.

## What

Extracted the 17-line `createFactsEngine` fixture wiring (`inmemory` / `fstate` / `engineState` load+save / `facts` / `archive` setup) — duplicated verbatim between the "engine exposes .facts and pumps proposals on tick (%40 enabled)" test and the "proposeFact enqueues, resolves via the gatekeeper, and reports the verdict" test — into a local `makeFactsFixture()` helper in the same file. Both tests use it; assertions unchanged in intent.

## Why

The advisory duplication gate (jscpd, min-tokens 70) fails on ANY PR that touches `src/server/ctoEngine.test.mjs`, because the whole changed file is scanned. The clone is pre-existing on `main` @ `30775687`; PR #1418 (BET-1427) introduced zero clones and still went red. Every future PR touching this file would hit the same noise.

No entry was added to `scripts/duplication-gate-ignore.txt` (out of scope per the issue — would mask the whole file for future real clones).

## Acceptance

- [x] jscpd reports **0 clones** for `src/server/ctoEngine.test.mjs` at min-tokens 70 (verified locally with the repo's own `.jscpd.json` config via `npx jscpd`; baseline before the change was exactly this 1 clone, 17 lines)
- [x] `npm run typecheck && npm test` passes; both tests' assertions unchanged in intent

Base: origin/main @ 30775687

**Files changed:** 1 file. `src/server/ctoEngine.test.mjs` (+10 / −14)

**Verification results:**
- PR branch (`multica/BET-1435-dedup-ctoengine-fixtures` @ `29580370`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3512` pass / `0` fail / `0` skip. Failures: none. log sha256: `03bc1cf4517e43b9022aafe60c3be24563b599c3349d2665d97d9248c808c814`
- Base (`main` @ `30775687`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3512` pass / `0` fail / `0` skip. Failures: none. log sha256: `063bee768bd2f39d2dc7bfe8576e39dd4962141665c7b1c1e2639275ee18ec9e`
- **Conclusion:** 0 new failures, 0 pre-existing failures — both branches fully green. The two ctoEngine facts tests now run against the shared helper with identical assertions.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
