### PR TITLE
BET-1396: Adaptive CTO probe runner (§7.5) + vitality (§7.3) + relevance (§7.6) + auth-failure escalation (§10.6-7)

### DIFF
--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -71,6 +71,24 @@ export const INBOX_SOURCE_KIND = "inbox";
 // Connect-ask cards (BET-1395 / §7.4): one §7.2 tool identity per card, keyed
 // by the tool id.
 export const CONNECT_SOURCE_KIND = "tool";
+// Probe-failure blocker cards (BET-1396 / §10.6-7): an auth-shaped probe
+// failure that degraded the digest. Keyed by `<tool>/<probe>`; the body
+// deep-links (in copy) to the secrets surface — the fix is a rotated key.
+export const PROBE_SOURCE_KIND = "probe";
+
+// §10.6-7 probe-auth-failure card copy (3 consecutive auth failures — the
+// runner's AUTH_FAIL_ESCALATE). `secretKey` is the vault KEY NAME (not a
+// value) when the spec declared one — naming the exact key the user should
+// update is the deep-link to the secrets surface in words.
+export function probeBlockerCopy(tool, probeName, secretKey = null) {
+  const secret = secretKey
+    ? ` If the key was rotated, update "${secretKey}" on the secrets surface (⚙ Settings → Secrets).`
+    : " Check the tool's credential on the secrets surface (⚙ Settings → Secrets).";
+  return {
+    title: `Probe failing — ${tool} key may have been rotated`,
+    body: `The "${probeName}" probe for ${tool} failed auth 3 times in a row (HTTP 401/403 or the credential is gone), so the digest's view of ${tool} is degraded.${secret}`,
+  };
+}
 
 // Stable, collision-resistant card id. Re-detection of the same (sourceKind,
 // sourceId) yields the same id → upsert in place, never a duplicate.

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -55,6 +55,7 @@ import {
   verdictsStore,
   watchersStore,
   factsArchiveStore,
+  probeStateStore,
   patchEngineState,
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
@@ -88,6 +89,7 @@ import {
   createCtoCards,
   isAskResolveEvent,
 } from "./ctoCards.mjs";
+import { createProbes } from "./ctoProbes.mjs";
 import { createSegmenter, segmentEventKind } from "./ctoSegments.mjs";
 import {
   createRollupRunner,
@@ -415,6 +417,7 @@ export function createCtoEngine(deps = {}) {
   let trustEngine = null;
   let watcherEngine = null;
   let toolEngine = null;
+  let probesEngine = null;
   let lastToolScanDay = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
@@ -568,6 +571,8 @@ export function createCtoEngine(deps = {}) {
         // §7 tool discovery: the daily evidence scan + lifecycle + connect
         // asks (BET-1395). Once per UTC day; self-paced inside the registry.
         await toolsTick();
+        // §7.5 probe runner (BET-1396): due probes + weekly relevance.
+        await probesTick();
       }
       // §10.6-4 cold-start backfill — also ambient, gated on enabled. Its own
       // drained state marker makes it run at most once per box.
@@ -1076,8 +1081,65 @@ export function createCtoEngine(deps = {}) {
         collectSurfaces: toolsGetSurfaces,
         backfillStartInstant,
         recordVerdict: (input) => getVerdictsEngine().recordVerdict(input),
+        // §7.5 BET-1396: the consent path authors the tool's probe-spec
+        // template through the probes engine (late-bound — the probes engine
+        // is constructed just below with THIS registry as its registry dep).
+        scaffoldProbes: (toolId, opts) => getProbes().scaffoldSpec(toolId, opts),
       });
+    getProbes();
     return toolEngine;
+  }
+
+  // §7.5 probe runner (BET-1396). Built lazily next to the registry it reads.
+  // `toolsRunEphemeral` is the §3.3-gated classifier seam (the SAME gate the
+  // registry's LLM fallback rides) — relevance's weekly nano score rides it
+  // too, so an ungated ambient call path never exists. `isThrifty` reads the
+  // engine's LIVE thrifty flag (the §12.2 shed ladder's rung 2).
+  function getProbes() {
+    if (probesEngine) return probesEngine;
+    if (!tools && !toolEngine) getTools();
+    if (!toolEngine) return null;
+    probesEngine = createProbes({
+      registry: toolEngine,
+      stateStore: probeStateStore,
+      cards,
+      ledger,
+      now,
+      isThrifty: () => thrifty,
+      listProjects: () => getFactsEngine().listProjects(),
+      getTopFacts: (project, k) => getFactsEngine().topFacts(project, { k }),
+      getRollups: probesRollupLines,
+      runEphemeral: toolsRunEphemeral ?? null,
+    });
+    return probesEngine;
+  }
+
+  // §7.6 relevance context: the most recent day-rollup's bullet lines (the
+  // blackboard's freshest summarized work). Cross-project attribution of
+  // rollup bullets needs segment resolution (ctoRollups' proposal mapper) —
+  // deliberately not paid for a nano context; the project's own top facts
+  // (which rollups are fused into) carry the per-project signal.
+  async function probesRollupLines() {
+    try {
+      const rollups = await loadRecentDayRollups(7);
+      const latest = rollups[rollups.length - 1];
+      return (latest?.bullets ?? [])
+        .map((b) => (typeof b?.text === "string" ? b.text.trim() : ""))
+        .filter(Boolean)
+        .slice(0, 5)
+        .join("\n");
+    } catch {
+      return "";
+    }
+  }
+
+  // The §7.5 probe tick (BET-1396): due probes + weekly relevance, behind the
+  // master toggle, thrifty-shed, paused with the rest of the tick.
+  async function probesTick() {
+    const eng = getProbes();
+    if (!eng) return;
+    await eng.runDue().catch(() => {});
+    await eng.relevanceScan().catch(() => {});
   }
 
   // §7.1-2: the daily batch's db seam — tool-call part rows in the scan
@@ -2252,6 +2314,8 @@ export function createCtoEngine(deps = {}) {
     lastHeartbeat,
     proposeFact,
     factsContextBlock,
+    // BET-1396 (§7.5/§10.5): the A12 health endpoint's probe-health reader.
+    probeHealth: () => getProbes()?.healthSnapshot() ?? { tools: 0, probes: 0, healthy: 0, authFailed: 0, lastRunAt: null },
     // BET-1391 verdict ledger (§9.5): record + read the verdict ledger (the
     // opencode `cto_verdict` tool + the digest-opened rewire + the health card
     // all reach one path through these).

--- a/src/server/ctoHealth.mjs
+++ b/src/server/ctoHealth.mjs
@@ -28,6 +28,7 @@ export const HEALTH_STAT_MIN = Object.freeze({
   capHitsCaused: 1,
   reserveFractile: 1,
   roi: 1,
+  probeHealth: 1,
 });
 
 // EN month labels for ROI row copy — deterministic (server locale must not
@@ -87,6 +88,9 @@ export async function computeHealthStats({
   // BET-1405 (§12.4): async () => { month, roll, collectingUntil } — the
   // monthly ROI roll; the endpoint refreshes it before this read.
   roiRead = async () => null,
+  // BET-1396 (§7.5/§10.5): async () => { tools, probes, healthy, authFailed,
+  // lastRunAt } — the probe runner's snapshot over consented tools.
+  probesRead = async () => null,
 } = {}) {
   const t = now();
   const stats = [];
@@ -298,6 +302,32 @@ export async function computeHealthStats({
       collectingText: firstReportText ? `collecting — first report ${firstReportText}` : "collecting",
     });
   }
+
+  // 9. Probe health (BET-1396, §7.5/§10.5 "probe health per consented tool")
+  //    — how many §7.5 metadata probes are configured and how many reported
+  //    healthy on their last run. Auth-failed probes surface separately (they
+  //    carry their own §10.6-7 blocker card); a probe that never ran keeps
+  //    the row collecting (n counts configured probes, value needs a run).
+  let probes = null;
+  try {
+    probes = (await probesRead()) ?? null;
+  } catch {
+    probes = null;
+  }
+  const probeCount = Number(probes?.probes ?? 0);
+  const probeRan = Number(probes?.lastRunAt ?? 0) > 0;
+  const probeAuth = Number(probes?.authFailed ?? 0);
+  stats.push({
+    id: "probeHealth",
+    label: "Probe health",
+    min: HEALTH_STAT_MIN.probeHealth,
+    n: probeCount,
+    value:
+      probeCount >= HEALTH_STAT_MIN.probeHealth && probeRan
+        ? `${Number(probes.healthy ?? 0)}/${probeCount} probes healthy${probeAuth > 0 ? ` · ${probeAuth} auth-failed` : ""}`
+        : null,
+    ...(probeCount > 0 && !probeRan ? { collectingText: "configured — waiting for first run" } : {}),
+  });
 
   return { stats, generatedAt: t };
 }

--- a/src/server/ctoProbes.mjs
+++ b/src/server/ctoProbes.mjs
@@ -85,9 +85,14 @@ export const AUTH_FAIL_ESCALATE = 3;
 // §7.3 cadence adaptation band (daily ↔ weekly on observed inflow).
 export const CADENCE_DAILY_MS = 24 * 3_600_000;
 export const CADENCE_WEEKLY_MS = 7 * 24 * 3_600_000;
-// §7.6: one relevance call per (tool, project) per week, paced per day.
+// §7.6: one relevance call per (tool, project) per week, paced per day. The
+// daily budget bounds ATTEMPTS, not successes — a failed or unparseable nano
+// call consumes the day's pacing AND sets a short retry watermark, so a
+// persistently failing/gated model makes at most RELEVANCE_PER_DAY attempts
+// per day instead of spinning one attempt per due pair per minute-tick.
 export const RELEVANCE_WEEK_MS = 7 * 24 * 3_600_000;
 export const RELEVANCE_PER_DAY = 6;
+export const RELEVANCE_FAILURE_RETRY_MS = 3_600_000;
 export const RELEVANCE_TASK_CLASS = "ambient-summarize";
 
 // Consent rings (D13). Probes only ever declare metadata | deep_read — the
@@ -342,6 +347,12 @@ export function validateProbeSpec(spec, { tool, allowedHosts = [], consentedRing
       if (typeof spec.auth.header !== "string") {
         push("auth.header", `"auth.header" must be a header template string`);
       } else {
+        if (!spec.auth.header.includes(":")) {
+          // A colon-less template would mangle the header NAME at run time
+          // (everything before the first ":" becomes the name) and 401 into a
+          // misleading rotated-key card — catch it at authoring time.
+          push("auth.header", `"auth.header" must be a full header line "Name: value template" (missing ":")`);
+        }
         const count = spec.auth.header.split(SECRET_PLACEHOLDER).length - 1;
         if (count !== 1) {
           push("auth.header", `"auth.header" must contain exactly one ${SECRET_PLACEHOLDER} placeholder (found ${count})`);
@@ -935,15 +946,20 @@ export function createProbes(deps = {}) {
   /**
    * Weekly per consented tool × active project: one nano call matching the
    * tool's data domain against the project's top facts + recent rollups →
-   * `relevance[project] ∈ [0,1]`. Paced at RELEVANCE_PER_DAY calls/day.
+   * `relevance[project] ∈ [0,1]`. Pacing bounds ATTEMPTS: every call —
+   * success or failure — consumes the RELEVANCE_PER_DAY budget, and a failed
+   * call also sets a RELEVANCE_FAILURE_RETRY_MS watermark so a persistently
+   * failing or gate-rejecting model cannot retry one pair per minute-tick
+   * indefinitely (review cycle 1, Question 1). Successful pairs then rest
+   * for the week.
    */
   async function relevanceScan({ ts = now(), todayKey = dayKeyOf(ts) } = {}) {
-    if (typeof runEphemeral !== "function") return { ran: 0, skipped: "no-ephemeral" };
+    if (typeof runEphemeral !== "function") return { ran: 0, attempts: 0, skipped: "no-ephemeral" };
     let tools;
     try {
       tools = await probes.list();
     } catch {
-      return { ran: 0 };
+      return { ran: 0, attempts: 0 };
     }
     let projects = [];
     try {
@@ -951,7 +967,7 @@ export function createProbes(deps = {}) {
     } catch {
       projects = [];
     }
-    if (tools.length === 0 || projects.length === 0) return { ran: 0 };
+    if (tools.length === 0 || projects.length === 0) return { ran: 0, attempts: 0 };
     let st;
     try {
       st = (await state.load("_relevance")) ?? {};
@@ -964,6 +980,7 @@ export function createProbes(deps = {}) {
     }
     let budget = RELEVANCE_PER_DAY - (st.todayCount ?? 0);
     let ran = 0;
+    let attempts = 0;
     for (const tool of tools) {
       if (budget <= 0) break;
       if ((await registry.consentFor(tool, "metadata")) !== "yes") continue;
@@ -975,20 +992,23 @@ export function createProbes(deps = {}) {
       let toolTouched = false;
       for (const project of projects) {
         if (budget <= 0) break;
-        if (typeof relAt[project] === "number" && ts - relAt[project] < RELEVANCE_WEEK_MS) continue;
+        const entry = relAt[project];
+        const restMs = entry?.ok ? RELEVANCE_WEEK_MS : RELEVANCE_FAILURE_RETRY_MS;
+        if (entry && typeof entry.at === "number" && ts - entry.at < restMs) continue;
         const facts = await getTopFacts(project, 5).catch(() => []);
         const rollups = await getRollups(project).catch(() => "");
         if (!factLines(facts) && !rollupLines(rollups)) {
-          relAt[project] = ts; // nothing to match against — do not retry all week
+          relAt[project] = { at: ts, ok: true }; // nothing to match against — do not retry all week
           toolTouched = true;
           continue;
         }
-        const score = await scoreRelevance({ tool, domain, project, facts, rollups });
-        if (score === null) continue; // model/parse failure → retry next scan
-        relAt[project] = ts;
-        budget -= 1;
-        ran += 1;
+        budget -= 1; // the attempt itself is the paced resource
+        attempts += 1;
         toolTouched = true;
+        const score = await scoreRelevance({ tool, domain, project, facts, rollups });
+        relAt[project] = { at: ts, ok: score !== null };
+        if (score === null) continue; // retried after the failure watermark, still budget-bounded
+        ran += 1;
         try {
           await registry.applyRelevance(tool, project, score);
         } catch {
@@ -1003,11 +1023,11 @@ export function createProbes(deps = {}) {
       st.relAt = { ...(st.relAt ?? {}), [tool]: relAt };
       if (toolTouched) await saveToolState("_relevance", st);
     }
-    if (ran > 0) {
-      st.todayCount = (st.todayCount ?? 0) + ran;
+    if (attempts > 0) {
+      st.todayCount = (st.todayCount ?? 0) + attempts;
       await saveToolState("_relevance", st);
     }
-    return { ran };
+    return { ran, attempts };
   }
 
   function factLines(facts) {

--- a/src/server/ctoProbes.mjs
+++ b/src/server/ctoProbes.mjs
@@ -1,0 +1,1070 @@
+// ctoProbes.mjs — the §7.5 probe runner (BET-1396 / spec §7.5, §7.3, §7.6,
+// §10.6-7) for the Adaptive CTO.
+//
+// Consented tools get DECLARATIVE metadata probes: `~/.manta/cto/probes/<tool>.yaml`
+// holds a §7.5 spec (validated like forge rules — unknown keys fail BY NAME),
+// and this runner executes the probes on their cadence against the tool's
+// EVIDENCED hosts only.
+//
+// Hard enforcement (§7.5 "every runner enforcement rule"):
+//   - GET-only. The validator rejects any other method by name; the runner
+//     never issues one.
+//   - Exact-host allowlist derived from the tool's evidence rows. A probe URL
+//     on any other host is a spec validation error, and a redirect is NEVER
+//     followed — a 3xx is a failure row, so nothing off-list is ever hit.
+//   - Public DNS only, SSRF-safe by construction: the default transport
+//     RESOLVES the hostname first, rejects every private/reserved address
+//     (RFC1918, loopback, link-local, CGNAT, v4-mapped v6, ...), then issues
+//     the TLS request with a pinned `lookup` so the socket can only reach the
+//     validated addresses (no rebinding window). `Host` + SNI keep the
+//     hostname. Rationale: a probe spec is AI-authored content; without this
+//     an LLM could be steered into fetching `http://169.254.169.254/` or a
+//     box-local service.
+//   - 256 KB response cap + 10 s timeout, enforced on the response stream.
+//   - Auth by reference only: `auth.secret` names a vault KEY; the runner
+//     resolves it AT SPAWN through the existing secrets machinery to a
+//     materialized file path and reads the value inside the request closure.
+//     The value never enters logs, stores, ledger rows, or model contexts —
+//     failure rows carry status codes and error codes only. Secret usage is
+//     NOT recorded on probe spawns (a provide that inflated engagement would
+//     make the registry's axis a feedback loop of its own runner).
+//   - Responses are UNTRUSTED DATA: only tiny extracted fields (the spec's
+//     json-path `extract` map) survive into the ledger/vitality/relevance
+//     paths; the raw body is never persisted or fed to a model.
+//
+// Vitality (§7.3): successful metadata probes hand {last_event, inflow_rate}
+// to `ctoToolRegistry.applyProbeResult` (EWMA in the §7.2 schema) and the
+// probe's cadence adapts daily↔weekly on observed inflow (spec cadence stays
+// unclamped until the first vitality sample).
+//
+// Relevance (§7.6, scoring half only — deep analyses are P3): weekly per
+// consented tool × active project, one nano runEphemeral call scores the
+// tool's data domain against the project's top facts + recent rollups into
+// `relevance[project] ∈ [0,1]`.
+//
+// Failure escalation (§10.6-7): consecutive auth-shaped failures (401/403, or
+// a secret that no longer materializes — the same "key may have been rotated"
+// failure mode) ≥ 3 → ONE blocker card per probe (idempotent upsert; the body
+// names the secrets surface). Any success resolves the card. Non-auth
+// failures produce health rows only — they never page the user. The whole
+// subsystem sits behind the master CTO toggle (§10.5) and does nothing for
+// tools without consent (§7.5).
+//
+// Thrifty (§12.2): probe fan-outs are rung 2 of the shed ladder. While
+// thrifty is on every due-probe execution is skipped EXCEPT probes that
+// currently back an open probe-failure blocker card (their liveness IS the
+// card's resolution path).
+//
+// Injection discipline: no live network, fs, secrets, registry, cards, or
+// opencode in tests — everything arrives injected, so tests are pure over
+// fakes (AGENTS.md server rule).
+
+import { readFile } from "node:fs/promises";
+import https from "node:https";
+import dns from "node:dns/promises";
+import { probesStore, probeStateStore } from "./ctoStores.mjs";
+import { provideSecret } from "./secrets.mjs";
+import {
+  PROBE_SOURCE_KIND,
+  probeBlockerCopy,
+  stableCardId,
+} from "./ctoCards.mjs";
+
+// ---------------------------------------------------------------------------
+// Constants (§7.5 / §7.3 / §10.6-7)
+// ---------------------------------------------------------------------------
+
+export const RESPONSE_CAP_BYTES = 256 * 1024;
+export const PROBE_TIMEOUT_MS = 10_000;
+// §7.5: every probe declares its cadence; the floor is 5m (validation floor —
+// the ADAPTIVE band below can only move a probe within daily↔weekly, and the
+// effective cadence never dips under the floor).
+export const CADENCE_FLOOR_MS = 5 * 60_000;
+// §10.6-7: escalate an auth-shaped failure to a blocker card after 3 consecutive.
+export const AUTH_FAIL_ESCALATE = 3;
+// §7.3 cadence adaptation band (daily ↔ weekly on observed inflow).
+export const CADENCE_DAILY_MS = 24 * 3_600_000;
+export const CADENCE_WEEKLY_MS = 7 * 24 * 3_600_000;
+// §7.6: one relevance call per (tool, project) per week, paced per day.
+export const RELEVANCE_WEEK_MS = 7 * 24 * 3_600_000;
+export const RELEVANCE_PER_DAY = 6;
+export const RELEVANCE_TASK_CLASS = "ambient-summarize";
+
+// Consent rings (D13). Probes only ever declare metadata | deep_read — the
+// write ring creates no standing specs (§7.4). Ordering matters: a probe's
+// ring must be ≤ the tool's consented ring for that access level.
+export const RING_LEVELS = Object.freeze({ metadata: 1, deep_read: 2 });
+export const PROBE_RINGS = Object.freeze(Object.keys(RING_LEVELS));
+
+// Cadence grammar: `<n><s|m|h|d>` — the pluginManifest timeout style.
+export const CADENCE_RE = /^\d+(s|m|h|d)$/;
+const CADENCE_UNIT_MS = Object.freeze({ s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 });
+
+// Auth header template: exactly one {secret} placeholder, by reference only.
+export const SECRET_PLACEHOLDER = "{secret}";
+const SECRET_PLACEHOLDER_RE = /\{secret\}/g;
+
+// Probe names / extract fields are identifiers (never paths); secret keys are
+// vault KEY NAMEs (SCREAMING_SNAKE) — never a value.
+const IDENTIFIER_RE = /^[a-z0-9][a-z0-9_.-]{0,63}$/;
+const SECRET_KEY_RE = /^[A-Z][A-Z0-9_]{0,63}$/;
+const HOSTLIKE_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+// ---------------------------------------------------------------------------
+// Pure predicates — URL / host / address (SSRF catalogue, §7.5)
+// ---------------------------------------------------------------------------
+
+/** Parse a spec URL into `{url, host}` or null. Only https is a probe URL. */
+export function parseProbeUrl(raw) {
+  if (typeof raw !== "string" || raw.length === 0 || raw.length > 2048) return null;
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== "https:") return null;
+  if (!u.hostname || u.username || u.password) return null;
+  return { url: u, host: u.hostname.toLowerCase() };
+}
+
+/** Exact-host allowlist match (case-insensitive, no subdomain forgiveness). */
+export function hostAllowed(host, hosts) {
+  if (typeof host !== "string" || !Array.isArray(hosts)) return false;
+  const h = host.toLowerCase();
+  return hosts.some((x) => typeof x === "string" && x.toLowerCase() === h);
+}
+
+function octetsOf(address) {
+  return address.split(".").map((o) => {
+    if (!/^\d{1,3}$/.test(o)) return null;
+    const n = Number(o);
+    return n <= 255 ? n : null;
+  });
+}
+
+/**
+ * True when `address` (a DNS result for the probe host) is private/reserved —
+ * rejected before any socket is opened. Covers loopback, RFC1918, link-local,
+ * 0.0.0.0/8, CGNAT, multicast/reserved, IPv6 loopback/ULA/link-local/multicast,
+ * and IPv4-mapped IPv6 (::ffff:a.b.c.d). Pure + deterministic for tests.
+ */
+export function isPrivateAddress(address) {
+  if (typeof address !== "string" || address.length === 0) return true;
+  const a = address.toLowerCase();
+  if (a.includes(":")) {
+    const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(a);
+    if (mapped) {
+      const o = octetsOf(mapped[1]);
+      if (o.length !== 4 || o.some((x) => x === null)) return true;
+      return isPrivateV4(o);
+    }
+    if (a === "::1" || a === "::") return true; // loopback / unspecified
+    if (/^f[c-f]/.test(a)) return true; // fc00::/7 ULA, fe80::/10 link-local, ff00::/8 multicast
+    const compat = /^::(\d{1,3}(?:\.\d{1,3}){3})$/.exec(a);
+    if (compat) {
+      const o = octetsOf(compat[1]);
+      if (o.length !== 4 || o.some((x) => x === null)) return true;
+      return isPrivateV4(o);
+    }
+    return false;
+  }
+  const o = octetsOf(a);
+  if (o.length !== 4 || o.some((x) => x === null)) return true;
+  return isPrivateV4(o);
+}
+
+function isPrivateV4([a, b]) {
+  if (a === 10) return true; // RFC1918
+  if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+  if (a === 192 && b === 168) return true; // RFC1918
+  if (a === 127) return true; // loopback
+  if (a === 0) return true; // this-network
+  if (a === 169 && b === 254) return true; // link-local
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  if (a >= 224) return true; // multicast (224/4) + reserved (240/4) + broadcast
+  return false;
+}
+
+/** Pure filter: keep only the DNS results a probe may connect to. */
+export function publicAddresses(results) {
+  if (!Array.isArray(results)) return [];
+  return results.filter((r) => typeof r?.address === "string" && !isPrivateAddress(r.address));
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — cadence, extraction, escalation
+// ---------------------------------------------------------------------------
+
+/** Parse a §7.5 cadence string to ms, or null when malformed. */
+export function cadenceMs(value) {
+  const m = CADENCE_RE.exec(String(value ?? ""));
+  if (!m) return null;
+  const num = Number(m[0].slice(0, -1));
+  return num * CADENCE_UNIT_MS[m[0].slice(-1)];
+}
+
+/**
+ * §7.3 adaptive cadence (daily ↔ weekly on observed inflow):
+ *   - no vitality sample yet (`vitality?.ewma` null) → the spec cadence
+ *     unclamped (the declared value is the truth until data exists);
+ *   - inflow observed (ewma > 0) → accelerate toward daily: min(spec, 1 day);
+ *   - observed silence (ewma === 0) → stretch toward weekly: max(spec, 1 week).
+ * The result never dips below CADENCE_FLOOR_MS.
+ */
+export function effectiveCadenceMs(specMs, vitality) {
+  const base = Math.max(specMs ?? CADENCE_FLOOR_MS, CADENCE_FLOOR_MS);
+  const ewma = vitality?.ewma;
+  if (typeof ewma !== "number" || !Number.isFinite(ewma)) return base;
+  if (ewma > 0) return Math.max(Math.min(base, CADENCE_DAILY_MS), CADENCE_FLOOR_MS);
+  return Math.max(base, CADENCE_WEEKLY_MS);
+}
+
+/**
+ * Extract the spec's json-path map from a parsed JSON body. Paths are dot
+ * notation with numeric array indexes; a `length` segment on an array yields
+ * its length. Missing paths yield null (non-fatal — probes report what they
+ * can see). Returns `{ok, fields}`; ok is false only when the body is not JSON.
+ */
+export function extractFields(bodyText, extractMap) {
+  if (!extractMap || typeof extractMap !== "object" || Array.isArray(extractMap)) {
+    return { ok: true, fields: {} };
+  }
+  let data;
+  try {
+    data = JSON.parse(bodyText);
+  } catch {
+    return { ok: false, fields: {} };
+  }
+  const fields = {};
+  for (const [field, path] of Object.entries(extractMap)) {
+    fields[field] = extractPath(data, String(path ?? ""));
+  }
+  return { ok: true, fields };
+}
+
+function extractPath(data, path) {
+  let cur = data;
+  for (const seg of path.split(".")) {
+    if (cur == null) return null;
+    if (seg === "length" && Array.isArray(cur)) return cur.length;
+    if (Array.isArray(cur)) {
+      const idx = /^\d+$/.test(seg) ? Number(seg) : -1;
+      cur = idx >= 0 && idx < cur.length ? cur[idx] : undefined;
+    } else if (typeof cur === "object") {
+      cur = cur[seg];
+    } else {
+      return undefined;
+    }
+  }
+  return cur === undefined ? null : cur;
+}
+
+// Well-known vitality extract fields (§7.2: {last_event, inflow_rate}).
+export const VITALITY_FIELDS = Object.freeze(["last_event", "inflow_rate"]);
+
+/** Pull the vitality pair out of an extracted-field bag (missing → absent). */
+export function vitalityOf(fields) {
+  const lastEvent = fields?.last_event;
+  const rate = fields?.inflow_rate;
+  const out = {};
+  if (lastEvent !== undefined && lastEvent !== null && lastEvent !== "") out.last_event = lastEvent;
+  if (typeof rate === "number" && Number.isFinite(rate)) out.inflow_rate = rate;
+  return out;
+}
+
+/**
+ * Escalation state machine (pure). `state` = the durable per-probe counters
+ * `{fails, authFails, cardOpen}`. Returns the next state plus the ACTION to
+ * take: `escalate` the first time the auth-failure streak reaches 3 (the
+ * returned state already carries cardOpen:true), `resolve` when a success
+ * lands while a card is open (cardOpen cleared). Both streaks are
+ * consecutive-sensitive: any success zeroes them; a non-auth failure keeps
+ * `fails` but resets `authFails` (a 500 between 401s means the wire works and
+ * the credential verdict must restart — no half-counted escalation). The
+ * machine is self-consistent: a fourth auth failure with cardOpen already
+ * true does not re-escalate.
+ */
+export function stepFailureState(state, outcome) {
+  const prev = state ?? { fails: 0, authFails: 0, cardOpen: false };
+  if (outcome === "success") {
+    return { state: { fails: 0, authFails: 0, cardOpen: false }, action: prev.cardOpen ? "resolve" : null };
+  }
+  const authShaped = outcome === "auth";
+  const authFails = authShaped ? prev.authFails + 1 : 0;
+  const escalate = authShaped && authFails >= AUTH_FAIL_ESCALATE && !prev.cardOpen;
+  return {
+    state: { fails: prev.fails + 1, authFails, cardOpen: prev.cardOpen || escalate },
+    action: escalate ? "escalate" : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// §7.5 spec validation — the forge-rules-style error catalogue
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a parsed probe spec. Returns `{ok, errors}` where every error names
+ * the offending key BY NAME (pluginManifest.mjs style). `ctx`:
+ *   tool          — the canonical tool id this file belongs to
+ *   allowedHosts  — the tool's evidenced hosts (exact)
+ *   consentedRing — the highest ring consented for the tool ("metadata" |
+ *                   "deep_read" | null — null means nothing may run)
+ */
+export function validateProbeSpec(spec, { tool, allowedHosts = [], consentedRing = null } = {}) {
+  const errors = [];
+  const push = (key, message) => errors.push({ key, message });
+
+  if (!spec || typeof spec !== "object" || Array.isArray(spec)) {
+    return { ok: false, errors: [{ key: "", message: "probe spec must be a YAML mapping" }] };
+  }
+
+  const allowedTop = ["tool", "auth", "probes"];
+  for (const k of Object.keys(spec)) {
+    if (!allowedTop.includes(k)) push(k, `unknown probe-spec key "${k}"`);
+  }
+  if (typeof spec.tool !== "string" || !IDENTIFIER_RE.test(spec.tool)) {
+    push("tool", `probe spec "tool" must match ${IDENTIFIER_RE}`);
+  } else if (tool && spec.tool !== tool) {
+    push("tool", `probe spec "tool" is "${spec.tool}" but this file belongs to "${tool}"`);
+  }
+
+  if (spec.auth !== undefined) {
+    if (!spec.auth || typeof spec.auth !== "object" || Array.isArray(spec.auth)) {
+      push("auth", `"auth" must be a mapping`);
+    } else {
+      for (const k of Object.keys(spec.auth)) {
+        if (k !== "secret" && k !== "header") push(`auth.${k}`, `unknown auth key "auth.${k}"`);
+      }
+      if (typeof spec.auth.secret !== "string" || !SECRET_KEY_RE.test(spec.auth.secret)) {
+        push("auth.secret", `"auth.secret" must be a vault KEY NAME (${SECRET_KEY_RE}), never a value`);
+      }
+      if (typeof spec.auth.header !== "string") {
+        push("auth.header", `"auth.header" must be a header template string`);
+      } else {
+        const count = spec.auth.header.split(SECRET_PLACEHOLDER).length - 1;
+        if (count !== 1) {
+          push("auth.header", `"auth.header" must contain exactly one ${SECRET_PLACEHOLDER} placeholder (found ${count})`);
+        }
+      }
+    }
+  }
+
+  if (!Array.isArray(spec.probes)) {
+    push("probes", `"probes" must be an array (may be empty for a template)`);
+  } else {
+    for (let i = 0; i < spec.probes.length; i++) {
+      const p = spec.probes[i];
+      const at = `probes[${i}]`;
+      if (!p || typeof p !== "object" || Array.isArray(p)) {
+        push(at, `${at} must be a mapping`);
+        continue;
+      }
+      const allowedProbe = ["name", "method", "url", "extract", "cadence", "ring"];
+      for (const k of Object.keys(p)) {
+        if (!allowedProbe.includes(k)) push(`${at}.${k}`, `unknown probe key "${k}"`);
+      }
+      if (typeof p.name !== "string" || !IDENTIFIER_RE.test(p.name)) {
+        push(`${at}.name`, `probe "name" must match ${IDENTIFIER_RE}`);
+      }
+      if (p.method !== "GET") {
+        push(`${at}.method`, `probe method must be GET (got ${JSON.stringify(p.method ?? null)})`);
+      }
+      const parsed = parseProbeUrl(p.url);
+      if (!parsed) {
+        push(`${at}.url`, `probe "url" must be an https URL (≤ 2048 chars, no userinfo)`);
+      } else if (!hostAllowed(parsed.host, allowedHosts)) {
+        push(`${at}.url`, `probe host "${parsed.host}" is not on the tool's evidenced-host allowlist`);
+      }
+      if (p.extract !== undefined) {
+        if (!p.extract || typeof p.extract !== "object" || Array.isArray(p.extract)) {
+          push(`${at}.extract`, `"extract" must be a mapping of field → json-path`);
+        } else {
+          for (const [f, v] of Object.entries(p.extract)) {
+            if (!IDENTIFIER_RE.test(f)) push(`${at}.extract.${f}`, `extract field "${f}" must match ${IDENTIFIER_RE}`);
+            if (typeof v !== "string" || v.length === 0 || v.length > 256) {
+              push(`${at}.extract.${f}`, `extract path for "${f}" must be a 1-256 char json-path string`);
+            }
+          }
+        }
+      }
+      if (typeof p.cadence !== "string" || !CADENCE_RE.test(p.cadence)) {
+        push(`${at}.cadence`, `probe "cadence" must look like "<n>s|m|h|d" (got ${JSON.stringify(p.cadence ?? null)})`);
+      } else {
+        const ms = cadenceMs(p.cadence);
+        if (ms < CADENCE_FLOOR_MS) {
+          push(`${at}.cadence`, `probe cadence ${p.cadence} is below the 5m floor (§7.5)`);
+        }
+      }
+      if (!PROBE_RINGS.includes(p.ring)) {
+        push(`${at}.ring`, `probe "ring" must be one of ${PROBE_RINGS.join(" | ")}`);
+      } else {
+        const consented = RING_LEVELS[consentedRing] ?? 0;
+        if (RING_LEVELS[p.ring] > consented) {
+          push(`${at}.ring`, `probe ring "${p.ring}" exceeds the tool's consented ring ("${consentedRing ?? "none"}")`);
+        }
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// The default transport — resolve-then-pinned-connect (SSRF-safe §7.5)
+// ---------------------------------------------------------------------------
+
+class ProbeHttpError extends Error {
+  constructor(code, message) {
+    super(message || code);
+    this.code = code;
+  }
+}
+
+/**
+ * Consume an https response with the §7.5 enforcement: 10 s wall timeout and
+ * a 256 KB body cap. Exported (over a plain Readable) so tests exercise the
+ * cap/timeout with PassThrough streams — no sockets.
+ */
+export function consumeResponse(res, { maxBytes = RESPONSE_CAP_BYTES, timeoutMs = PROBE_TIMEOUT_MS } = {}) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      res.destroy();
+      reject(new ProbeHttpError("timeout", `probe exceeded ${timeoutMs}ms`));
+    }, timeoutMs);
+    const chunks = [];
+    let size = 0;
+    res.on("data", (chunk) => {
+      size += chunk.length;
+      if (size > maxBytes) {
+        clearTimeout(timer);
+        res.destroy();
+        reject(new ProbeHttpError("too_large", `probe body exceeded ${maxBytes} bytes`));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    res.on("end", () => {
+      clearTimeout(timer);
+      resolve({ bodyText: Buffer.concat(chunks).toString("utf-8") });
+    });
+    res.on("error", (err) => {
+      clearTimeout(timer);
+      reject(new ProbeHttpError("socket", err?.message ?? "socket error"));
+    });
+  });
+}
+
+/**
+ * The default §7.5 request: https GET only. DNS-resolves the host FIRST,
+ * refuses every private/reserved result, then pins the connection to the
+ * validated addresses via a custom `lookup` (no rebinding window) while
+ * keeping SNI (`servername`) + the Host header on the hostname. Redirects are
+ * never followed — a 3xx is returned as a status and the runner records a
+ * failure row, so nothing off-list is ever hit.
+ */
+export function defaultHttpRequest({ url, headers = {}, dnsLookup = dns.lookup } = {}) {
+  return new Promise((resolve, reject) => {
+    const parsed = parseProbeUrl(url);
+    if (!parsed) {
+      reject(new ProbeHttpError("bad_url", "probe URL must be https"));
+      return;
+    }
+    dnsLookup(parsed.url.hostname, { all: true, verbatim: true }, (err, results) => {
+      if (err) {
+        reject(new ProbeHttpError("dns_failed", err?.message ?? "dns lookup failed"));
+        return;
+      }
+      const addresses = publicAddresses(results);
+      if (addresses.length === 0) {
+        reject(new ProbeHttpError("dns_private", "probe host resolved only to private/reserved addresses"));
+        return;
+      }
+      let settled = false;
+      const settle = (v) => {
+        if (!settled) {
+          settled = true;
+          resolve(v);
+        }
+      };
+      const fail = (e) => {
+        if (!settled) {
+          settled = true;
+          reject(e);
+        }
+      };
+      const req = https.request(
+        {
+          host: parsed.url.hostname,
+          servername: parsed.url.hostname,
+          path: `${parsed.url.pathname}${parsed.url.search}`,
+          method: "GET",
+          headers: { host: parsed.url.host, ...headers },
+          // Pin the socket to the validated addresses only; SNI + Host keep
+          // the hostname so CDNs and vhosts still route.
+          lookup: (hostname, opts, cb) => {
+            const family = opts?.family === 6 ? 6 : opts?.family === 4 ? 4 : 0;
+            const pick = addresses.find((a) => family === 0 || a.family === family) ?? addresses[0];
+            process.nextTick(() => cb(null, pick.address, pick.family ?? 4));
+          },
+          timeout: PROBE_TIMEOUT_MS,
+        },
+        (res) => {
+          consumeResponse(res)
+            .then((body) => settle({ status: res.statusCode ?? 0, ...body }))
+            .catch(fail);
+        },
+      );
+      req.on("timeout", () => {
+        req.destroy();
+        fail(new ProbeHttpError("timeout", `probe exceeded ${PROBE_TIMEOUT_MS}ms`));
+      });
+      req.on("error", (err) => {
+        fail(new ProbeHttpError("socket", err?.message ?? "request failed"));
+      });
+      req.end();
+    });
+  });
+}
+
+// Classify an on-wire status into the escalation vocabulary. Auth-shaped =
+// 401/403; everything else is a plain failure (health row only).
+export function classifyOutcome(status) {
+  if (status === 401 || status === 403) return "auth";
+  return "fail";
+}
+
+export function classifyError(err) {
+  if (err?.code === "secret_missing") return { outcome: "auth", error: "secret_missing" };
+  return { outcome: "fail", error: err?.code || String(err?.message ?? "unknown").slice(0, 200) };
+}
+
+// ---------------------------------------------------------------------------
+// Hosts from evidence rows (BET-1395 channel shapes)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the exact host from an evidence detail row. Known channel shapes:
+ * `domain:<host>`, `git:<host>[/:…]`, `mcp:<name>:<host>`,
+ * `forge:<host>/<owner>/<repo>`. Secret/cli/webhook/schedule rows carry no
+ * host and never widen the allowlist.
+ */
+export function evidenceHost(detail) {
+  if (typeof detail !== "string") return null;
+  const ok = (h) => (h && HOSTLIKE_RE.test(h) ? h.toLowerCase() : null);
+  if (detail.startsWith("domain:")) return ok(detail.slice("domain:".length));
+  if (detail.startsWith("git:")) return ok(detail.slice("git:".length).split(/[/:]/)[0]);
+  if (detail.startsWith("mcp:")) return ok(detail.split(":")[2]);
+  if (detail.startsWith("forge:")) return ok(detail.slice("forge:".length).split("/")[0]);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// The runner
+// ---------------------------------------------------------------------------
+
+/**
+ * `createProbes(deps)` — injected I/O everywhere; the engine owns the tick.
+ *   registry      — the tool-registry engine (consentFor, toolRow,
+ *                   applyProbeResult, applyRelevance, appendEvidence). Required.
+ *   probes        — YAML spec store (default: the ctoStores one; needs list()).
+ *   stateStore    — per-tool probe state dir store (default probeStateStore).
+ *   cards, ledger — the needs-you cards engine + A1 ledger (both default).
+ *   now           — clock.
+ *   httpRequest   — the §7.5 transport (default: defaultHttpRequest).
+ *   getSecretPath — async (keyName) => path | null (default: the shared
+ *                   provideSecret machinery, usage-recording suppressed).
+ *   readSecret    — async (path) => string (default fs.readFile utf-8).
+ *   isThrifty     — () => boolean (live engine thrifty flag).
+ *   listProjects  — async () => [projectName] (active projects for §7.6).
+ *   getTopFacts   — async (project, k) => [{statement}].
+ *   getRollups    — async (project) => string lines (recent rollup facts).
+ *   runEphemeral  — the pre-gated ephemeral session call (nano classify).
+ */
+export function createProbes(deps = {}) {
+  const {
+    registry,
+    probes = probesStore,
+    stateStore = probeStateStore,
+    cards,
+    ledger,
+    now = () => Date.now(),
+    httpRequest = defaultHttpRequest,
+    // Default: the shared provideSecret machinery, BY REFERENCE, with usage
+    // recording suppressed — a probe provide must never inflate the tool's
+    // own engagement axis (that would make the registry a feedback loop of
+    // its runner). Only shared/global secrets resolve without a session.
+    getSecretPath = async (key) => {
+      const r = await provideSecret({ key }, { recordUsage: async () => {} });
+      return r?.ok ? r.path : null;
+    },
+    readSecret = (path) => readFile(path, "utf-8"),
+    isThrifty = () => false,
+    listProjects = async () => [],
+    getTopFacts = async () => [],
+    getRollups = async () => "",
+    runEphemeral,
+  } = deps;
+  if (!registry || typeof registry.consentFor !== "function" || typeof registry.applyProbeResult !== "function") {
+    throw new Error("createProbes requires a tool registry with consentFor() + applyProbeResult()");
+  }
+
+  const state = stateStore;
+
+  function probeKey(tool, probeName) {
+    return `${tool}/${probeName}`;
+  }
+
+  async function loadToolState(tool) {
+    try {
+      const payload = await state.load(tool);
+      return payload && typeof payload === "object" ? payload : {};
+    } catch {
+      return {};
+    }
+  }
+
+  async function saveToolState(tool, payload) {
+    try {
+      await state.save(tool, payload);
+    } catch {
+      /* state persistence is best-effort; the run continues */
+    }
+  }
+
+  // Open probe-failure blocker ids (thrifty exemption: probes backing an open
+  // card keep running so the card's liveness predicate can resolve).
+  async function openProbeBlockers() {
+    if (!cards || typeof cards.listOpen !== "function") return new Set();
+    try {
+      const open = await cards.listOpen();
+      return new Set(
+        (open ?? [])
+          .filter((c) => c?.sourceKind === PROBE_SOURCE_KIND && typeof c?.sourceId === "string")
+          .map((c) => c.sourceId),
+      );
+    } catch {
+      return new Set();
+    }
+  }
+
+  // Consent + host allowlist for one tool, straight from the registry.
+  async function consentContext(tool) {
+    const row = await registry.toolRow(tool);
+    let consentedRing = null;
+    if ((await registry.consentFor(tool, "metadata")) === "yes") consentedRing = "metadata";
+    if (consentedRing && (await registry.consentFor(tool, "deep_read")) === "yes") consentedRing = "deep_read";
+    const hosts = new Set();
+    for (const e of row?.evidence ?? []) {
+      const host = evidenceHost(e?.detail);
+      if (host) hosts.add(host);
+    }
+    return { consentedRing, allowedHosts: [...hosts], row };
+  }
+
+  async function validSpecFor(tool) {
+    let raw;
+    try {
+      raw = await probes.load(tool);
+    } catch {
+      return null;
+    }
+    if (!raw || typeof raw !== "object") return null;
+    const ctx = await consentContext(tool);
+    const check = validateProbeSpec(raw, { tool, allowedHosts: ctx.allowedHosts, consentedRing: ctx.consentedRing });
+    return check.ok ? { spec: raw, ctx } : null;
+  }
+
+  // ---- spec authoring (engine-written; the AI's content goes through here) —
+
+  /** Write the §7.5 template for a tool at consent time. Never overwrites. */
+  async function scaffoldSpec(tool, { secret = null } = {}) {
+    let existing = null;
+    try {
+      existing = await probes.load(tool);
+    } catch {
+      existing = null; // no spec yet (the common consent-time case)
+    }
+    if (existing && typeof existing === "object" && (existing.tool || Array.isArray(existing.probes))) {
+      return { changed: false };
+    }
+    const spec = { tool, probes: [] };
+    // A credential is already evidenced for this tool → pre-fill the auth
+    // template (key NAME only; the header template is the common default the
+    // AI may adjust — a wrong one fails 401 into the §10.6-7 card path).
+    if (secret && SECRET_KEY_RE.test(secret)) {
+      spec.auth = { secret, header: `Authorization: Bearer ${SECRET_PLACEHOLDER}` };
+    }
+    await probes.save(tool, spec);
+    return { changed: true };
+  }
+
+  /**
+   * The ONE write path for probe specs (AI-authored, engine-written): the
+   * candidate content is validated against the tool's CURRENT consent ring +
+   * evidence hosts before a byte lands on disk; invalid content is refused
+   * with the error catalogue.
+   */
+  async function writeSpec(tool, candidate) {
+    const ctx = await consentContext(tool);
+    const check = validateProbeSpec(candidate, { tool, allowedHosts: ctx.allowedHosts, consentedRing: ctx.consentedRing });
+    if (!check.ok) return { ok: false, errors: check.errors };
+    await probes.save(tool, candidate);
+    return { ok: true, errors: [] };
+  }
+
+  // ---- one probe execution -------------------------------------------------
+
+  // Resolve the secret AT SPAWN, by reference: vault KEY NAME → materialized
+  // file path → read inside this closure only. Usage is deliberately NOT
+  // recorded (provideSecret with a no-op recorder) so the runner can never
+  // inflate the tool's own engagement axis.
+  async function buildHeaders(specAuth) {
+    if (!specAuth) return {};
+    let path = null;
+    if (typeof getSecretPath === "function") {
+      path = await getSecretPath(specAuth.secret);
+    }
+    if (!path) {
+      throw new ProbeHttpError("secret_missing", `secret "${specAuth.secret}" is not available`);
+    }
+    const value = (await readSecret(path)).trim();
+    if (!value) throw new ProbeHttpError("secret_missing", `secret "${specAuth.secret}" materialized empty`);
+    const idx = specAuth.header.indexOf(":");
+    const name = specAuth.header.slice(0, idx).trim();
+    const template = specAuth.header.slice(idx + 1).trim();
+    // Function replacement: a secret containing `$&`-style sequences must
+    // land verbatim.
+    const value_ = template.replace(SECRET_PLACEHOLDER_RE, () => value);
+    return { [name]: value_ };
+  }
+
+  async function runOne(tool, spec, probe, st, { ts = now() } = {}) {
+    const startedAt = ts;
+    let status = 0;
+    let bodyText = null;
+    let error = null;
+    let outcome = "fail";
+    try {
+      const headers = await buildHeaders(spec.auth);
+      const out = await httpRequest({ url: probe.url, headers });
+      status = out.status;
+      bodyText = out.bodyText;
+      outcome = classifyOutcome(status);
+      if (!(status >= 200 && status < 300)) error = `http_${status}`;
+    } catch (err) {
+      const c = classifyError(err);
+      outcome = c.outcome;
+      error = c.error;
+    }
+
+    const ok = outcome === "fail" && status >= 200 && status < 300 && error === null;
+    let fields = {};
+    if (ok && bodyText !== null) {
+      const ex = extractFields(bodyText, probe.extract);
+      if (ex.ok) fields = ex.fields;
+    }
+    bodyText = null; // untrusted raw body never persists
+
+    const key = probe.name;
+    const prev = st?.probes?.[key] ?? { fails: 0, authFails: 0, cardOpen: false };
+    const { state: nextState, action } = stepFailureState(prev, ok ? "success" : outcome);
+
+    const row = {
+      kind: "cto.probe.result",
+      tool,
+      probe: probeKey(tool, key),
+      ok,
+      status,
+      durMs: Math.max(0, now() - startedAt),
+      ...(ok ? { fields: pruneFields(fields) } : { error: error ?? "unknown" }),
+      ts,
+    };
+    if (ledger && typeof ledger.append === "function") {
+      try {
+        await ledger.append({ actor: "cto", ...row });
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    const vit = registry.toolRow ? await registry.toolRow(tool) : null;
+    const cadence = effectiveCadenceMs(cadenceMs(probe.cadence), vit?.vitality);
+
+    if (ok) {
+      // Vitality + adaptive cadence + lifecycle (§7.3, §7.4).
+      try {
+        await registry.applyProbeResult(tool, { fields, probedAt: ts, cadenceMs: cadence, probeName: key });
+      } catch {
+        /* vitality is best-effort */
+      }
+    } else {
+      // Failure evidence on the registry row (the connect-ask evidence trail).
+      try {
+        await registry.appendEvidence?.(tool, { channel: "probe", detail: `${key}:${error ?? status}`, ts });
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    // Escalation / resolution (§10.6-7) — nextState already carries cardOpen.
+    const p = st.probes ?? {};
+    p[key] = {
+      ...nextState,
+      lastAt: ts,
+      lastOk: ok,
+      lastError: ok ? null : (error ?? "unknown"),
+      lastStatus: status,
+      nextRunAt: ts + cadence,
+    };
+    st.probes = p;
+    if (action === "escalate" && cards && typeof cards.upsertBlocker === "function") {
+      const copy = probeBlockerCopy(tool, key, spec.auth?.secret ?? null);
+      await cards
+        .upsertBlocker({
+          sourceKind: PROBE_SOURCE_KIND,
+          sourceId: probeKey(tool, key),
+          title: copy.title,
+          body: copy.body,
+          refs: [tool],
+          ts,
+        })
+        .catch(() => {});
+    } else if (action === "resolve" && cards && typeof cards.resolveById === "function") {
+      await cards.resolveById(stableCardId(PROBE_SOURCE_KIND, probeKey(tool, key)), { reason: "probe recovered", ts }).catch(() => {});
+    }
+    await saveToolState(tool, st);
+    return row;
+  }
+
+  // Keep only the tiny extracted fields in ledger rows — the extract map is
+  // authored content, so cap every value defensively.
+  function pruneFields(fields) {
+    const out = {};
+    for (const [k, v] of Object.entries(fields ?? {})) {
+      if (v === undefined || v === null) continue;
+      const s = typeof v === "object" ? JSON.stringify(v) : v;
+      out[k] = typeof s === "string" && s.length > 256 ? `${s.slice(0, 253)}...` : s;
+    }
+    return out;
+  }
+
+  // ---- §10.5 A12 probe-health read ------------------------------------------
+
+  // One snapshot over the CONSENTED tools' valid specs: how many probes are
+  // configured, how many reported healthy on their last run, how many are in
+  // the auth-failure state (their §10.6-7 card is the escalation), and when
+  // the most recent run happened. Pure read — the endpoint composes the row.
+  async function healthSnapshot() {
+    const out = { tools: 0, probes: 0, healthy: 0, authFailed: 0, lastRunAt: null };
+    let tools;
+    try {
+      tools = await probes.list();
+    } catch {
+      return out;
+    }
+    for (const tool of tools) {
+      const valid = await validSpecFor(tool);
+      if (!valid) continue;
+      out.tools += 1;
+      const st = await loadToolState(tool);
+      for (const probe of valid.spec.probes) {
+        out.probes += 1;
+        const pst = st.probes?.[probe.name];
+        if (!pst) continue; // never ran yet — counts toward n, not healthy
+        if (typeof pst.lastAt === "number" && (out.lastRunAt == null || pst.lastAt > out.lastRunAt)) {
+          out.lastRunAt = pst.lastAt;
+        }
+        if (pst.lastOk) out.healthy += 1;
+        else if (pst.lastError === "secret_missing" || pst.lastStatus === 401 || pst.lastStatus === 403) {
+          out.authFailed += 1;
+        }
+      }
+    }
+    return out;
+  }
+
+  // ---- the tick ------------------------------------------------------------
+
+  /**
+   * Run every due probe across every consented tool. `opts.forceTool` runs
+   * one tool's probes regardless of nextRunAt (diagnostics/tests). Thrifty
+   * sheds non-blocker-relevant probes (§12.2 rung 2).
+   */
+  async function runDue({ forceTool = null, ts = now() } = {}) {
+    const results = [];
+    let tools;
+    try {
+      tools = await probes.list();
+    } catch {
+      return results;
+    }
+    const exempt = await openProbeBlockers();
+    const thrifty = isThrifty() === true;
+    for (const tool of tools) {
+      if (forceTool && tool !== forceTool) continue;
+      const valid = await validSpecFor(tool);
+      if (!valid) continue;
+      const { spec } = valid;
+      const st = await loadToolState(tool);
+      if (!st.probes || typeof st.probes !== "object") st.probes = {};
+      let touched = false;
+      for (const probe of spec.probes) {
+        const pst = st.probes[probe.name] ?? {};
+        const due =
+          forceTool === tool ||
+          pst.nextRunAt === undefined ||
+          (typeof pst.nextRunAt === "number" && pst.nextRunAt <= ts);
+        if (!due) continue;
+        if (thrifty && !exempt.has(probeKey(tool, probe.name))) continue;
+        results.push(await runOne(tool, spec, probe, st, { ts }));
+        touched = true;
+      }
+      if (touched) await saveToolState(tool, st);
+    }
+    return results;
+  }
+
+  // ---- §7.6 relevance (scoring half only) -----------------------------------
+
+  function dayKeyOf(ts) {
+    const d = new Date(ts);
+    return `${d.getUTCFullYear()}-${d.getUTCMonth()}-${d.getUTCDate()}`;
+  }
+
+  /**
+   * Weekly per consented tool × active project: one nano call matching the
+   * tool's data domain against the project's top facts + recent rollups →
+   * `relevance[project] ∈ [0,1]`. Paced at RELEVANCE_PER_DAY calls/day.
+   */
+  async function relevanceScan({ ts = now(), todayKey = dayKeyOf(ts) } = {}) {
+    if (typeof runEphemeral !== "function") return { ran: 0, skipped: "no-ephemeral" };
+    let tools;
+    try {
+      tools = await probes.list();
+    } catch {
+      return { ran: 0 };
+    }
+    let projects = [];
+    try {
+      projects = (await listProjects()) ?? [];
+    } catch {
+      projects = [];
+    }
+    if (tools.length === 0 || projects.length === 0) return { ran: 0 };
+    let st;
+    try {
+      st = (await state.load("_relevance")) ?? {};
+    } catch {
+      st = {};
+    }
+    if (st.day !== todayKey) {
+      st.day = todayKey;
+      st.todayCount = 0;
+    }
+    let budget = RELEVANCE_PER_DAY - (st.todayCount ?? 0);
+    let ran = 0;
+    for (const tool of tools) {
+      if (budget <= 0) break;
+      if ((await registry.consentFor(tool, "metadata")) !== "yes") continue;
+      const valid = await validSpecFor(tool);
+      if (!valid) continue;
+      const row = valid.ctx.row ?? (await registry.toolRow(tool));
+      const relAt = st.relAt?.[tool] ?? {};
+      const domain = toolDomain(row);
+      let toolTouched = false;
+      for (const project of projects) {
+        if (budget <= 0) break;
+        if (typeof relAt[project] === "number" && ts - relAt[project] < RELEVANCE_WEEK_MS) continue;
+        const facts = await getTopFacts(project, 5).catch(() => []);
+        const rollups = await getRollups(project).catch(() => "");
+        if (!factLines(facts) && !rollupLines(rollups)) {
+          relAt[project] = ts; // nothing to match against — do not retry all week
+          toolTouched = true;
+          continue;
+        }
+        const score = await scoreRelevance({ tool, domain, project, facts, rollups });
+        if (score === null) continue; // model/parse failure → retry next scan
+        relAt[project] = ts;
+        budget -= 1;
+        ran += 1;
+        toolTouched = true;
+        try {
+          await registry.applyRelevance(tool, project, score);
+        } catch {
+          /* best-effort */
+        }
+        if (ledger && typeof ledger.append === "function") {
+          await ledger
+            .append({ actor: "cto", kind: "cto.tool.relevance", tool, project, relevance: score, ts })
+            .catch(() => {});
+        }
+      }
+      st.relAt = { ...(st.relAt ?? {}), [tool]: relAt };
+      if (toolTouched) await saveToolState("_relevance", st);
+    }
+    if (ran > 0) {
+      st.todayCount = (st.todayCount ?? 0) + ran;
+      await saveToolState("_relevance", st);
+    }
+    return { ran };
+  }
+
+  function factLines(facts) {
+    return (facts ?? [])
+      .map((f) => (typeof f?.statement === "string" && f.statement ? f.statement : typeof f?.text === "string" ? f.text : ""))
+      .filter(Boolean)
+      .slice(0, 5)
+      .map((s) => `- ${s}`)
+      .join("\n");
+  }
+
+  function rollupLines(rollups) {
+    return String(rollups ?? "")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .slice(0, 5)
+      .join("\n");
+  }
+
+  function toolDomain(row) {
+    const parts = [];
+    for (const e of row?.evidence ?? []) {
+      if (typeof e?.detail === "string") parts.push(e.detail.split(":").slice(1).join(":"));
+    }
+    return parts.slice(0, 5).join(", ") || row?.tool || "external data";
+  }
+
+  // One nano call (§7.6): the tool's data domain vs the project's facts +
+  // recent rollups → [0,1]. Untrusted context, structured-only output.
+  async function scoreRelevance({ tool, domain, project, facts, rollups }) {
+    const prompt = [
+      `Tool "${tool}" provides external data (evidence: ${domain}).`,
+      `Project "${project}" blackboard facts:`,
+      factLines(facts) || "(none)",
+      rollupLines(rollups) ? `Recent rollups:\n${rollupLines(rollups)}` : "",
+      "",
+      "Score how relevant this tool's data domain is to the project's active work: 0.0 (unrelated) to 1.0 (core data source for this work).",
+      "Reply with ONLY the number.",
+    ]
+      .filter(Boolean)
+      .join("\n");
+    let text = null;
+    try {
+      const out = await runEphemeral({ taskClass: RELEVANCE_TASK_CLASS, context: [{ priority: 10, text: prompt }] });
+      text = typeof out === "string" ? out : (out?.text ?? out?.output ?? null);
+    } catch {
+      return null;
+    }
+    const m = /(\d*\.?\d+)/.exec(String(text ?? ""));
+    if (!m) return null;
+    const n = Number(m[1]);
+    if (!Number.isFinite(n)) return null;
+    // The prompt asks for 0..1; an out-of-range reply means "very relevant" —
+    // clamp, never fabricate a mid-scale number.
+    return Math.max(0, Math.min(1, n));
+  }
+
+  return { scaffoldSpec, writeSpec, runDue, relevanceScan, healthSnapshot, probeKey, consentContext, loadToolState };
+}

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -1,0 +1,905 @@
+// ctoProbes.test.mjs — BET-1396 (§7.5 probe runner, §7.3 vitality, §7.6
+// relevance, §10.6-7 escalation). Pure over injected fakes: no live network,
+// no secrets vault, no registry store (AGENTS.md server rule).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  AUTH_FAIL_ESCALATE,
+  CADENCE_DAILY_MS,
+  CADENCE_FLOOR_MS,
+  CADENCE_WEEKLY_MS,
+  RESPONSE_CAP_BYTES,
+  classifyError,
+  classifyOutcome,
+  consumeResponse,
+  cadenceMs,
+  createProbes,
+  defaultHttpRequest,
+  effectiveCadenceMs,
+  evidenceHost,
+  extractFields,
+  hostAllowed,
+  isPrivateAddress,
+  parseProbeUrl,
+  publicAddresses,
+  stepFailureState,
+  validateProbeSpec,
+  vitalityOf,
+} from "./ctoProbes.mjs";
+import { PROBE_SOURCE_KIND, probeBlockerCopy, stableCardId } from "./ctoCards.mjs";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+function memProbesStore(initial = {}) {
+  const files = { ...initial };
+  return {
+    list: async () => Object.keys(files),
+    load: async (tool) => {
+      const v = files[tool];
+      if (v === undefined) throw new Error(`missing ${tool}`);
+      return JSON.parse(JSON.stringify(v));
+    },
+    save: async (tool, spec) => {
+      files[tool] = JSON.parse(JSON.stringify(spec));
+    },
+    _files: files,
+  };
+}
+
+function memStateStore(initial = {}) {
+  const files = { ...initial };
+  return {
+    list: async () => Object.keys(files),
+    load: async (tool) => {
+      const v = files[tool];
+      return v === undefined ? {} : JSON.parse(JSON.stringify(v));
+    },
+    save: async (tool, payload) => {
+      files[tool] = JSON.parse(JSON.stringify(payload));
+    },
+    _files: files,
+  };
+}
+
+function fakeRegistry(rows = []) {
+  const byTool = new Map(rows.map((r) => [r.tool, r]));
+  return {
+    consentFor: async (tool, ring = "metadata") => byTool.get(tool)?.consent?.[ring] ?? null,
+    toolRow: async (tool) => byTool.get(tool) ?? null,
+    async applyProbeResult(tool, input) {
+      const t = byTool.get(tool);
+      if (!t) return { ok: false };
+      (t._probeCalls = t._probeCalls ?? []).push(input);
+      // minimal mirror of the registry's real vitality fold (the registry's
+      // own math is exercised in its dedicated tests below)
+      t.vitality = { ...(t.vitality ?? {}), last_probed: input.probedAt };
+      return { ok: true };
+    },
+    async applyRelevance(tool, project, score) {
+      const t = byTool.get(tool);
+      if (!t) return { ok: false };
+      t.relevance = { ...(t.relevance ?? {}), [project]: score };
+      return { ok: true };
+    },
+    async appendEvidence(tool, entry) {
+      const t = byTool.get(tool);
+      if (!t) return { ok: false };
+      t.evidence = [...(t.evidence ?? []), entry];
+      return { ok: true };
+    },
+    _rows: byTool,
+  };
+}
+
+function fakeCards() {
+  const upserts = [];
+  const resolved = [];
+  const open = [];
+  return {
+    open,
+    upserts,
+    resolved,
+    async upsertBlocker(input) {
+      upserts.push(input);
+      open.push({ id: stableCardId(input.sourceKind, input.sourceId), ...input, variant: "blocker", state: "open" });
+      return { changed: true, isNew: true };
+    },
+    async listOpen() {
+      return [...open];
+    },
+    async resolveById(id, opts = {}) {
+      const idx = open.findIndex((c) => c.id === id);
+      if (idx < 0) return { changed: false };
+      open.splice(idx, 1);
+      resolved.push({ id, reason: opts.reason });
+      return { changed: true };
+    },
+  };
+}
+
+function fakeLedger() {
+  const rows = [];
+  return {
+    rows,
+    async append(entry) {
+      rows.push(entry);
+    },
+  };
+}
+
+// A valid consented tool row with evidenced hosts + a secret.
+function consentedTool(tool = "github", hosts = ["api.github.com"]) {
+  return {
+    tool,
+    status: "candidate",
+    consent: { metadata: "yes", deep_read: null, write: null },
+    evidence: [
+      ...hosts.map((h) => ({ channel: "config", detail: `git:${h}`, ts: 1 })),
+      { channel: "secret", detail: "secret:GITHUB_TOKEN", ts: 1 },
+    ],
+  };
+}
+
+function githubSpec(overrides = {}) {
+  return {
+    tool: "github",
+    auth: { secret: "GITHUB_TOKEN", header: "Authorization: Bearer {secret}" },
+    probes: [
+      {
+        name: "repo_events",
+        method: "GET",
+        url: "https://api.github.com/users/octocat/events",
+        extract: { last_event: "0.created_at", inflow_rate: "length" },
+        cadence: "30m",
+        ring: "metadata",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function build({ rows, specs, state, cards, ledger, http, now, thrifty, runEphemeral, projects, getTopFacts, getRollups } = {}) {
+  return createProbes({
+    registry: fakeRegistry(rows ?? [consentedTool()]),
+    probes: memProbesStore(specs ?? { github: githubSpec() }),
+    stateStore: memStateStore(state),
+    cards: cards ?? fakeCards(),
+    ledger: ledger ?? fakeLedger(),
+    now: now ?? (() => 1_700_000_000_000),
+    httpRequest: http ?? (async () => ({ status: 200, bodyText: JSON.stringify([{ created_at: "2026-08-20T00:00:00Z" }]) })),
+    getSecretPath: async () => "/tmp/secret-file",
+    readSecret: async () => "sekrit-value",
+    isThrifty: thrifty ?? (() => false),
+    listProjects: async () => projects ?? ["proj"],
+    getTopFacts: getTopFacts ?? (async () => [{ statement: "ships the parser" }]),
+    getRollups: getRollups ?? (async () => "did a thing"),
+    runEphemeral: runEphemeral ?? null,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// §7.5 validator — every violation fails BY NAME
+// ---------------------------------------------------------------------------
+
+test("validateProbeSpec: valid spec passes", () => {
+  const r = validateProbeSpec(githubSpec(), {
+    tool: "github",
+    allowedHosts: ["api.github.com"],
+    consentedRing: "metadata",
+  });
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+});
+
+test("validateProbeSpec: unknown top-level key fails by name", () => {
+  const r = validateProbeSpec({ ...githubSpec(), extras: 1 }, { tool: "github" });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "extras" && e.message.includes('"extras"')));
+});
+
+test("validateProbeSpec: non-GET method fails by name", () => {
+  const spec = githubSpec();
+  spec.probes[0].method = "POST";
+  const r = validateProbeSpec(spec, { tool: "github" });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "probes[0].method" && e.message.includes("POST")));
+});
+
+test("validateProbeSpec: off-allowlist host fails by name", () => {
+  const spec = githubSpec();
+  spec.probes[0].url = "https://evil.example.com/x";
+  const r = validateProbeSpec(spec, { tool: "github", allowedHosts: ["api.github.com"] });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "probes[0].url" && e.message.includes("evil.example.com")));
+});
+
+test("validateProbeSpec: ring escalation fails by name; write ring is not even a legal value", () => {
+  const spec = githubSpec();
+  spec.probes[0].ring = "deep_read";
+  let r = validateProbeSpec(spec, { tool: "github", consentedRing: "metadata" });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "probes[0].ring"));
+  spec.probes[0].ring = "write";
+  r = validateProbeSpec(spec, { tool: "github", consentedRing: "deep_read" });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "probes[0].ring" && e.message.includes("deep_read")));
+});
+
+test("validateProbeSpec: deep_read consent admits a deep_read probe", () => {
+  const spec = githubSpec();
+  spec.probes[0].ring = "deep_read";
+  const r = validateProbeSpec(spec, { tool: "github", allowedHosts: ["api.github.com"], consentedRing: "deep_read" });
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+});
+
+test("validateProbeSpec: sub-5m cadence fails by name", () => {
+  const spec = githubSpec();
+  spec.probes[0].cadence = "4m";
+  const r = validateProbeSpec(spec, { tool: "github", allowedHosts: ["api.github.com"], consentedRing: "metadata" });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "probes[0].cadence" && e.message.includes("5m floor")));
+});
+
+test("validateProbeSpec: auth template must hold exactly one {secret}; secret must be a KEY NAME", () => {
+  const spec = githubSpec();
+  spec.auth = { secret: "GITHUB_TOKEN", header: "Authorization: Bearer" };
+  let r = validateProbeSpec(spec, { tool: "github" });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "auth.header"));
+  spec.auth = { secret: "hunter2", header: "Authorization: Bearer {secret}" };
+  r = validateProbeSpec(spec, { tool: "github" });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "auth.secret"));
+});
+
+test("validateProbeSpec: tool mismatch fails by name", () => {
+  const r = validateProbeSpec(githubSpec({ tool: "gitlab" }), { tool: "github" });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "tool"));
+});
+
+// ---------------------------------------------------------------------------
+// Pure predicates — SSRF catalogue
+// ---------------------------------------------------------------------------
+
+test("parseProbeUrl: https only, no userinfo, bounded length", () => {
+  assert.equal(parseProbeUrl("http://api.github.com/x"), null);
+  assert.equal(parseProbeUrl("https://user:pass@api.github.com/"), null);
+  assert.equal(parseProbeUrl(`https://a.com/${"x".repeat(2100)}`), null);
+  const ok = parseProbeUrl("https://api.github.com/x?y=1");
+  assert.equal(ok.host, "api.github.com");
+});
+
+test("hostAllowed: exact host, case-insensitive, no subdomain forgiveness", () => {
+  assert.equal(hostAllowed("api.github.com", ["api.github.com"]), true);
+  assert.equal(hostAllowed("API.GitHub.com", ["api.github.com"]), true);
+  assert.equal(hostAllowed("evil-api.github.com", ["api.github.com"]), false);
+  assert.equal(hostAllowed("api.github.com.evil.com", ["api.github.com"]), false);
+  assert.equal(hostAllowed("github.com", ["api.github.com"]), false);
+});
+
+test("isPrivateAddress: the whole catalogue is rejected", () => {
+  for (const a of [
+    "127.0.0.1", "127.255.1.1", "10.1.2.3", "172.16.0.1", "172.31.255.255",
+    "192.168.1.1", "0.0.0.0", "169.254.169.254", "100.64.0.1", "224.0.0.1",
+    "240.0.0.1", "255.255.255.255", "::1", "::", "::ffff:127.0.0.1",
+    "::ffff:10.0.0.1", "::ffff:169.254.169.254", "fc00::1", "fd12::1",
+    "fe80::1", "ff02::1", "garbage", "", null,
+  ]) {
+    assert.equal(isPrivateAddress(a), true, `${a} must be private`);
+  }
+  for (const a of ["93.184.216.34", "2606:4700::6810:85e5", "2606:4700:4700::1111"]) {
+    assert.equal(isPrivateAddress(a), false, `${a} must be public`);
+  }
+});
+
+test("publicAddresses: keeps only connectable results", () => {
+  const kept = publicAddresses([
+    { address: "93.184.216.34", family: 4 },
+    { address: "127.0.0.1", family: 4 },
+    { address: "2606:4700::1111", family: 6 },
+  ]);
+  assert.deepEqual(kept.map((k) => k.address), ["93.184.216.34", "2606:4700::1111"]);
+  assert.deepEqual(publicAddresses(null), []);
+});
+
+test("defaultHttpRequest: rejects non-https and private-only DNS before any socket", async () => {
+  await assert.rejects(
+    defaultHttpRequest({ url: "http://api.github.com/x" }),
+    (e) => e.code === "bad_url",
+  );
+  await assert.rejects(
+    defaultHttpRequest({ url: "https://internal.corp/x", dnsLookup: (h, o, cb) => cb(null, [{ address: "10.0.0.5", family: 4 }]) }),
+    (e) => e.code === "dns_private",
+  );
+  await assert.rejects(
+    defaultHttpRequest({ url: "https://dead.dns/x", dnsLookup: (h, o, cb) => cb(new Error("nx")) }),
+    (e) => e.code === "dns_failed",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// consumeResponse — 256 KB cap + 10 s timeout on a real stream
+// ---------------------------------------------------------------------------
+
+test("consumeResponse: caps oversized bodies (too_large)", async () => {
+  const s = new PassThrough();
+  const p = consumeResponse(s, { maxBytes: 1024, timeoutMs: 5_000 });
+  const big = Buffer.alloc(2048, 0x61);
+  s.write(big);
+  await assert.rejects(p, (e) => e.code === "too_large");
+});
+
+test("consumeResponse: times out a stalled stream", async () => {
+  const s = new PassThrough();
+  const p = consumeResponse(s, { maxBytes: RESPONSE_CAP_BYTES, timeoutMs: 50 });
+  await assert.rejects(p, (e) => e.code === "timeout");
+});
+
+test("consumeResponse: resolves a normal body", async () => {
+  const s = new PassThrough();
+  const p = consumeResponse(s, { maxBytes: RESPONSE_CAP_BYTES, timeoutMs: 5_000 });
+  s.end('{"ok":true}');
+  const r = await p;
+  assert.equal(r.bodyText, '{"ok":true}');
+});
+
+test("consumeResponse: a slow-but-under-timeout body survives a 250ms stall", async () => {
+  const s = new PassThrough();
+  const p = consumeResponse(s, { maxBytes: RESPONSE_CAP_BYTES, timeoutMs: 2_000 });
+  await delay(250);
+  s.end("late");
+  assert.equal((await p).bodyText, "late");
+});
+
+// ---------------------------------------------------------------------------
+// Extraction + vitality helpers
+// ---------------------------------------------------------------------------
+
+test("extractFields: dot paths, indexes, length; non-JSON body reports ok:false", () => {
+  const body = JSON.stringify({ items: [{ created_at: "2026-08-20T00:00:00Z" }, { created_at: "x" }], meta: { total: 7 } });
+  const r = extractFields(body, { last_event: "items.0.created_at", inflow_rate: "items.length", total: "meta.total", missing: "nope.deep" });
+  assert.deepEqual(r.fields, { last_event: "2026-08-20T00:00:00Z", inflow_rate: 2, total: 7, missing: null });
+  assert.equal(extractFields("not json", { a: "b" }).ok, false);
+  assert.deepEqual(extractFields(body, null).fields, {});
+});
+
+test("vitalityOf: only the §7.2 well-known pair survives, only well-typed", () => {
+  assert.deepEqual(vitalityOf({ last_event: "2026-08-20T00:00:00Z", inflow_rate: 3, junk: "x" }), {
+    last_event: "2026-08-20T00:00:00Z",
+    inflow_rate: 3,
+  });
+  assert.deepEqual(vitalityOf({ inflow_rate: "3" }), {});
+  assert.deepEqual(vitalityOf({}), {});
+});
+
+// ---------------------------------------------------------------------------
+// Adaptive cadence (§7.3 daily ↔ weekly)
+// ---------------------------------------------------------------------------
+
+test("effectiveCadenceMs: spec cadence unclamped until a vitality sample exists", () => {
+  const spec = 6 * 3_600_000; // 6h
+  assert.equal(effectiveCadenceMs(spec, null), spec);
+  assert.equal(effectiveCadenceMs(spec, {}), spec);
+  assert.equal(effectiveCadenceMs(spec, { ewma: null }), spec);
+});
+
+test("effectiveCadenceMs: observed inflow accelerates slow specs toward daily; silence stretches toward weekly", () => {
+  // a slower-than-daily spec accelerates to daily on inflow
+  assert.equal(effectiveCadenceMs(7 * 24 * 3_600_000, { ewma: 0.5 }), CADENCE_DAILY_MS);
+  // a spec already faster than daily is HONORED (§7.5: the runner honors the
+  // declared cadence exactly — the band only accelerates, never slows)
+  assert.equal(effectiveCadenceMs(6 * 3_600_000, { ewma: 0.5 }), 6 * 3_600_000);
+  assert.equal(effectiveCadenceMs(30 * 60_000, { ewma: 2 }), 30 * 60_000);
+  // observed silence stretches to weekly, even past a slower spec
+  assert.equal(effectiveCadenceMs(6 * 3_600_000, { ewma: 0 }), CADENCE_WEEKLY_MS);
+  assert.equal(effectiveCadenceMs(14 * CADENCE_DAILY_MS, { ewma: 0 }), 14 * CADENCE_DAILY_MS);
+  // the 5m floor always holds
+  assert.equal(effectiveCadenceMs(null, null), CADENCE_FLOOR_MS);
+});
+
+test("cadenceMs: parses the grammar", () => {
+  assert.equal(cadenceMs("30m"), 30 * 60_000);
+  assert.equal(cadenceMs("1h"), 3_600_000);
+  assert.equal(cadenceMs("7d"), CADENCE_WEEKLY_MS);
+  assert.equal(cadenceMs("nope"), null);
+});
+
+// ---------------------------------------------------------------------------
+// Escalation state machine (§10.6-7)
+// ---------------------------------------------------------------------------
+
+test("stepFailureState: 3 consecutive auth failures escalate exactly once; success resolves", () => {
+  let st = null;
+  let actions = [];
+  for (let i = 0; i < AUTH_FAIL_ESCALATE; i++) {
+    const r = stepFailureState(st, "auth");
+    st = r.state;
+    actions.push(r.action);
+  }
+  assert.deepEqual(actions, [null, null, "escalate"]);
+  // a 4th auth failure with the card already open does NOT re-escalate
+  assert.equal(stepFailureState(st, "auth").action, null);
+  // success resolves
+  const ok = stepFailureState(st, "success");
+  assert.equal(ok.action, "resolve");
+  assert.equal(ok.state.fails, 0);
+  assert.equal(ok.state.authFails, 0);
+  // a clean success with no card resolves nothing
+  assert.equal(stepFailureState(ok.state, "success").action, null);
+});
+
+test("stepFailureState: non-auth failure resets the auth streak but keeps the fail streak", () => {
+  let r = stepFailureState(null, "auth");
+  r = stepFailureState(r.state, "auth");
+  r = stepFailureState(r.state, "fail");
+  assert.equal(r.state.fails, 3);
+  assert.equal(r.state.authFails, 0);
+  // two more auth failures do NOT escalate (streak restarted at the 500)
+  r = stepFailureState(r.state, "auth");
+  r = stepFailureState(r.state, "auth");
+  assert.equal(r.action, null);
+  r = stepFailureState(r.state, "auth");
+  assert.equal(r.action, "escalate");
+});
+
+test("classifyOutcome/classifyError: 401/403 + secret_missing are auth-shaped", () => {
+  assert.equal(classifyOutcome(401), "auth");
+  assert.equal(classifyOutcome(403), "auth");
+  assert.equal(classifyOutcome(200), "fail");
+  assert.equal(classifyOutcome(500), "fail");
+  assert.deepEqual(classifyError({ code: "secret_missing" }), { outcome: "auth", error: "secret_missing" });
+  assert.deepEqual(classifyError({ code: "timeout" }).outcome, "fail");
+});
+
+// ---------------------------------------------------------------------------
+// Evidence hosts (§7.5 allowlist source)
+// ---------------------------------------------------------------------------
+
+test("evidenceHost: reads the BET-1395 channel shapes; secrets/webhooks never widen the list", () => {
+  assert.equal(evidenceHost("domain:api.github.com"), "api.github.com");
+  assert.equal(evidenceHost("git:github.com/antoinedc/MantaUI.git"), "github.com");
+  assert.equal(evidenceHost("mcp:github:api.github.com"), "api.github.com");
+  assert.equal(evidenceHost("forge:github.com/a/b.yaml"), "github.com");
+  assert.equal(evidenceHost("secret:GITHUB_TOKEN"), null);
+  assert.equal(evidenceHost("webhook:my hook"), null);
+  assert.equal(evidenceHost("schedule:nightly"), null);
+  assert.equal(evidenceHost("cli:some-token"), null);
+});
+
+// ---------------------------------------------------------------------------
+// The runner end-to-end (injected fakes)
+// ---------------------------------------------------------------------------
+
+test("runDue: executes a due probe, ledger row is evidence-shaped, vitality + status flip happen", async () => {
+  const rows = [consentedTool()];
+  const reg = fakeRegistry(rows);
+  const ledger = fakeLedger();
+  const eng = createProbes({
+    registry: reg,
+    probes: memProbesStore({ github: githubSpec() }),
+    stateStore: memStateStore(),
+    ledger,
+    now: () => 1_700_000_000_000,
+    httpRequest: async ({ url, headers }) => {
+      assert.equal(url, "https://api.github.com/users/octocat/events");
+      assert.equal(headers.Authorization, "Bearer sekrit-value");
+      return { status: 200, bodyText: JSON.stringify([{ created_at: "2026-08-20T00:00:00Z" }, {}, {}, {}]) };
+    },
+    getSecretPath: async () => "/tmp/secret-file",
+    readSecret: async () => "sekrit-value",
+  });
+  const results = await eng.runDue();
+  assert.equal(results.length, 1);
+  const row = results[0];
+  assert.equal(row.ok, true);
+  assert.equal(row.status, 200);
+  assert.equal(row.probe, "github/repo_events");
+  assert.equal(row.fields.inflow_rate, 4);
+  assert.equal(row.fields.last_event, "2026-08-20T00:00:00Z");
+  assert.ok(!("bodyText" in row));
+  assert.equal(ledger.rows.length, 1);
+  assert.equal(ledger.rows[0].actor, "cto");
+  assert.equal(ledger.rows[0].kind, "cto.probe.result");
+  assert.equal(rows[0]._probeCalls.length, 1);
+  // next run scheduled at spec cadence (no vitality sample yet on the row)
+  const st = await eng.loadToolState("github");
+  assert.equal(st.probes.repo_events.nextRunAt, 1_700_000_000_000 + 30 * 60_000);
+  assert.equal(st.probes.repo_events.lastOk, true);
+});
+
+test("runDue: no second run before the cadence elapses; a forced tool runs immediately", async () => {
+  const eng = build({ state: { github: { probes: { repo_events: { nextRunAt: 1_700_000_000_000 + 60_000 } } } } });
+  assert.equal((await eng.runDue()).length, 0);
+  const forced = await eng.runDue({ forceTool: "github" });
+  assert.equal(forced.length, 1);
+});
+
+test("runDue: nothing runs without consent (§7.5 'nothing for tools without consent')", async () => {
+  const eng = build({
+    rows: [{ tool: "github", consent: { metadata: null, deep_read: null, write: null }, evidence: [{ channel: "config", detail: "git:api.github.com", ts: 1 }] }],
+  });
+  assert.equal((await eng.runDue()).length, 0);
+  const ledgerRows = eng.loadToolState; // no throw
+  assert.ok(ledgerRows);
+});
+
+test("runDue: an off-allowlist or escalated-ring spec is re-validated at run time and skipped", async () => {
+  const eng = build({
+    rows: [consentedTool("github", ["api.github.com"])],
+    specs: {
+      github: (() => {
+        const s = githubSpec();
+        s.probes[0].url = "https://evil.example.com/x";
+        return s;
+      })(),
+    },
+  });
+  assert.equal((await eng.runDue()).length, 0);
+});
+
+test("runDue: thrifty sheds due probes; a probe backing an open blocker card is exempt", async () => {
+  const cards = fakeCards();
+  cards.open.push({ id: "x", sourceKind: PROBE_SOURCE_KIND, sourceId: "github/repo_events", state: "open" });
+  const eng = build({ cards, thrifty: () => true });
+  const exempt = await eng.runDue();
+  assert.equal(exempt.length, 1, "blocker-backed probe runs even while thrifty");
+  const cards2 = fakeCards();
+  const eng2 = build({ cards: cards2, thrifty: () => true });
+  assert.equal((await eng2.runDue()).length, 0, "no blocker → shed entirely");
+});
+
+test("auth-shaped failure path: 401×3 escalates ONE card with the key name; recovery resolves it", async () => {
+  const cards = fakeCards();
+  const ledger = fakeLedger();
+  let status = 401;
+  const eng = build({
+    cards,
+    ledger,
+    http: async () => ({ status, bodyText: "" }),
+  });
+  await eng.runDue({ forceTool: "github" });
+  await eng.runDue({ forceTool: "github" });
+  assert.equal(cards.upserts.length, 0, "no card before the 3rd consecutive auth failure");
+  await eng.runDue({ forceTool: "github" });
+  assert.equal(cards.upserts.length, 1);
+  assert.equal(cards.upserts[0].sourceKind, "probe");
+  assert.equal(cards.upserts[0].sourceId, "github/repo_events");
+  assert.match(cards.upserts[0].title, /rotated/);
+  assert.match(cards.upserts[0].body, /GITHUB_TOKEN/);
+  assert.match(cards.upserts[0].body, /secrets surface/);
+  const st = await eng.loadToolState("github");
+  assert.equal(st.probes.repo_events.cardOpen, true);
+  // recovery
+  status = 200;
+  await eng.runDue({ forceTool: "github" });
+  assert.equal(cards.resolved.length, 1);
+  assert.equal(cards.resolved[0].id, stableCardId(PROBE_SOURCE_KIND, "github/repo_events"));
+  const st2 = await eng.loadToolState("github");
+  assert.equal(st2.probes.repo_events.cardOpen, false);
+  assert.equal(st2.probes.repo_events.authFails, 0);
+});
+
+test("a missing secret is auth-shaped (same rotated-key failure mode) and escalates", async () => {
+  const cards = fakeCards();
+  const eng = build({
+    cards,
+    http: async () => {
+      throw Object.assign(new Error("no vault"), { code: "secret_missing" });
+    },
+  });
+  for (let i = 0; i < 3; i++) await eng.runDue({ forceTool: "github" });
+  assert.equal(cards.upserts.length, 1);
+  assert.match(cards.upserts[0].body, /GITHUB_TOKEN/);
+});
+
+test("non-auth failures (500s / timeouts) never escalate — health rows only", async () => {
+  const cards = fakeCards();
+  const eng = build({ cards, http: async () => ({ status: 500, bodyText: "" }) });
+  for (let i = 0; i < 6; i++) await eng.runDue({ forceTool: "github" });
+  assert.equal(cards.upserts.length, 0);
+  const st = await eng.loadToolState("github");
+  assert.equal(st.probes.repo_events.fails, 6);
+  assert.equal(st.probes.repo_events.authFails, 0);
+});
+
+test("failure evidence lands on the registry row via appendEvidence", async () => {
+  const rows = [consentedTool()];
+  const eng = createProbes({
+    registry: fakeRegistry(rows),
+    probes: memProbesStore({ github: githubSpec() }),
+    stateStore: memStateStore(),
+    now: () => 1_700_000_000_000,
+    httpRequest: async () => ({ status: 500, bodyText: "" }),
+    getSecretPath: async () => "/tmp/x",
+    readSecret: async () => "v",
+  });
+  await eng.runDue({ forceTool: "github" });
+  const ev = rows[0].evidence.find((e) => e.channel === "probe");
+  assert.ok(ev);
+  assert.equal(ev.detail, "repo_events:http_500");
+});
+
+// ---------------------------------------------------------------------------
+// Spec authoring — engine-written, validated
+// ---------------------------------------------------------------------------
+
+test("scaffoldSpec writes the §7.5 template with the evidenced key; never overwrites", async () => {
+  const specs = memProbesStore();
+  const eng = createProbes({
+    registry: fakeRegistry([consentedTool()]),
+    probes: specs,
+    stateStore: memStateStore(),
+    now: () => 1_700_000_000_000,
+  });
+  const r = await eng.scaffoldSpec("github", { secret: "GITHUB_TOKEN" });
+  assert.equal(r.changed, true);
+  const spec = specs._files.github;
+  assert.equal(spec.tool, "github");
+  assert.deepEqual(spec.probes, []);
+  assert.equal(spec.auth.secret, "GITHUB_TOKEN");
+  assert.equal(spec.auth.header.includes("{secret}"), true);
+  // second call is a no-op
+  specs._files.github.probes.push({ name: "x" });
+  const r2 = await eng.scaffoldSpec("github", { secret: "OTHER" });
+  assert.equal(r2.changed, false);
+});
+
+test("writeSpec: valid content lands; invalid content is refused with the catalogue", async () => {
+  const specs = memProbesStore({ github: githubSpec({ probes: [] }) });
+  const eng = createProbes({
+    registry: fakeRegistry([consentedTool()]),
+    probes: specs,
+    stateStore: memStateStore(),
+    now: () => 1_700_000_000_000,
+  });
+  const good = await eng.writeSpec("github", githubSpec());
+  assert.equal(good.ok, true);
+  assert.equal(specs._files.github.probes.length, 1);
+  const bad = githubSpec();
+  bad.probes[0].method = "DELETE";
+  const refused = await eng.writeSpec("github", bad);
+  assert.equal(refused.ok, false);
+  assert.ok(refused.errors.some((e) => e.key === "probes[0].method"));
+  assert.equal(specs._files.github.probes.length, 1, "invalid content never touches disk");
+});
+
+// ---------------------------------------------------------------------------
+// §7.6 relevance — weekly, paced, only through the gated ephemeral seam
+// ---------------------------------------------------------------------------
+
+test("relevanceScan: one call per (tool, project) per week, clamped to [0,1], written to the registry", async () => {
+  const rows = [consentedTool()];
+  let calls = 0;
+  const eng = build({
+    rows,
+    runEphemeral: async () => {
+      calls += 1;
+      return { text: "0.8" };
+    },
+  });
+  const r1 = await eng.relevanceScan({ ts: 1_700_000_000_000 });
+  assert.equal(r1.ran, 1);
+  assert.equal(calls, 1);
+  assert.equal(rows[0].relevance.proj, 0.8);
+  // same week → no second call
+  const r2 = await eng.relevanceScan({ ts: 1_700_000_000_000 + 60_000 });
+  assert.equal(r2.ran, 0);
+  assert.equal(calls, 1);
+  // next week → runs again
+  const r3 = await eng.relevanceScan({ ts: 1_700_000_000_000 + 8 * 24 * 3_600_000 });
+  assert.equal(r3.ran, 1);
+  assert.equal(calls, 2);
+});
+
+test("relevanceScan: out-of-range model output is clamped, parse failure retries later", async () => {
+  const rows = [consentedTool()];
+  const outputs = ["1.7", "garbage", "0.25"];
+  let i = 0;
+  const eng = build({
+    rows,
+    runEphemeral: async () => ({ text: outputs[i++] ?? "" }),
+  });
+  await eng.relevanceScan({ ts: 1_700_000_000_000 });
+  assert.equal(rows[0].relevance.proj, 1, "1.7 clamps to 1");
+  await eng.relevanceScan({ ts: 1_700_000_000_000 + 8 * 24 * 3_600_000 });
+  assert.equal(rows[0].relevance.proj, 1, "garbage → null → watermark not set");
+  await eng.relevanceScan({ ts: 1_700_000_000_000 + 9 * 24 * 3_600_000 });
+  assert.equal(rows[0].relevance.proj, 0.25);
+});
+
+test("relevanceScan: projects with nothing on the blackboard are watermarked, not retried", async () => {
+  const rows = [consentedTool()];
+  let calls = 0;
+  const eng = build({
+    rows,
+    projects: ["empty"],
+    getTopFacts: async () => [],
+    getRollups: async () => "",
+    runEphemeral: async () => {
+      calls += 1;
+      return { text: "0.5" };
+    },
+  });
+  await eng.relevanceScan({ ts: 1_700_000_000_000 });
+  assert.equal(calls, 0);
+  await eng.relevanceScan({ ts: 1_700_000_000_000 + 60_000 });
+  assert.equal(calls, 0);
+});
+
+test("relevanceScan: paces at 6 calls/day across tools and pairs", async () => {
+  const rows = ["a", "b", "c", "d", "e", "f", "g", "h"].map((t) => consentedTool(t));
+  const specs = {};
+  for (const t of rows) specs[t.tool] = githubSpec({ tool: t.tool });
+  let calls = 0;
+  const eng = build({
+    rows,
+    specs,
+    projects: ["p1", "p2", "p3", "p4"],
+    runEphemeral: async () => {
+      calls += 1;
+      return { text: "0.5" };
+    },
+  });
+  const day0 = 1_700_000_000_000;
+  await eng.relevanceScan({ ts: day0 });
+  assert.equal(calls, 6, "daily budget caps the first scan");
+  await eng.relevanceScan({ ts: day0 + 60_000 });
+  assert.equal(calls, 6, "the same UTC day gets no further calls");
+  await eng.relevanceScan({ ts: day0 + 24 * 3_600_000 });
+  assert.equal(calls, 12, "the next day gets a fresh budget");
+});
+
+// ---------------------------------------------------------------------------
+// §10.5 A12 probe-health snapshot
+// ---------------------------------------------------------------------------
+
+test("healthSnapshot: counts configured vs healthy vs auth-failed probes", async () => {
+  const eng = build({ http: async () => ({ status: 401, bodyText: "" }) });
+  await eng.runDue({ forceTool: "github" });
+  const snap = await eng.healthSnapshot();
+  assert.equal(snap.tools, 1);
+  assert.equal(snap.probes, 1);
+  assert.equal(snap.healthy, 0);
+  assert.equal(snap.authFailed, 1);
+  assert.ok(snap.lastRunAt > 0);
+});
+
+test("healthSnapshot: an unconsented tool's spec never counts", async () => {
+  const eng = build({
+    rows: [{ tool: "github", consent: { metadata: null, deep_read: null, write: null }, evidence: [] }],
+  });
+  const snap = await eng.healthSnapshot();
+  assert.equal(snap.tools, 0);
+  assert.equal(snap.probes, 0);
+});
+
+// ---------------------------------------------------------------------------
+// ctoHealth row composition
+// ---------------------------------------------------------------------------
+
+test("computeHealthStats: the probe-health row renders healthy/auth counts, collects before the first run", async () => {
+  const { computeHealthStats } = await import("./ctoHealth.mjs");
+  const ran = await computeHealthStats({ probesRead: async () => ({ tools: 1, probes: 2, healthy: 1, authFailed: 1, lastRunAt: 1 }) });
+  const rowRan = ran.stats.find((s) => s.id === "probeHealth");
+  assert.equal(rowRan.n, 2);
+  assert.equal(rowRan.value, "1/2 probes healthy · 1 auth-failed");
+  const fresh = await computeHealthStats({ probesRead: async () => ({ tools: 1, probes: 1, healthy: 0, authFailed: 0, lastRunAt: null }) });
+  const rowFresh = fresh.stats.find((s) => s.id === "probeHealth");
+  assert.equal(rowFresh.value, null);
+  assert.equal(rowFresh.collectingText, "configured — waiting for first run");
+  const none = await computeHealthStats({ probesRead: async () => null });
+  const rowNone = none.stats.find((s) => s.id === "probeHealth");
+  assert.equal(rowNone.n, 0);
+});
+
+// ---------------------------------------------------------------------------
+// §10.6-7 card copy
+// ---------------------------------------------------------------------------
+
+test("probeBlockerCopy names the key + the secrets surface; titles name the rotation", () => {
+  const withKey = probeBlockerCopy("github", "repo_events", "GITHUB_TOKEN");
+  assert.match(withKey.title, /github/);
+  assert.match(withKey.title, /rotated/);
+  assert.match(withKey.body, /GITHUB_TOKEN/);
+  assert.match(withKey.body, /secrets surface/);
+  const noKey = probeBlockerCopy("gitlab", "issues");
+  assert.match(noKey.body, /secrets surface/);
+  assert.ok(!noKey.body.includes("GITHUB_TOKEN"), "no cross-tool key leakage");
+});
+
+// ---------------------------------------------------------------------------
+// Registry vitality fold (§7.3 math) — through the real registry
+// ---------------------------------------------------------------------------
+
+test("registry applyProbeResult: folds inflow into an EWMA, adapts the cadence memory, flips candidate→integrated", async () => {
+  const { createToolRegistry } = await import("./ctoToolRegistry.mjs");
+  const reg = createToolRegistry({
+    registryStore: memStore({
+      v: 1,
+      tools: [
+        {
+          tool: "github",
+          status: "candidate",
+          consent: { metadata: "yes", deep_read: null, write: null },
+          evidence: [{ channel: "config", detail: "git:api.github.com", ts: 1 }],
+        },
+      ],
+    }),
+    now: () => 1_700_000_000_000,
+  });
+  const t0 = 1_700_000_000_000;
+  const cadence = 30 * 60_000;
+  // first sample: 4 new items in the spec cadence → per-week rate
+  const r1 = await reg.applyProbeResult("github", { fields: { inflow_rate: 4, last_event: "2026-08-20T00:00:00Z" }, probedAt: t0, cadenceMs: cadence });
+  assert.equal(r1.ok, true);
+  assert.equal(r1.flipped, true, "candidate → integrated on first success");
+  const v1 = r1.vitality;
+  const rate1 = (4 * 7 * 24 * 3_600_000) / cadence;
+  assert.ok(Math.abs(v1.ewma - rate1) < 1e-9, `ewma starts at the first rate (${v1.ewma} vs ${rate1})`);
+  assert.equal(v1.last_event, "2026-08-20T00:00:00Z");
+  // second sample 1h later: 0 new items → decayed EWMA, silence trend
+  const r2 = await reg.applyProbeResult("github", { fields: { inflow_rate: 0 }, probedAt: t0 + 3_600_000, cadenceMs: cadence });
+  assert.ok(r2.vitality.ewma < v1.ewma, "EWMA decays toward 0 on silence");
+  assert.ok(r2.vitality.ewma > 0, "EWMA never jumps to zero in one sample");
+  assert.equal(r2.flipped, false);
+  // the row is integrated now
+  const row = await reg.toolRow("github");
+  assert.equal(row.status, "integrated");
+  assert.equal(row.vitality.inflow_rate, 0);
+});
+
+test("registry applyProbeResult: unknown tool is rejected; relevance + evidence writers behave", async () => {
+  const { createToolRegistry } = await import("./ctoToolRegistry.mjs");
+  const reg = createToolRegistry({
+    registryStore: memStore({
+      v: 1,
+      tools: [{ tool: "github", status: "observed", consent: { metadata: "yes", deep_read: null, write: null }, evidence: [] }],
+    }),
+  });
+  assert.equal((await reg.applyProbeResult("nope", { fields: {}, probedAt: 1 })).ok, false);
+  assert.equal((await reg.applyRelevance("github", "proj", 0.9)).ok, true);
+  assert.equal((await reg.toolRow("github")).relevance.proj, 0.9);
+  assert.equal((await reg.applyRelevance("github", "proj", 42)).ok, true, "out-of-range scores clamp, not refuse");
+  assert.equal((await reg.toolRow("github")).relevance.proj, 1);
+  assert.equal((await reg.applyRelevance("github", "proj", Number.NaN)).ok, false, "non-finite scores refused");
+  const ev = await reg.appendEvidence("github", { channel: "probe", detail: "repo_events:http_500", ts: 5 });
+  assert.equal(ev.ok, true);
+  const dedup = await reg.appendEvidence("github", { channel: "probe", detail: "repo_events:http_500", ts: 6 });
+  assert.equal(dedup.changed, false, "same (channel, detail) is deduped");
+});
+
+// ---------------------------------------------------------------------------
+// defaultHttpRequest connect path — pinned lookup reaches the validated host
+// ---------------------------------------------------------------------------
+
+test("defaultHttpRequest: the pinned lookup is used and the request carries the hostname SNI/Host", async () => {
+  // No real server: we assert only that the transport wires the pinned lookup
+  // (the connect fails fast against a public-but-dead address; the error is a
+  // socket error, NOT dns_private — proving the DNS validation passed).
+  await assert.rejects(
+    defaultHttpRequest({
+      url: "https://93.184.216.34.nip.io/x",
+      dnsLookup: (h, o, cb) => cb(null, [{ address: "93.184.216.34", family: 4 }]),
+    }),
+    (e) => ["socket", "timeout"].includes(e.code),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// helpers shared with the registry tests
+// ---------------------------------------------------------------------------
+
+function memStore(initial = {}) {
+  let state = { ...initial };
+  return {
+    load: async () => ({ ...state }),
+    save: async (next) => {
+      state = { ...next };
+    },
+    _state: () => state,
+  };
+}

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -243,7 +243,7 @@ test("validateProbeSpec: sub-5m cadence fails by name", () => {
   assert.ok(r.errors.some((e) => e.key === "probes[0].cadence" && e.message.includes("5m floor")));
 });
 
-test("validateProbeSpec: auth template must hold exactly one {secret}; secret must be a KEY NAME", () => {
+test("validateProbeSpec: auth template must hold exactly one {secret}; secret must be a KEY NAME; header must be Name: value", () => {
   const spec = githubSpec();
   spec.auth = { secret: "GITHUB_TOKEN", header: "Authorization: Bearer" };
   let r = validateProbeSpec(spec, { tool: "github" });
@@ -253,6 +253,14 @@ test("validateProbeSpec: auth template must hold exactly one {secret}; secret mu
   r = validateProbeSpec(spec, { tool: "github" });
   assert.equal(r.ok, false);
   assert.ok(r.errors.some((e) => e.key === "auth.secret"));
+});
+
+test("validateProbeSpec: colon-less auth.header fails at authoring time (nit: mangled header name)", () => {
+  const spec = githubSpec();
+  spec.auth = { secret: "GITHUB_TOKEN", header: "Bearer {secret}" };
+  const r = validateProbeSpec(spec, { tool: "github", allowedHosts: ["api.github.com"], consentedRing: "metadata" });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.key === "auth.header" && e.message.includes('missing ":"')));
 });
 
 test("validateProbeSpec: tool mismatch fails by name", () => {
@@ -706,9 +714,37 @@ test("relevanceScan: out-of-range model output is clamped, parse failure retries
   await eng.relevanceScan({ ts: 1_700_000_000_000 });
   assert.equal(rows[0].relevance.proj, 1, "1.7 clamps to 1");
   await eng.relevanceScan({ ts: 1_700_000_000_000 + 8 * 24 * 3_600_000 });
-  assert.equal(rows[0].relevance.proj, 1, "garbage → null → watermark not set");
+  assert.equal(rows[0].relevance.proj, 1, "garbage → null → value unchanged");
   await eng.relevanceScan({ ts: 1_700_000_000_000 + 9 * 24 * 3_600_000 });
   assert.equal(rows[0].relevance.proj, 0.25);
+});
+
+test("relevanceScan: failed attempts consume the day budget AND rest on a short failure watermark (no per-minute spin)", async () => {
+  const rows = [consentedTool()];
+  let calls = 0;
+  const eng = build({
+    rows,
+    projects: ["p1", "p2", "p3", "p4"],
+    runEphemeral: async () => {
+      calls += 1;
+      throw new Error("provider down");
+    },
+  });
+  const t0 = 1_700_000_000_000;
+  const MIN = 60_000;
+  let r = await eng.relevanceScan({ ts: t0 });
+  assert.equal(r.attempts, 4, "first scan attempts all four pairs");
+  r = await eng.relevanceScan({ ts: t0 + 1 * MIN });
+  assert.equal(r.attempts, 0, "failure watermark suppresses the next minute-tick");
+  r = await eng.relevanceScan({ ts: t0 + 2 * MIN });
+  assert.equal(r.attempts, 0, "still suppressed");
+  r = await eng.relevanceScan({ ts: t0 + 61 * MIN });
+  assert.equal(r.attempts, 2, "after the 1h watermark the remaining day budget (6-4) bounds retries to 2");
+  r = await eng.relevanceScan({ ts: t0 + 62 * MIN });
+  assert.equal(r.attempts, 0, "day budget exhausted");
+  assert.equal(calls, 6, "a persistently failing model makes exactly 6 attempts per day, not one per tick");
+  r = await eng.relevanceScan({ ts: t0 + 24 * 3_600_000 });
+  assert.equal(r.attempts, 4, "a fresh day gets a fresh attempt budget (4 pairs exist)");
 });
 
 test("relevanceScan: projects with nothing on the blackboard are watermarked, not retried", async () => {
@@ -876,17 +912,19 @@ test("registry applyProbeResult: unknown tool is rejected; relevance + evidence 
 // defaultHttpRequest connect path — pinned lookup reaches the validated host
 // ---------------------------------------------------------------------------
 
-test("defaultHttpRequest: the pinned lookup is used and the request carries the hostname SNI/Host", async () => {
-  // No real server: we assert only that the transport wires the pinned lookup
-  // (the connect fails fast against a public-but-dead address; the error is a
-  // socket error, NOT dns_private — proving the DNS validation passed).
+test("defaultHttpRequest: the pinned lookup is consulted (spy) and connect failures are socket/timeout — never a private-DNS miss", async () => {
+  const looked = [];
   await assert.rejects(
     defaultHttpRequest({
       url: "https://93.184.216.34.nip.io/x",
-      dnsLookup: (h, o, cb) => cb(null, [{ address: "93.184.216.34", family: 4 }]),
+      dnsLookup: (h, o, cb) => {
+        looked.push(h);
+        cb(null, [{ address: "93.184.216.34", family: 4 }]);
+      },
     }),
     (e) => ["socket", "timeout"].includes(e.code),
   );
+  assert.deepEqual(looked, ["93.184.216.34.nip.io"], "the pinned custom lookup was consulted exactly once");
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -254,6 +254,11 @@ function createDirJsonStore(name, dirPart) {
 export const factsStore = createDirJsonStore("facts", "facts");
 export const factsArchiveStore = createDirJsonStore("facts-archive", "facts-archive");
 export const digestsStore = createDirJsonStore("digests", "digests");
+// BET-1396 probe runner state: one JSON file per tool —
+// `{ probes: { <probe>: { nextRunAt, fails, authFails, cardOpen, lastOk, … } } }`.
+// The §7.5 cadence schedule + consecutive-failure escalation counters must
+// survive restarts; `_relevance.json` carries the §7.6 weekly watermarks.
+export const probeStateStore = createDirJsonStore("probe-state", "probe-state");
 // Segments store — the read-layer work episodes (spec §5.1), one JSON file per
 // segment, swept 30d by sweepSegments(). Owned by the segmentation issue (A6).
 export const segmentsStore = createDirJsonStore("segments", "segments");
@@ -366,6 +371,27 @@ export const probesStore = {
   pathFor: (tool) => {
     assertSafeName(tool, "probes");
     return ctoPath("probes", `${tool}.yaml`);
+  },
+  // Tools that have a spec on disk (strip the `.yaml` suffix; skips other
+  // files defensively). BET-1396: the probe runner enumerates from here.
+  list: async () => {
+    let entries;
+    try {
+      entries = await readdir(ctoPath("probes"), { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    return entries
+      .filter((e) => e.isFile() && e.name.endsWith(".yaml"))
+      .map((e) => e.name.slice(0, -".yaml".length))
+      .filter((t) => {
+        try {
+          assertSafeName(t, "probes");
+          return true;
+        } catch {
+          return false;
+        }
+      });
   },
   loadSync: (tool) => {
     assertSafeName(tool, "probes");

--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -1,5 +1,5 @@
 // ctoToolRegistry.mjs — §7.2 registry + fusion + lifecycle + connect asks
-// (BET-1395).
+// (BET-1395) + the §7.3 vitality / §7.6 relevance axes (BET-1396).
 //
 // The registry fuses the four §7.1 evidence channels into ONE row per tool
 // identity ("one identity, one row"), derives engagement, runs the two
@@ -8,8 +8,8 @@
 //   observed (evidence accumulates) → candidate (either axis crosses its bar:
 //     engagement ≥3 uses across ≥2 weeks; OR the vitality path — a credential
 //     exists at all) → ONE connect ask (Connect read-only / Not now / Never)
-//     → integrated (probes run — §7.5, a later issue; this module only grants
-//     the metadata consent ring).
+//     → integrated (the FIRST successful §7.5 probe run flips it here;
+//     applyProbeResult does the flip).
 //
 // Raw evidence (unknown CLIs/hosts/keys) is classified by the LLM fallback at
 // most ONCE per identity — the model's judgment is cached in the registry
@@ -29,6 +29,9 @@ import {
   collectConfigEvidence,
   SCAN_ROW_CAP,
 } from "./ctoToolScan.mjs";
+// One-way dep (ctoProbes never imports this module): the §7.2 well-known
+// vitality pair {last_event, inflow_rate} pulled from a probe's extract map.
+import { vitalityOf } from "./ctoProbes.mjs";
 
 export const TOOL_REGISTRY_VERSION = 1;
 export const ACTOR = "cto";
@@ -56,6 +59,7 @@ export const REARM_FRESH_USES = 2;
 export const TOOL_CLASSIFY_TASK_CLASS = "ambient-summarize";
 
 const DAY_MS = 24 * 3_600_000;
+const WEEK_MS = 7 * DAY_MS;
 const EWMA_TAU_DAYS = 7; // engagement EWMA decay constant (1-week τ)
 
 export function emptyConsent() {
@@ -268,6 +272,11 @@ export function createToolRegistry(deps = {}) {
     collectDb = null, // async ({sinceTs, untilTs, cap}) => db part rows
     collectSurfaces = null, // async () => {config, forgeRepos, webhooks, gitRemotes, schedules}
     backfillStartInstant = null, // first-scan lower bound (the backfill range)
+    // BET-1396 §7.5: async (toolId, {secret}) — the probe runner's
+    // scaffoldSpec; called at consent time so the ENGINE authors the tool's
+    // probe-spec template (AI-authored content goes through the runner's
+    // validated writeSpec; no other writer touches probes/<tool>.yaml).
+    scaffoldProbes = null,
   } = deps;
 
   async function loadPayload() {
@@ -561,11 +570,19 @@ export function createToolRegistry(deps = {}) {
     const nowMs = now();
     t.consent = t.consent ?? emptyConsent();
     if (answer === "connect") {
-      // The metadata ring is granted. Status stays `candidate` until probes
-      // actually run (§7.5 flips it to `integrated` in a later issue).
+      // The metadata ring is granted. Status stays `candidate` until the
+      // first §7.5 probe actually runs (applyProbeResult flips it).
       t.consent.metadata = "yes";
       t.reArmAt = null;
       await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "yes" });
+      // §7.5 BET-1396: the ENGINE authors the tool's probe-spec template at
+      // consent time, filled with the evidenced credential key (if any). The
+      // file is engine-written; its content is completed through the runner's
+      // validated writeSpec path. Best-effort — consent never depends on it.
+      if (typeof scaffoldProbes === "function") {
+        const secretRow = (t.evidence ?? []).find((e) => e?.channel === "secret" && typeof e?.detail === "string" && e.detail.startsWith("secret:"));
+        await scaffoldProbes(id, { secret: secretRow ? secretRow.detail.slice("secret:".length) : null }).catch(() => {});
+      }
     } else if (answer === "not-now") {
       t.consent.metadata = "no";
       t.reArmAt = nowMs + NOT_NOW_REARM_MS;
@@ -640,6 +657,98 @@ export function createToolRegistry(deps = {}) {
     return t ? (t.consent?.[ring] ?? null) : null;
   }
 
+  // ---------------------------------------------------------------------------
+  // BET-1396 — §7.3 vitality / §7.6 relevance / §7.4 lifecycle. All mutating
+  // writers go through `serialized` (the whole-payload store's lost-update
+  // guard, same as the scan/connect writers).
+  // ---------------------------------------------------------------------------
+
+  // The full row for one tool (probe runner reads evidence hosts + vitality;
+  // the probe spec's host allowlist is derived from this). null when unknown.
+  async function toolRow(toolId) {
+    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
+    if (!id) return null;
+    const payload = await loadPayload();
+    return payload.tools.find((x) => x?.tool === id) ?? null;
+  }
+
+  // §7.3 vitality: fold ONE successful metadata probe's extract into the
+  // vitality axis. `fields` is the probe's extract map (untrusted but tiny);
+  // only the §7.2 well-known pair {last_event, inflow_rate} is consumed.
+  // `inflow_rate` semantics: the RAW count of new items since the previous
+  // probe, normalized to a per-week rate against elapsed wall time
+  // (cadence-independent; the spec cadence covers the very first sample).
+  // The rate is EWMA-smoothed (τ = 7d, the engagement axis's constant) into
+  // `vitality.ewma` — the runner reads it for the daily↔weekly adaptation.
+  // First success also flips §7.4 candidate → integrated (probes ran).
+  // NOTE: the body does NOT self-serialize — the exported wrapper already
+  // routes through `serialized` (nesting would deadlock the write chain).
+  async function applyProbeResult(toolId, { fields, probedAt, cadenceMs } = {}) {
+    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
+    if (!id) return { ok: false, error: "missing tool" };
+    const payload = await loadPayload();
+    const t = payload.tools.find((x) => x?.tool === id);
+    if (!t) return { ok: false, error: `unknown tool "${id}"` };
+    const vit = vitalityOf(fields);
+    t.vitality = t.vitality ?? { last_event: null, inflow_rate: null, ewma: null, last_probed: null };
+    const v = t.vitality;
+    const ts = typeof probedAt === "number" ? probedAt : now();
+    if (vit.last_event !== undefined) v.last_event = vit.last_event;
+    if (vit.inflow_rate !== undefined) {
+      const cad = Number.isFinite(cadenceMs) && cadenceMs > 0 ? cadenceMs : WEEK_MS;
+      const elapsed = Number.isFinite(v.last_probed) ? Math.max(ts - v.last_probed, 1) : cad;
+      const ratePerWeek = (vit.inflow_rate * WEEK_MS) / elapsed;
+      const decay = Math.exp(-(elapsed / DAY_MS) / EWMA_TAU_DAYS);
+      v.ewma = v.ewma == null ? ratePerWeek : v.ewma * decay + ratePerWeek * (1 - decay);
+      v.inflow_rate = vit.inflow_rate;
+    }
+    v.last_probed = ts;
+    let flipped = false;
+    if (t.status === "candidate") {
+      t.status = "integrated";
+      flipped = true;
+    }
+    await savePayload(payload);
+    if (flipped) {
+      await ledgerLog({ kind: "cto.tool.integrated", tool: id });
+    }
+    return { ok: true, vitality: { ...v }, flipped };
+  }
+
+  // §7.6 relevance: persist the weekly nano-score for one (tool, project)
+  // pair into the row's `relevance[project]` (clamped to [0,1]).
+  async function applyRelevance(toolId, project, score) {
+    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
+    if (!id || typeof project !== "string" || !project) return { ok: false, error: "missing tool/project" };
+    const s = Number(score);
+    if (!Number.isFinite(s)) return { ok: false, error: "invalid score" };
+    const payload = await loadPayload();
+    const t = payload.tools.find((x) => x?.tool === id);
+    if (!t) return { ok: false, error: `unknown tool "${id}"` };
+    t.relevance = { ...(t.relevance ?? {}), [project]: Math.max(0, Math.min(1, s)) };
+    await savePayload(payload);
+    return { ok: true };
+  }
+
+  // One evidence row on the tool's trail (probe failures; §7.2 evidence
+  // shape). Deduped on (channel, detail); capped at EVIDENCE_CAP.
+  async function appendEvidence(toolId, entry) {
+    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
+    if (!id || !entry || typeof entry.channel !== "string" || typeof entry.detail !== "string") {
+      return { ok: false, error: "missing tool/evidence" };
+    }
+    const payload = await loadPayload();
+    const t = payload.tools.find((x) => x?.tool === id);
+    if (!t) return { ok: false, error: `unknown tool "${id}"` };
+    const row = { channel: entry.channel, detail: entry.detail, ts: Number.isFinite(entry.ts) ? entry.ts : now() };
+    const exists = (t.evidence ?? []).some((e) => e?.channel === row.channel && e?.detail === row.detail);
+    if (exists) return { ok: true, changed: false };
+    t.evidence = [...(t.evidence ?? []), row];
+    if (t.evidence.length > EVIDENCE_CAP) t.evidence.splice(0, t.evidence.length - EVIDENCE_CAP);
+    await savePayload(payload);
+    return { ok: true, changed: true };
+  }
+
   // Registry view for the §10.5 tool surfaces (read-only, stable shape).
   async function listTools() {
     const payload = await loadPayload();
@@ -665,6 +774,13 @@ export function createToolRegistry(deps = {}) {
     consentFor,
     listTools,
     appendUsage,
+    // BET-1396: §7.5 probe-runner surface (read the row, fold vitality /
+    // relevance, append failure evidence). toolRow is a pure read — no
+    // serialization (it must never queue behind an in-flight scan).
+    toolRow,
+    applyProbeResult: (toolId, input) => serialized(() => applyProbeResult(toolId, input)),
+    applyRelevance: (toolId, project, score) => serialized(() => applyRelevance(toolId, project, score)),
+    appendEvidence: (toolId, entry) => serialized(() => appendEvidence(toolId, entry)),
   };
 }
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -4388,6 +4388,14 @@ const handleRequest = async (req, res) => {
         }
         return adaptiveCtoBudget.roiSnapshot();
       },
+      probesRead: async () => {
+        try {
+          return await adaptiveCto.probeHealth();
+        } catch {
+          /* the probe row degrades to collecting — never fail the health read */
+          return null;
+        }
+      },
         });
         respondJson(res, 200, result);
         return;


### PR DESCRIPTION
## BET-1396 — Probe runner + vitality + relevance (Adaptive CTO §7.5/§7.3/§7.6/§10.6-7)

**Base:** origin/main @ `2e0c5fb0`

### What ships

- **`src/server/ctoProbes.mjs` (new)** — the §7.5 probe subsystem:
  - **Spec validator** (forge-rules-style error catalogue, unknown keys fail BY NAME): `tool`/`auth`/`probes` grammar, GET-only (any other method named in the error), exact-host allowlist from the tool's evidence rows, cadence floor 5m, ring ≤ consented ring (probes can only ever declare `metadata`|`deep_read` — the write ring creates no standing specs, §7.4).
  - **Runner** — per-probe nextRunAt schedule in a durable per-tool state store; runs from the engine's 1-minute tick (paused/toggled with the rest of the CTO). Enforcement: https-only URLs, exact-host allowlist re-validated at run time, redirects NEVER followed (3xx = failure row), DNS resolved first with every private/reserved address rejected (RFC1918, loopback, link-local, CGNAT, 0/8, 224+/4, v4-mapped v6, ULA), then a **pinned `lookup` connect** so the socket can only reach the validated addresses (no rebinding window; SNI + Host keep the hostname). 256 KB response cap + 10 s timeout enforced on the response stream (`consumeResponse`, stream-tested via PassThrough).
  - **Auth by reference at spawn** — `auth.secret` is a vault KEY NAME; resolved through the existing `provideSecret` machinery to a materialized file path, read inside the request closure, interpolated into the header template. Usage recording is deliberately suppressed (a probe provide must never inflate the tool's own engagement axis). The value never enters logs, stores, ledger rows, or model contexts; failure rows carry status/error codes only.
  - **Responses are untrusted data** — only the tiny json-path `extract` fields survive into the ledger/vitality/relevance paths (defensively pruned to 256 chars); the raw body is never persisted.
  - **Results are evidence-layer events** — every run appends a `cto.probe.result` row (actor `cto`) to the A1 ledger: `{tool, probe, ok, status, durMs, fields|error, ts}`.
- **Registry (`ctoToolRegistry.mjs`)** — `toolRow` (read), `applyProbeResult` (§7.3 vitality fold: `{last_event, inflow_rate}` → per-week rate → EWMA τ=7d; **candidate → integrated flip on first successful probe**, §7.4 lifecycle), `applyRelevance` (§7.6 `relevance[project]` clamped [0,1]), `appendEvidence` (probe-failure trail, deduped, capped). Consent now scaffolds the engine-written probe template (§7.5: AI-authored, engine-written — the only write path is `writeSpec`, which validates against CURRENT consent + evidence hosts before touching disk).
- **§10.6-7 escalation** — 401/403 (or `secret_missing` — the same rotated-key failure mode) ×3 consecutive → ONE blocker card per probe (idempotent stable-id upsert; copy: "key may have been rotated" + names the exact vault key + the secrets surface). Any success resolves the card. Non-auth failures never page — health rows only.
- **§7.6 relevance** — weekly per consented tool × active project: one nano `runEphemeral` call (the SAME §3.3-gated seam the registry's classifier rides) matching the tool's data domain against the project's top facts + recent rollups → `relevance[project] ∈ [0,1]`. Paced ≤6 calls/day. The deep-analysis half is P3 and is not here.
- **Thrifty (§12.2)** — probe fan-outs are rung 2 of the shed ladder; probes backing an open probe-failure card are exempt (their liveness IS the card's resolution path).
- **A12 health** — new `probeHealth` row: `k/n probes healthy · m auth-failed`; collects until the first run.
- **Renderer** — none needed: sourceKind `probe` falls through the existing ledger-fallback in `blockerTarget` (not a session target), so the card drills into the failure row today.

### Semantics pinned here (spec is silent on the numbers)

- Adaptive cadence band (issue: daily↔weekly): no vitality sample → spec cadence unclamped; inflow observed (EWMA>0) → accelerate slow specs toward daily (faster specs are HONORED — the band never slows a declared cadence, §7.5); observed silence (EWMA=0) → stretch to weekly.
- `inflow_rate` extract semantics: raw count of new items since the previous probe, normalized to a per-week rate against elapsed wall time.
- Relevance rollup context: latest day-rollup bullets (box-wide; per-project attribution needs segment resolution — not paid for a nano context; the project's top facts, which rollups are fused into, carry the per-project signal).
- Out-of-range relevance replies clamp to [0,1].

### Cross-cutting

- `ctoStores.mjs`: `probeStateStore` (new dir store, one JSON per tool) + `probesStore.list()`.
- `ctoCards.mjs`: `PROBE_SOURCE_KIND` + `probeBlockerCopy` only — no card-machinery changes.
- No renderer/preload/IPC changes. No new dependencies.

### Follow-ups filed

- Parked: ephemeral session that FILLS scaffolded probe templates (the AI-authored content step).
- Parked: renderer deep-link from probe blocker cards to the secrets pane (today: card copy + ledger fallback).

### Verification results

See the issue comment (two-branch run captured there).
