### PR TITLE
BET-1404: feat(cto): as_source counter sink + Beta lower bound (§9.5); registry deep-read bar + consent fields (§7.6)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -354,17 +354,26 @@ export function CtoPanel({
   // all three; the client toasts the outcome and refreshes the cards.
   const handleConnectAnswer = useCallback(
     (card: ConnectCardRow, answer: string) => {
-      const tool = (card.options ?? []).find((o) => o.answer === answer)?.action?.payload?.tool;
+      const option = (card.options ?? []).find((o) => o.answer === answer);
+      const tool = option?.action?.payload?.tool;
       const toolId = typeof tool === "string" ? tool : card.id;
+      const ring = option?.action?.payload?.ring;
+      const deepRead = ring === "deep_read";
       void window.api
-        ?.ctoToolConnect?.({ tool: toolId, answer: answer as "connect" | "not-now" | "never" })
+        ?.ctoToolConnect?.({
+          tool: toolId,
+          answer: answer as "connect" | "not-now" | "never",
+          ...(deepRead ? { ring: "deep_read" as const } : {}),
+        })
         .then((r) => {
           if (r?.ok) {
             pushToast({
               id: `connect-${Date.now()}`,
               message:
                 answer === "connect"
-                  ? "Connected read-only — metadata consent granted"
+                  ? deepRead
+                    ? "Connected — deep read access granted"
+                    : "Connected read-only — metadata consent granted"
                   : answer === "never"
                     ? "Will not connect to this tool"
                     : "Not now — I'll ask again later",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1887,6 +1887,7 @@ export const httpApi: Api = {
   ctoToolConnect: async (input: {
     tool: string;
     answer: "connect" | "not-now" | "never";
+    ring?: "metadata" | "deep_read";
   }): Promise<{ ok: boolean; error?: string; tool?: string; answer?: string }> => {
     const url = `${serverBase()}/api/cto/tools/connect`;
     try {

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -539,13 +539,15 @@ export function createCtoCards(deps = {}) {
   // which writes the consent ring + the §9.5 verdict and calls
   // resolveConnectCards. No notification path — like decision cards, this is
   // a resting needs-you surface.
-  async function upsertConnect({ toolId, title, body, evidence = [], refs = [], ts = now() } = {}) {
+  async function upsertConnect({ toolId, title, body, evidence = [], refs = [], ring = "metadata", ts = now() } = {}) {
     if (!toolId || typeof toolId !== "string") return { changed: false, isNew: false };
+    const deep = ring === "deep_read";
+    const sourceId = deep ? `${toolId}:deep` : toolId;
     return upsertOpenCard({
-      id: stableCardId(CONNECT_SOURCE_KIND, toolId),
+      id: stableCardId(CONNECT_SOURCE_KIND, sourceId),
       variant: "connect",
       sourceKind: CONNECT_SOURCE_KIND,
-      sourceId: toolId,
+      sourceId,
       ts,
       build: () => ({
         title: typeof title === "string" && title ? title : `Connect ${toolId} (read-only)?`,
@@ -557,7 +559,7 @@ export function createCtoCards(deps = {}) {
           { label: "Never for this tool", answer: "never" },
         ].map((o) => ({
           ...o,
-          action: { type: "tool-connect", payload: { tool: toolId, answer: o.answer } },
+          action: { type: "tool-connect", payload: { tool: toolId, answer: o.answer, ring } },
         })),
         refs: Array.isArray(refs) && refs.length ? refs : [toolId],
         sessionID: null,

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -383,9 +383,29 @@ test("upsertConnect: writes a variant=connect card with the three bound answers"
   );
   for (const o of card.options) {
     assert.equal(o.action.type, "tool-connect");
-    assert.deepEqual(o.action.payload, { tool: "vercel", answer: o.answer });
+    // BET-1404: the payload carries the ring the ask was about — the
+    // metadata default here, "deep_read" for the deep-read ask's card.
+    assert.deepEqual(o.action.payload, { tool: "vercel", answer: o.answer, ring: "metadata" });
   }
   assert.ok(h.ledgerRows.some((row) => row.kind === CARD_CREATED && row.variant === "connect"));
+});
+
+test("upsertConnect: the deep_read ask gets its own card id and ring-tagged payloads", async () => {
+  const h = makeHarness();
+  await h.cards.upsertConnect({ toolId: "vercel", title: "meta", refs: ["vercel"] });
+  const r = await h.cards.upsertConnect({
+    toolId: "vercel",
+    ring: "deep_read",
+    title: "deep",
+    refs: ["vercel"],
+  });
+  assert.equal(r.changed, true);
+  const deep = h.store().cards.find((c) => c.variant === "connect" && c.title === "deep");
+  assert.ok(deep);
+  assert.equal(deep.sourceId, "vercel:deep", "a distinct stable id — the metadata card is untouched");
+  for (const o of deep.options) {
+    assert.deepEqual(o.action.payload, { tool: "vercel", answer: o.answer, ring: "deep_read" });
+  }
 });
 
 test("upsertConnect: re-raising the same tool upserts in place (no dup)", async () => {

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -59,7 +59,7 @@ import {
   patchEngineState,
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
-import { createVerdictEngine } from "./ctoVerdicts.mjs";
+import { createVerdictEngine, createAsSourceSink } from "./ctoVerdicts.mjs";
 // BET-1403: the earned-trust ladder (§9.3/§9.4). Its per-class Beta counters
 // ride the §9.5 verdict sink registry below; the digest announces acts and
 // tier changes through the same engine.
@@ -118,7 +118,7 @@ import {
 // BET-1419 overnight execution (§11): the pure window/portfolio machine
 // (BET-1402) back the engine's veto/tonight verbs; resolveForgeOwner is the
 // pure project→job-parent resolver shared with forge dispatch.
-import { createOvernightScheduler, normalizeWindow, scheduleCountdown } from "./ctoOvernight.mjs";
+import { createOvernightScheduler, normalizeWindow, scheduleCountdown, dataAnalysisCandidatesFromTools } from "./ctoOvernight.mjs";
 import { resolveForgeOwner } from "./delegate.mjs";
 
 // BET-1395 tool discovery (§7): the registry engine — fusion of the four
@@ -994,6 +994,18 @@ export function createCtoEngine(deps = {}) {
     verdictsEngine = createVerdictEngine({ verdicts, now });
     verdictsEngine.registerCounterSink(factsCounterSink);
     verdictsEngine.registerCounterSink(tonightCounterSink);
+    // BET-1404 (§9.5): tool-as-source verdicts fold into the tool registry's
+    // as_source counters — the decay chain's input data. Late-bound registry
+    // handle: the tool registry is constructed lazily and the sink fires
+    // after any verdict, so resolve getTools() at fold time. Best-effort
+    // like every sink.
+    verdictsEngine.registerCounterSink(
+      createAsSourceSink({
+        registry: {
+          applyAsSource: (toolId, effects) => getTools().applyAsSource(toolId, effects),
+        },
+      }),
+    );
     // BET-1403 (§9.4): the trust counters ride the same §9.5 sink registry —
     // per-action-class Beta counters over class-attributed suggestion
     // verdicts. Best-effort like every sink: a failure never breaks verdict
@@ -1629,6 +1641,16 @@ export function createCtoEngine(deps = {}) {
     const candidates = [
       ...queueCandidatesFromRows(await tonightQueueRows()),
       ...watcherCandidatesFromRows(recentLedger),
+      // §7.6 (BET-1404): data-source analyses — one per deep-consented tool
+      // at argmax relevance, p_use = ewma × max(relevance). Best-effort: a
+      // registry hiccup must never take the overnight tick down.
+      ...await (async () => {
+        try {
+          return dataAnalysisCandidatesFromTools(await getTools().listTools());
+        } catch {
+          return [];
+        }
+      })(),
     ];
     let out = null;
     try {

--- a/src/server/ctoOvernight.mjs
+++ b/src/server/ctoOvernight.mjs
@@ -630,6 +630,88 @@ export function routeRequestShaped(candidate, providers = {}) {
 }
 
 /**
+ * §7.6 data-source candidates (BET-1404): ONE per deep-consented,
+ * chain-untripped, integrated tool, targeting the argmax-relevance project —
+ * emitted only when a relevance score exists. `p_use = vitality.ewma ×
+ * max(relevance)` (the scoring composition the issue fixes; selectivity
+ * lives here, value stays mid-lattice). `requestShaped: true` so §11.2
+ * batch routing picks them up where a provider adapter supports a batch
+ * pool. Experiment-first: a tool with zero as_source reports runs a forced-
+ * small first analysis (single probe window, halved context budget — carried
+ * in the prompt contract and a 0.5 predicted cost); its verdict seeds the
+ * as_source counters via the §9.5 sink.
+ * @param {Array<{tool: string, displayName?: string, status?: string,
+ *   consent?: {deep_read?: string|null}, asSourceDecayed?: boolean,
+ *   as_source?: {reports?: number, accepted?: number}, relevance?: Object,
+ *   vitality?: {ewma?: number|null}}>} tools registry projections (listTools)
+ */
+export function dataAnalysisCandidatesFromTools(tools) {
+  const out = [];
+  for (const t of Array.isArray(tools) ? tools : []) {
+    if (!t || typeof t !== "object" || typeof t.tool !== "string" || !t.tool) continue;
+    if (t.consent?.deep_read !== "yes") continue; // deep-consented only
+    if (t.status !== "integrated") continue; // probes actually ran
+    if (t.asSourceDecayed === true) continue; // chain tripped → analyses stopped
+    let project = null;
+    let best = 0;
+    for (const [p, r] of Object.entries(t.relevance ?? {})) {
+      const s = Number(r);
+      if (Number.isFinite(s) && s > best) {
+        best = s;
+        project = p;
+      }
+    }
+    if (project === null || !(best > 0)) continue; // only when a relevance score exists
+    const ewma = Number(t.vitality?.ewma);
+    if (!(Number.isFinite(ewma) && ewma > 0)) continue; // no live vitality → nothing fresh to mine
+    const name = t.displayName ?? t.tool;
+    const experiment = (t.asSource?.reports ?? t.as_source?.reports ?? 0) === 0;
+    const pUse = Math.max(0, Math.min(1, ewma * best));
+    out.push({
+      id: `data-source:${t.tool}`,
+      name: `Analyze ${name}'s data (overnight report)`,
+      prompt: dataAnalysisPrompt(name, project, { experiment }),
+      project,
+      category: "data-source",
+      pUse,
+      value: 1,
+      confidence: 0.5,
+      predictedCost: experiment ? 0.5 : 1,
+      requestShaped: true,
+      refs: [t.tool],
+    });
+  }
+  return out;
+}
+
+/**
+ * The data-analysis job's prompt contract (§11.5): read-only analysis of the
+ * tool's collected probe data, output = a draft REPORT markdown artifact in
+ * the worktree root, no code changes — a report runs no gates, so the
+ * standard no-gates note applies. Experiment-first appends the forced-small
+ * constraints (single most-recent probe window, ~half the context budget).
+ */
+export function dataAnalysisPrompt(name, project, { experiment = false } = {}) {
+  const slug = String(name ?? "tool")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const lines = [
+    `You are the Adaptive CTO's overnight analyst. Draft a findings REPORT on ${name}'s data for the "${project}" project.`,
+    ``,
+    `Read-only analysis: use the probe data the CTO already collected for ${name} (~/.manta/cto/probe-state/ and the tool registry) — no new credentials, no new API access beyond what the probes already cover, and NO code changes.`,
+    `Output: write your findings to REPORT-${slug || "tool"}.md in the worktree root — markdown, what the data shows, 3-5 concrete observations, any anomalies, one recommended next step. This is a report job: it runs no code gates and must leave the project untouched.`,
+  ];
+  if (experiment === true) {
+    lines.push(
+      ``,
+      `EXPERIMENT-FIRST CONSTRAINTS (first analysis for this tool): keep it deliberately small — use ONLY the single most recent probe window of data, spend no more than about half the normal context budget, and end with a one-line verdict on whether a deeper analysis looks worthwhile.`,
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
  * §11.5 draft expiry: unreviewed drafts close after 7 days with an `expire`
  * verdict and a one-line digest note. Returns the expired drafts (each with
  * its verdict row) and the survivors. Never throws; garbage entries are kept

--- a/src/server/ctoOvernight.test.mjs
+++ b/src/server/ctoOvernight.test.mjs
@@ -566,3 +566,81 @@ test("a trough-opened window closes when the profile re-derives the trough away 
   const rn = evaluateWindow(null, tickInput({ now: T0 + 2 * H, trough: shifted, runNow: true }));
   assert.equal(rn.window.state, "open");
 });
+
+// ---------------------------------------------------------------------------
+// BET-1404 — §7.6 data-source candidate source (p_use composition,
+// experiment-first, chain + consent gates)
+// ---------------------------------------------------------------------------
+
+import { dataAnalysisCandidatesFromTools, dataAnalysisPrompt } from "./ctoOvernight.mjs";
+
+function deepTool(overrides = {}) {
+  return {
+    tool: "github",
+    displayName: "GitHub",
+    status: "integrated",
+    consent: { metadata: "yes", deep_read: "yes", write: null },
+    asSourceDecayed: false,
+    asSource: { reports: 0, accepted: 0 },
+    relevance: { alpha: 0.7, beta: 0.3 },
+    vitality: { ewma: 0.8, last_event: 1, inflow_rate: 3, last_probed: 1 },
+    ...overrides,
+  };
+}
+
+test("dataAnalysisCandidatesFromTools: one candidate per deep-consented tool at argmax relevance; p_use = ewma × max(relevance)", () => {
+  const out = dataAnalysisCandidatesFromTools([deepTool()]);
+  assert.equal(out.length, 1);
+  const c = out[0];
+  assert.equal(c.id, "data-source:github");
+  assert.equal(c.project, "alpha", "argmax relevance picks the project");
+  assert.equal(c.category, "data-source");
+  assert.ok(Math.abs(c.pUse - 0.8 * 0.7) < 1e-9, `p_use = ewma × max(relevance), got ${c.pUse}`);
+  assert.equal(c.requestShaped, true, "§11.2 batch routing flag");
+  assert.deepEqual(c.refs, ["github"]);
+  assert.equal(c.value, 1);
+  assert.equal(c.confidence, 0.5);
+  assert.equal(c.predictedCost, 0.5, "reports=0 → the experiment-first shape (halved cost)");
+});
+
+test("dataAnalysisCandidatesFromTools: the gates exclude non-consented, non-integrated, decayed, vitality-dead, and relevance-less tools", () => {
+  const out = dataAnalysisCandidatesFromTools([
+    deepTool({ consent: { metadata: "yes", deep_read: null, write: null } }), // not deep-consented
+    deepTool({ status: "candidate" }), // probes never ran
+    deepTool({ asSourceDecayed: true }), // chain tripped → analyses stopped
+    deepTool({ vitality: { ewma: 0, last_event: 1, inflow_rate: 0, last_probed: 1 } }), // ewma=0 is not 'high' (Q1)
+    deepTool({ relevance: { alpha: 0.1 } }), // no relevance ≥ threshold... argmax exists but pUse>0 still — relevance score exists
+    deepTool({ relevance: {} }), // no relevance score at all → not emitted
+    deepTool(), // the eligible one
+  ]);
+  assert.equal(out.length, 2, "the 0.1-relevance tool emits (score exists; p_use carries selectivity); the empty-relevance one does not");
+  assert.deepEqual(out.map((c) => c.project).sort(), ["alpha", "alpha"]);
+});
+
+test("dataAnalysisCandidatesFromTools: experiment-first — the FIRST analysis is flagged small, later ones are full-size", () => {
+  const first = dataAnalysisCandidatesFromTools([deepTool({ asSource: { reports: 0, accepted: 0 } })]);
+  assert.equal(first.length, 1);
+  assert.equal(first[0].predictedCost, 0.5, "halved predicted cost for the experiment");
+  assert.match(first[0].prompt, /EXPERIMENT-FIRST CONSTRAINTS/);
+  assert.match(first[0].prompt, /single most recent probe window/);
+  assert.match(first[0].prompt, /half the normal context budget/);
+  const later = dataAnalysisCandidatesFromTools([deepTool({ asSource: { reports: 2, accepted: 1 } })]);
+  assert.equal(later.length, 1);
+  assert.equal(later[0].predictedCost, 1);
+  assert.ok(!later[0].prompt.includes("EXPERIMENT-FIRST"));
+  // every prompt carries the §11.5 report-artifact contract
+  assert.match(first[0].prompt, /REPORT-github\.md/);
+  assert.match(first[0].prompt, /no code gates/);
+});
+
+test("dataAnalysisCandidatesFromTools: survives garbage input (graceful-empty)", () => {
+  assert.deepEqual(dataAnalysisCandidatesFromTools(null), []);
+  assert.deepEqual(dataAnalysisCandidatesFromTools([null, 42, { tool: "" }, "x"]), []);
+});
+
+test("dataAnalysisPrompt: concrete intent names the tool and the project", () => {
+  const p = dataAnalysisPrompt("GitHub", "alpha", { experiment: false });
+  assert.match(p, /GitHub/);
+  assert.match(p, /alpha/);
+  assert.match(p, /REPORT/);
+});

--- a/src/server/ctoProbes.mjs
+++ b/src/server/ctoProbes.mjs
@@ -729,7 +729,16 @@ export function createProbes(deps = {}) {
     if (!raw || typeof raw !== "object") return null;
     const ctx = await consentContext(tool);
     const check = validateProbeSpec(raw, { tool, allowedHosts: ctx.allowedHosts, consentedRing: ctx.consentedRing });
-    return check.ok ? { spec: raw, ctx } : null;
+    if (check.ok) return { spec: raw, ctx };
+    // A consent REVOCATION narrows the tool's ring after authoring: ring-
+    // escalation errors drop just those probes (the tool's metadata probes
+    // keep running — losing deep_read must not invalidate the whole spec).
+    // Any other validation failure still does.
+    const escalated = new Set(check.errors.filter((e) => typeof e?.key === "string" && e.key.endsWith(".ring")).map((e) => e.key));
+    if (escalated.size === 0 || check.errors.length > escalated.size) return null;
+    const kept = (Array.isArray(raw.probes) ? raw.probes : []).filter((_, i) => !escalated.has(`probes[${i}].ring`));
+    if (kept.length === 0) return null;
+    return { spec: { ...raw, probes: kept }, ctx };
   }
 
   // ---- spec authoring (engine-written; the AI's content goes through here) —

--- a/src/server/ctoProbes.mjs
+++ b/src/server/ctoProbes.mjs
@@ -846,7 +846,18 @@ export function createProbes(deps = {}) {
     }
 
     const vit = registry.toolRow ? await registry.toolRow(tool) : null;
-    const cadence = effectiveCadenceMs(cadenceMs(probe.cadence), vit?.vitality);
+    let cadence = effectiveCadenceMs(cadenceMs(probe.cadence), vit?.vitality);
+    // §7.6 decay chain (BET-1404, Q2 cascade): a chain-tripped tool probes at
+    // most weekly — the registry is the chain's source of truth, the runner
+    // just asks. The cap only ever slows probing down (max, never min).
+    if (registry.probeCadenceCapMs) {
+      try {
+        const cap = await registry.probeCadenceCapMs(tool);
+        if (Number.isFinite(cap) && cap > 0) cadence = Math.max(cadence, cap);
+      } catch {
+        /* best-effort — the standard cadence stands */
+      }
+    }
 
     if (ok) {
       // Vitality + adaptive cadence + lifecycle (§7.3, §7.4).
@@ -974,6 +985,20 @@ export function createProbes(deps = {}) {
           (typeof pst.nextRunAt === "number" && pst.nextRunAt <= ts);
         if (!due) continue;
         if (thrifty && !exempt.has(probeKey(tool, probe.name))) continue;
+        // Deep-ring probes run only while the tool's deep_read consent is
+        // CURRENTLY "yes" (BET-1404). The authoring gate validated the spec
+        // against the ring at write time; this re-checks the live source of
+        // truth so a revocation stops deep probes on the next tick without
+        // invalidating the tool's metadata probes.
+        if (probe.ring === "deep_read") {
+          let deepOk = false;
+          try {
+            deepOk = (await registry.consentFor(tool, "deep_read")) === "yes";
+          } catch {
+            deepOk = false;
+          }
+          if (!deepOk) continue;
+        }
         results.push(await runOne(tool, spec, probe, st, { ts }));
         touched = true;
       }

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -941,3 +941,72 @@ function memStore(initial = {}) {
     _state: () => state,
   };
 }
+
+// ---------------------------------------------------------------------------
+// BET-1404 — deep-ring probes for deep-consented tools (characterization) +
+// the §7.6 decay chain's weekly probing cap
+// ---------------------------------------------------------------------------
+
+test("runDue: a deep-ring probe runs for a deep-consented tool; a metadata-only tool never runs it", async () => {
+  const deepSpec = () => {
+    const s = githubSpec();
+    s.probes[0].ring = "deep_read";
+    return s;
+  };
+  // deep-consented → the probe runs
+  const deep = build({
+    rows: [{ ...consentedTool(), consent: { metadata: "yes", deep_read: "yes", write: null } }],
+    specs: { github: deepSpec() },
+  });
+  const results = await deep.runDue();
+  assert.equal(results.length, 1, "deep-consented tool runs its deep-ring probe");
+  assert.equal(results[0].ok, true);
+  // metadata-only consent → the runner re-checks the live source of truth and skips
+  const meta = build({
+    rows: [consentedTool()],
+    specs: { github: deepSpec() },
+  });
+  assert.equal((await meta.runDue()).length, 0, "no deep probe without deep consent");
+});
+
+test("runDue: revoking deep consent stops the deep probe but the metadata probe still runs", async () => {
+  const s = githubSpec();
+  s.probes = [
+    { name: "meta_probe", method: "GET", url: "https://api.github.com/users/octocat/events", extract: { inflow_rate: "length" }, cadence: "30m", ring: "metadata" },
+    { name: "deep_probe", method: "GET", url: "https://api.github.com/users/octocat/events/full", extract: { inflow_rate: "length" }, cadence: "30m", ring: "deep_read" },
+  ];
+  const eng = build({
+    rows: [{ ...consentedTool(), consent: { metadata: "yes", deep_read: "no", write: null } }],
+    specs: { github: s },
+  });
+  const results = await eng.runDue();
+  assert.equal(results.length, 1);
+  assert.equal(results[0].probe, "github/meta_probe", "only the metadata probe ran");
+});
+
+test("runOne: a chain-tripped tool's probing cadence is capped at weekly (registry is the chain's source of truth)", async () => {
+  const base = fakeRegistry([{ ...consentedTool(), asSourceDecayed: true }]);
+  const eng = createProbes({
+    registry: {
+      ...base,
+      probeCadenceCapMs: async (tool) => (tool === "github" ? CADENCE_WEEKLY_MS : null),
+    },
+    probes: memProbesStore({ github: githubSpec() }),
+    stateStore: memStateStore(),
+    cards: fakeCards(),
+    ledger: fakeLedger(),
+    now: () => 1_700_000_000_000,
+    httpRequest: async () => ({ status: 200, bodyText: JSON.stringify([{ created_at: "2026-08-20T00:00:00Z" }]) }),
+    getSecretPath: async () => "/tmp/secret-file",
+    readSecret: async () => "sekrit-value",
+    isThrifty: () => false,
+    listProjects: async () => ["proj"],
+    getTopFacts: async () => [],
+    getRollups: async () => "",
+    runEphemeral: null,
+  });
+  const results = await eng.runDue();
+  assert.equal(results.length, 1);
+  const st = await eng.loadToolState("github");
+  assert.equal(st.probes.repo_events.nextRunAt, 1_700_000_000_000 + CADENCE_WEEKLY_MS, "30m spec capped at weekly while decayed");
+});

--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -540,6 +540,22 @@ export function createToolRegistry(deps = {}) {
       }
     }
 
+    // §7.6 decay-chain revival (§7.3/B7): renewed engagement re-promotes a
+    // tripped tool — fresh uses beyond the trip's snapshot clear the flag
+    // (deep analyses + candidate generation resume) and the deep-read ask
+    // re-arms on the §7.4 30-day timer. No second dormancy definition: the
+    // standard lifecycle owns everything downstream (Q2 decision).
+    for (const t of payload.tools) {
+      if (t?.asSourceDecayed !== true) continue;
+      if ((t?.uses ?? 0) > (t?.decayedAtUses ?? 0) + REARM_FRESH_USES) {
+        t.asSourceDecayed = false;
+        t.decayedAtUses = 0;
+        t.deepReArmAt = nowMs + NOT_NOW_REARM_MS;
+        changed = true;
+        await ledgerLog({ kind: "cto.tool.as_source_revived", tool: t.tool, uses: t.uses ?? 0 });
+      }
+    }
+
     // Promote observed → candidate when either axis crosses its bar. After an
     // un-never (§7.4: "returns the tool to observed; a new ask still requires
     // a fresh bar crossing") the promotion needs NEW engagement beyond the
@@ -614,6 +630,54 @@ export function createToolRegistry(deps = {}) {
         changed = true;
         await ledgerLog({ kind: "cto.tool.ask", tool: t.tool, askRound: t.askRound });
       }
+
+      // Deep-read ask (§7.6, BET-1404): one ring up from metadata — for an
+      // integrated tool whose metadata consent exists but deep_read hasn't
+      // been asked (or was declined and re-armed), whose vitality × relevance
+      // clears the bar. The ask states the concrete intent (analyze <tool>'s
+      // data about <project> overnight and report findings). Ring semantics
+      // per §7.4: never/not-now rules identical (30-day timer re-arm only —
+      // the bar's vitality half cannot re-cross); ≤1 new ask/day; never for
+      // a chain-tripped tool (the cascade stopped deep analyses).
+      const deepEligible = payload.tools
+        .filter((t) => {
+          if (t?.status !== "integrated" || t?.asSourceDecayed === true) return false;
+          const consent = t?.consent ?? {};
+          if (consent.metadata !== "yes") return false;
+          if (consent.deep_read === "yes" || consent.deep_read === "never") return false;
+          if ((t?.deepAskRound ?? 0) >= MAX_ASK_ROUNDS) return false;
+          if (consent.deep_read === "no") {
+            // Vitality-path rule: the 30-day timer is the only re-arm.
+            if (!(t?.deepReArmAt != null && nowMs >= t.deepReArmAt)) return false;
+          }
+          if (openConnectTools.has(t.tool)) return false;
+          return deepReadBar(t).met;
+        })
+        .sort((a, b) => (b?.uses ?? 0) - (a?.uses ?? 0));
+
+      if (deepEligible.length && payload.lastDeepAskDay !== today) {
+        const t = deepEligible[0];
+        if (t.consent?.deep_read === "no") t.consent.deep_read = null; // re-armed
+        const bar = deepReadBar(t);
+        const name = t.displayName ?? t.tool;
+        const ev = (t?.evidence ?? []).slice(-4).map((e) => `${e?.channel}: ${e?.detail}`);
+        await cards.upsertConnect({
+          toolId: t.tool,
+          ring: "deep_read",
+          title: `Let the CTO analyze ${name}'s data?`,
+          body: `The CTO would analyze ${name}'s data about ${bar.project} overnight and report findings — one read-only pass beyond metadata. Reports can be dismissed, and ignored reports wind the analyses down.`,
+          evidence: ev,
+          refs: [t.tool],
+          ts: nowMs,
+        });
+        t.deepAskRound = (t.deepAskRound ?? 0) + 1;
+        t.deepAskAtUses = t.uses ?? 0;
+        t.deepReArmAt = null;
+        t.deepAskBarMet = bar.met;
+        payload.lastDeepAskDay = today;
+        changed = true;
+        await ledgerLog({ kind: "cto.tool.deep_ask", tool: t.tool, project: bar.project, askRound: t.deepAskRound });
+      }
     }
 
     return { changed, asked };
@@ -655,13 +719,22 @@ export function createToolRegistry(deps = {}) {
     return { ok: true, scanned: rows.length, asked: asked ?? null };
   }
 
-  // Resolve a connect ask (§7.4 three-way). Writes the consent ring, the
-  // §9.5 verdict (accept / dismiss / never), and resolves the open card.
-  async function resolveConnect({ tool, answer } = {}) {
+  // Resolve a connect ask (§7.4 three-way, per ring). Writes the consent
+  // ring, the §9.5 verdict (accept / dismiss / never), and resolves the open
+  // card. `ring` selects which ring the ask was about: "metadata" (default)
+  // or "deep_read" (BET-1404 — the deep-read ask's connect grants deep_read,
+  // its not-now re-arms on the 30-day timer; never kills ALL rings either
+  // way). A deep_read grant backstops on metadata consent (the ask gate
+  // already requires it; this keeps a hand-crafted answer from skipping a
+  // ring).
+  async function resolveConnect({ tool, answer, ring = "metadata" } = {}) {
     const id = typeof tool === "string" ? tool.trim().toLowerCase() : "";
     if (!id) return { ok: false, error: "missing tool" };
     if (answer !== "connect" && answer !== "not-now" && answer !== "never") {
       return { ok: false, error: `invalid answer "${answer}"` };
+    }
+    if (ring !== "metadata" && ring !== "deep_read") {
+      return { ok: false, error: `invalid ring "${ring}"` };
     }
     const payload = await loadPayload();
     const t = payload.tools.find((x) => x?.tool === id);
@@ -669,24 +742,38 @@ export function createToolRegistry(deps = {}) {
     const nowMs = now();
     t.consent = t.consent ?? emptyConsent();
     if (answer === "connect") {
-      // The metadata ring is granted. Status stays `candidate` until the
-      // first §7.5 probe actually runs (applyProbeResult flips it).
-      t.consent.metadata = "yes";
-      t.reArmAt = null;
-      await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "yes" });
-      // §7.5 BET-1396: the ENGINE authors the tool's probe-spec template at
-      // consent time, filled with the evidenced credential key (if any). The
-      // file is engine-written; its content is completed through the runner's
-      // validated writeSpec path. Best-effort — consent never depends on it.
-      if (typeof scaffoldProbes === "function") {
-        const secretRow = (t.evidence ?? []).find((e) => e?.channel === "secret" && typeof e?.detail === "string" && e.detail.startsWith("secret:"));
-        await scaffoldProbes(id, { secret: secretRow ? secretRow.detail.slice("secret:".length) : null }).catch(() => {});
+      if (ring === "deep_read") {
+        if (t.consent.metadata !== "yes") return { ok: false, error: `tool "${id}" has no metadata consent` };
+        t.consent.deep_read = "yes";
+        t.deepReArmAt = null;
+        await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "deep_read", value: "yes" });
+      } else {
+        // The metadata ring is granted. Status stays `candidate` until the
+        // first §7.5 probe actually runs (applyProbeResult flips it).
+        t.consent.metadata = "yes";
+        t.reArmAt = null;
+        await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "yes" });
+        // §7.5 BET-1396: the ENGINE authors the tool's probe-spec template at
+        // consent time, filled with the evidenced credential key (if any). The
+        // file is engine-written; its content is completed through the runner's
+        // validated writeSpec path. Best-effort — consent never depends on it.
+        if (typeof scaffoldProbes === "function") {
+          const secretRow = (t.evidence ?? []).find((e) => e?.channel === "secret" && typeof e?.detail === "string" && e.detail.startsWith("secret:"));
+          await scaffoldProbes(id, { secret: secretRow ? secretRow.detail.slice("secret:".length) : null }).catch(() => {});
+        }
       }
     } else if (answer === "not-now") {
-      t.consent.metadata = "no";
-      t.reArmAt = nowMs + NOT_NOW_REARM_MS;
-      t.askAtUses = t.uses ?? 0;
-      await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "no" });
+      if (ring === "deep_read") {
+        t.consent.deep_read = "no";
+        t.deepReArmAt = nowMs + NOT_NOW_REARM_MS;
+        t.deepAskAtUses = t.uses ?? 0;
+        await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "deep_read", value: "no" });
+      } else {
+        t.consent.metadata = "no";
+        t.reArmAt = nowMs + NOT_NOW_REARM_MS;
+        t.askAtUses = t.uses ?? 0;
+        await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "no" });
+      }
     } else {
       // Never: kills ALL rings and suppresses future asks (revocable only in
       // the §10.5 tool drill-down).
@@ -696,15 +783,18 @@ export function createToolRegistry(deps = {}) {
     await savePayload(payload);
 
     // §9.5: every UI control that expresses a judgment writes exactly one
-    // verdict. Connect → accept; Not now → dismiss; Never → never.
+    // verdict. Connect → accept; Not now → dismiss; Never → never. The class
+    // names the ring the ask was about (metadata / deep-read), so §9.4
+    // per-class trust counting and the as_source sink stay unambiguous.
     if (typeof recordVerdict === "function") {
       try {
+        const subjectClass = ring === "deep_read" ? "tool-deep-read" : "tool-metadata";
         if (answer === "connect") {
-          await recordVerdict({ subject: { type: "tool", id, class: "tool-metadata" }, verdict: "accept" });
+          await recordVerdict({ subject: { type: "tool", id, class: subjectClass }, verdict: "accept" });
         } else if (answer === "not-now") {
-          await recordVerdict({ subject: { type: "tool", id, class: "tool-metadata" }, verdict: "dismiss" });
+          await recordVerdict({ subject: { type: "tool", id, class: subjectClass }, verdict: "dismiss" });
         } else {
-          await recordVerdict({ subject: { type: "tool", id, class: "tool-metadata" }, verdict: "never", never: true });
+          await recordVerdict({ subject: { type: "tool", id, class: subjectClass }, verdict: "never", never: true });
         }
       } catch {
         /* best-effort — the consent ring is the source of truth */
@@ -792,6 +882,15 @@ export function createToolRegistry(deps = {}) {
     return payload.tools.find((x) => x?.tool === id) ?? null;
   }
 
+  // The §7.6 decay chain's probing cap (Q2 cascade): a chain-tripped tool's
+  // metadata probes run AT MOST weekly. The runner consults this instead of
+  // deriving chain state itself — one source of truth for the chain's
+  // effects, and the reason CADENCE_WEEKLY_MS lives in this module.
+  async function probeCadenceCapMs(toolId) {
+    const row = await toolRow(toolId);
+    return row?.asSourceDecayed === true ? CADENCE_WEEKLY_MS : null;
+  }
+
   // §7.3 vitality: fold ONE successful metadata probe's extract into the
   // vitality axis. `fields` is the probe's extract map (untrusted but tiny);
   // only the §7.2 well-known pair {last_event, inflow_rate} is consumed.
@@ -848,6 +947,47 @@ export function createToolRegistry(deps = {}) {
     return { ok: true };
   }
 
+  // §9.5 as_source sink target (BET-1404): fold one tool-as-source verdict's
+  // effects into the §7.2 counters — accept/edit (`success`) → accepted+1 &
+  // reports+1; dismiss/veto/correct/never (`rejection`) → reports+1;
+  // `access`/`decay` (open/expire) are ephemeral and never enter the
+  // acceptance counters. After a report fold, evaluate the §7.6 dismissal
+  // decay chain's trip: ≥ AS_SOURCE_MIN_REPORTS reports AND the Beta lower
+  // bound below AS_SOURCE_DECAY_LOWER_BOUND flips `asSourceDecayed` — the
+  // Q2 one-shot cascade (deep analyses stop, probing caps at weekly, dormant
+  // is the §7.3 dead condition). Revival is the fresh-engagement path in
+  // lifecycleStep (§7.3/B7: renewed engagement re-promotes).
+  async function applyAsSource(toolId, effects) {
+    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
+    if (!id) return { ok: false, error: "missing tool" };
+    const e = effects && typeof effects === "object" ? effects : {};
+    const isReport = e.success === true || e.rejection === true;
+    if (!isReport) return { ok: true, changed: false };
+    const r = await resolveToolRow(id);
+    if (!r.ok) return r;
+    const { payload, t } = r;
+    t.as_source = t.as_source ?? { reports: 0, accepted: 0 };
+    if (e.success === true) t.as_source.accepted = (t.as_source.accepted ?? 0) + 1;
+    t.as_source.reports = (t.as_source.reports ?? 0) + 1;
+    const reports = t.as_source.reports;
+    const rejected = reports - (t.as_source.accepted ?? 0);
+    const tripped =
+      reports >= AS_SOURCE_MIN_REPORTS &&
+      betaLowerBound(t.as_source.accepted ?? 0, rejected) < AS_SOURCE_DECAY_LOWER_BOUND;
+    if (tripped && t.asSourceDecayed !== true) {
+      t.asSourceDecayed = true;
+      t.decayedAtUses = t.uses ?? 0;
+      await ledgerLog({
+        kind: "cto.tool.as_source_decayed",
+        tool: id,
+        reports,
+        accepted: t.as_source.accepted ?? 0,
+      });
+    }
+    await savePayload(payload);
+    return { ok: true, changed: true, as_source: { ...t.as_source }, decayed: t.asSourceDecayed === true };
+  }
+
   // One evidence row on the tool's trail (probe failures; §7.2 evidence
   // shape). Deduped on (channel, detail); capped at EVIDENCE_CAP.
   async function appendEvidence(toolId, entry) {
@@ -891,6 +1031,10 @@ export function createToolRegistry(deps = {}) {
         vitality,
         consent: { ...emptyConsent(), ...(row.consent ?? {}) },
         askRound: row.askRound ?? 0,
+        // §7.6 chain visibility (§10.5 drill-down): counters + trip state so
+        // the surface can explain why deep analyses stopped — no dead state.
+        asSource: { ...(row.as_source ?? { reports: 0, accepted: 0 }) },
+        asSourceDecayed: row.asSourceDecayed === true,
       };
     });
   }
@@ -910,6 +1054,12 @@ export function createToolRegistry(deps = {}) {
     applyProbeResult: (toolId, input) => serialized(() => applyProbeResult(toolId, input)),
     applyRelevance: (toolId, project, score) => serialized(() => applyRelevance(toolId, project, score)),
     appendEvidence: (toolId, entry) => serialized(() => appendEvidence(toolId, entry)),
+    // §9.5 as_source sink target (BET-1404) — serialized like the other
+    // whole-payload writers; the verdict sink is fire-and-forget, so the
+    // guard keeps concurrent folds from clobbering each other.
+    applyAsSource: (toolId, effects) => serialized(() => applyAsSource(toolId, effects)),
+    // §7.6 decay chain: the runner asks instead of deriving chain state.
+    probeCadenceCapMs,
   };
 }
 

--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -1035,6 +1035,9 @@ export function createToolRegistry(deps = {}) {
         // the surface can explain why deep analyses stopped — no dead state.
         asSource: { ...(row.as_source ?? { reports: 0, accepted: 0 }) },
         asSourceDecayed: row.asSourceDecayed === true,
+        // §7.6 relevance map (BET-1404 overnight candidates read it through
+        // this projection; also drives the drill-down's relevance display).
+        relevance: { ...(row.relevance ?? {}) },
       };
     });
   }

--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -31,7 +31,8 @@ import {
 } from "./ctoToolScan.mjs";
 // One-way dep (ctoProbes never imports this module): the §7.2 well-known
 // vitality pair {last_event, inflow_rate} pulled from a probe's extract map.
-import { vitalityOf } from "./ctoProbes.mjs";
+import { vitalityOf, CADENCE_WEEKLY_MS } from "./ctoProbes.mjs";
+import { betaLowerBound } from "./ctoVerdicts.mjs";
 
 export const TOOL_REGISTRY_VERSION = 1;
 export const ACTOR = "cto";
@@ -55,6 +56,17 @@ export const MAX_ASK_ROUNDS = 3;
 // "a fresh axis-bar crossing"; the vitality path's bar cannot re-cross, so
 // for credentials only the 30-day timer re-arms).
 export const REARM_FRESH_USES = 2;
+// Deep-read ask bar (spec §7.6 + BET-1404 on-call decision): max relevance
+// ≥ 0.5. The vitality half of the bar is `ewma > 0` — the only vitality
+// threshold precedent in shipped code (the daily-cadence regime,
+// `effectiveCadenceMs`); selectivity belongs to the relevance half.
+export const DEEP_RELEVANCE_MIN = 0.5;
+// Dismissal decay chain (spec §7.6): trip when the as_source Beta lower bound
+// drops below 0.3 after ≥3 reports (§9.4's 0.95 tail convention). "Then
+// dormant" is the §7.3 dead condition under the standard lifecycle — no
+// second dormancy definition lives here.
+export const AS_SOURCE_MIN_REPORTS = 3;
+export const AS_SOURCE_DECAY_LOWER_BOUND = 0.3;
 // The classification task class (§12.1 — cheapest nano tier).
 export const TOOL_CLASSIFY_TASK_CLASS = "ambient-summarize";
 
@@ -114,6 +126,15 @@ function baseTool(identity, ts) {
     askAtUses: 0,
     reArmAt: null,
     unneverAtUses: null,
+    // Deep-read ring ask bookkeeping (§7.4 ring semantics apply per ask).
+    deepAskRound: 0,
+    deepAskAtUses: 0,
+    deepReArmAt: null,
+    deepAskBarMet: false, // the deep bar's met-state snapshot at ask time
+    lastDeepAskDay: null,
+    // Dismissal decay chain (§7.6): the as_source trip's persisted state.
+    asSourceDecayed: false,
+    decayedAtUses: 0,
     llmAt: null,
     relevance: {}, // §7.6 blackboard match — refreshed weekly (later issue)
     as_source: { reports: 0, accepted: 0 }, // §7.2 counters — fed by §9.5 later
@@ -164,6 +185,32 @@ export function deriveRole(tool, { nowMs = Date.now() } = {}) {
 // Either axis crossed its bar (§7.4 observed → candidate).
 export function barCrossed(tool) {
   return engagementBarMet(tool) || hasCredential(tool);
+}
+
+// The deep-read ask bar (§7.6): a tool with metadata consent whose vitality ×
+// relevance clears the bar — vitality EWMA high (`ewma > 0`, the daily-cadence
+// regime; BET-1404 on-call decision) AND max relevance ≥ 0.5. Returns the
+// bar's state plus the argmax-relevance project (what the ask's concrete
+// intent names). `met` implies metadata consent; the deep ask adds its own
+// consent gates on top.
+export function deepReadBar(tool) {
+  const consent = tool?.consent ?? {};
+  if (consent.metadata !== "yes") return { met: false, project: null, relevance: 0 };
+  const ewma = tool?.vitality?.ewma;
+  if (!(typeof ewma === "number" && ewma > 0)) return { met: false, project: null, relevance: 0 };
+  let project = null;
+  let best = 0;
+  for (const [p, r] of Object.entries(tool?.relevance ?? {})) {
+    const s = Number(r);
+    if (Number.isFinite(s) && s > best) {
+      best = s;
+      project = p;
+    }
+  }
+  if (project === null || !(best >= DEEP_RELEVANCE_MIN)) {
+    return { met: false, project, relevance: best };
+  }
+  return { met: true, project, relevance: best };
 }
 
 // Near-duplicate suppression (§7.3): a host that is a subdomain of an
@@ -310,13 +357,26 @@ export function createToolRegistry(deps = {}) {
       const p = await registryStore.load();
       return {
         v: TOOL_REGISTRY_VERSION,
-        tools: Array.isArray(p?.tools) ? p.tools : [],
+        // Rows persisted before the deep-read/decay fields existed are
+        // back-filled here so every consumer sees the fields at their
+        // §7.2-schema defaults (spread order: stored row wins).
+        tools: (Array.isArray(p?.tools) ? p.tools : []).map((t) => ({
+          deepAskRound: 0,
+          deepAskAtUses: 0,
+          deepReArmAt: null,
+          deepAskBarMet: false,
+          lastDeepAskDay: null,
+          asSourceDecayed: false,
+          decayedAtUses: 0,
+          ...(t ?? {}),
+        })),
         lastScanTs: Number.isFinite(p?.lastScanTs) ? p.lastScanTs : null,
         lastFusedTs: Number.isFinite(p?.lastFusedTs) ? p.lastFusedTs : null,
         lastAskDay: typeof p?.lastAskDay === "string" ? p.lastAskDay : null,
+        lastDeepAskDay: typeof p?.lastDeepAskDay === "string" ? p.lastDeepAskDay : null,
       };
     } catch {
-      return { v: TOOL_REGISTRY_VERSION, tools: [], lastScanTs: null, lastFusedTs: null, lastAskDay: null };
+      return { v: TOOL_REGISTRY_VERSION, tools: [], lastScanTs: null, lastFusedTs: null, lastAskDay: null, lastDeepAskDay: null };
     }
   }
 

--- a/src/server/ctoToolRegistry.test.mjs
+++ b/src/server/ctoToolRegistry.test.mjs
@@ -672,3 +672,222 @@ test("revoke then un-never-style lifecycle: a revoked tool can re-grant on a fre
   const t = registryStore._state().tools.find((x) => x.tool === "aws");
   assert.equal(t.status, statusBefore, "revoke narrows features; it does not reset the lifecycle");
 });
+
+// ---------------------------------------------------------------------------
+// BET-1404 — deep-read asks, as_source counters, dismissal decay chain
+// ---------------------------------------------------------------------------
+
+import { deepReadBar, AS_SOURCE_MIN_REPORTS, AS_SOURCE_DECAY_LOWER_BOUND } from "./ctoToolRegistry.mjs";
+import { CADENCE_WEEKLY_MS } from "./ctoProbes.mjs";
+import { betaLowerBound } from "./ctoVerdicts.mjs";
+
+// An integrated tool that clears the deep-read bar: metadata consented,
+// live vitality, and a relevance argmax above 0.5.
+function deepEligibleRow(overrides = {}) {
+  return {
+    tool: "github",
+    displayName: "GitHub",
+    status: "integrated",
+    consent: { metadata: "yes", deep_read: null, write: null },
+    engagement: { ewma_per_week: 4, last_used: W0, per_project: {} },
+    vitality: { last_event: W0 - DAY, inflow_rate: 3, ewma: 0.8, last_probed: W0 - DAY },
+    ewmaAt: W0,
+    uses: 6,
+    weeks: [weekKey(W0), weekKey(W0 - 7 * DAY)],
+    evidence: [],
+    relevance: { alpha: 0.7, beta: 0.3 },
+    as_source: { reports: 0, accepted: 0 },
+    askRound: 1,
+    firstSeenTs: W0 - 30 * DAY,
+    ...overrides,
+  };
+}
+
+function seededRegistry(rows, { nowMs = W0 + DAY } = {}) {
+  const registryStore = memStore({ tools: rows, lastScanTs: W0, lastAskDay: null, lastDeepAskDay: null });
+  const cards = fakeCards();
+  const ledger = fakeLedger();
+  const registry = createToolRegistry({ registryStore, usageStore: memStore({ rows: [] }), cards, ledger, now: () => nowMs });
+  return { registry, registryStore, cards, ledger };
+}
+
+test("thresholds match the BET-1404 on-call decisions", () => {
+  assert.equal(AS_SOURCE_MIN_REPORTS, 3);
+  assert.equal(AS_SOURCE_DECAY_LOWER_BOUND, 0.3);
+});
+
+test("deepReadBar: metadata yes + ewma>0 + max relevance >= 0.5 (Q1: no invented vitality floor)", () => {
+  assert.equal(deepReadBar(deepEligibleRow()).met, true);
+  assert.equal(deepReadBar(deepEligibleRow()).project, "alpha");
+  // each leg missing → not met
+  assert.equal(deepReadBar(deepEligibleRow({ consent: { metadata: "no", deep_read: null, write: null } })).met, false);
+  assert.equal(deepReadBar(deepEligibleRow({ vitality: { last_event: null, inflow_rate: null, ewma: null, last_probed: null } })).met, false);
+  assert.equal(deepReadBar(deepEligibleRow({ vitality: { last_event: W0, inflow_rate: 1, ewma: 0, last_probed: W0 } })).met, false, "ewma=0 is not 'high' — the bar is ewma > 0");
+  assert.equal(deepReadBar(deepEligibleRow({ relevance: { alpha: 0.49 } })).met, false);
+  assert.equal(deepReadBar(deepEligibleRow({ relevance: {} })).met, false);
+});
+
+test("deep-read ask: the bar crossing raises ONE concrete ask (ring deep_read, intent in the copy), once per day", async () => {
+  const { registry, registryStore, cards, ledger } = seededRegistry([deepEligibleRow()]);
+  const out = await registry.dailyScan();
+  assert.equal(out.ok, true);
+  assert.equal(cards.calls.upserts.length, 1, JSON.stringify(cards.calls.upserts));
+  const ask = cards.calls.upserts[0];
+  assert.equal(ask.ring, "deep_read");
+  assert.equal(ask.toolId, "github");
+  assert.match(ask.body, /analyze GitHub's data about alpha overnight and report findings/);
+  const row = registryStore._state().tools.find((x) => x.tool === "github");
+  assert.equal(row.deepAskRound, 1);
+  assert.equal(row.deepAskBarMet, true);
+  assert.equal(registryStore._state().lastDeepAskDay, new Date(W0 + DAY).toISOString().slice(0, 10));
+  assert.ok(ledger.rows.some((r) => r.kind === "cto.tool.deep_ask" && r.project === "alpha"));
+  // same day again → no second ask
+  await registry.dailyScan();
+  assert.equal(cards.calls.upserts.length, 1);
+  // next day → the gate re-opens (askRound < 3), one more ask
+  const { registry: reg2, cards: cards2 } = seededRegistry(
+    [deepEligibleRow({ deepAskRound: 1, deepAskBarMet: true })],
+    { nowMs: W0 + 2 * DAY },
+  );
+  await reg2.dailyScan();
+  assert.equal(cards2.calls.upserts.length, 1);
+});
+
+test("deep-read ask: consented, rounds exhausted, and chain-tripped tools are skipped", async () => {
+  // already deep-consented
+  const a = seededRegistry([deepEligibleRow({ consent: { metadata: "yes", deep_read: "yes", write: null } })]);
+  await a.registry.dailyScan();
+  assert.equal(a.cards.calls.upserts.length, 0);
+  // rounds exhausted
+  const b = seededRegistry([deepEligibleRow({ deepAskRound: 3 })]);
+  await b.registry.dailyScan();
+  assert.equal(b.cards.calls.upserts.length, 0);
+  // chain tripped
+  const c = seededRegistry([deepEligibleRow({ asSourceDecayed: true, decayedAtUses: 6 })]);
+  await c.registry.dailyScan();
+  assert.equal(c.cards.calls.upserts.length, 0);
+});
+
+test("deep-read ask: a declined ask re-arms ONLY on the 30-day timer (vitality path)", async () => {
+  const row = deepEligibleRow({ consent: { metadata: "yes", deep_read: "no", write: null }, deepAskRound: 1, deepAskAtUses: 6, deepReArmAt: W0 + DAY + 10 * DAY });
+  const { registry, cards } = seededRegistry([row]);
+  await registry.dailyScan();
+  assert.equal(cards.calls.upserts.length, 0, "timer not elapsed — no ask");
+  const row2 = deepEligibleRow({ consent: { metadata: "yes", deep_read: "no", write: null }, deepAskRound: 1, deepAskAtUses: 6, deepReArmAt: W0 + DAY - 1000 });
+  const { registry: r2, cards: c2, registryStore: s2 } = seededRegistry([row2]);
+  await r2.dailyScan();
+  assert.equal(c2.calls.upserts.length, 1);
+  const after = s2._state().tools.find((x) => x.tool === "github");
+  assert.equal(after.consent.deep_read, null, "re-armed");
+  assert.equal(after.deepAskRound, 2);
+});
+
+test("resolveConnect deep_read ring: connect grants deep read (metadata backstop); not-now re-arms; never kills all rings; bad ring rejected", async () => {
+  // grant — requires metadata consent
+  const ok = seededRegistry([deepEligibleRow()]);
+  const granted = await ok.registry.resolveConnect({ tool: "github", answer: "connect", ring: "deep_read" });
+  assert.equal(granted.ok, true);
+  const grantedRow = ok.registryStore._state().tools.find((x) => x.tool === "github");
+  assert.equal(grantedRow.consent.deep_read, "yes");
+  assert.ok(ok.ledger.rows.some((r) => r.kind === "cto.tool.consent" && r.ring === "deep_read" && r.value === "yes"));
+  // grant without metadata consent → refused
+  const noMeta = seededRegistry([deepEligibleRow({ consent: { metadata: "no", deep_read: null, write: null } })]);
+  const refused = await noMeta.registry.resolveConnect({ tool: "github", answer: "connect", ring: "deep_read" });
+  assert.equal(refused.ok, false);
+  // not-now re-arms on the 30-day timer
+  const later = seededRegistry([deepEligibleRow({ deepAskRound: 1 })]);
+  const declined = await later.registry.resolveConnect({ tool: "github", answer: "not-now", ring: "deep_read" });
+  assert.equal(declined.ok, true);
+  const declinedRow = later.registryStore._state().tools.find((x) => x.tool === "github");
+  assert.equal(declinedRow.consent.deep_read, "no");
+  assert.equal(declinedRow.deepReArmAt, W0 + DAY + 30 * DAY);
+  // never kills every ring regardless of the ask's ring
+  const never = seededRegistry([deepEligibleRow({ deepAskRound: 1 })]);
+  const killed = await never.registry.resolveConnect({ tool: "github", answer: "never", ring: "deep_read" });
+  assert.equal(killed.ok, true);
+  const killedRow = never.registryStore._state().tools.find((x) => x.tool === "github");
+  assert.deepEqual(killedRow.consent, { metadata: "never", deep_read: "never", write: "never" });
+  // invalid ring rejected without touching the store
+  const bad = seededRegistry([deepEligibleRow()]);
+  const badRes = await bad.registry.resolveConnect({ tool: "github", answer: "connect", ring: "write" });
+  assert.equal(badRes.ok, false);
+});
+
+test("applyAsSource: folds success/rejection, ignores access/decay, and trips the chain at LB<0.3 after >=3 reports", async () => {
+  // 3 reports, 1 accepted → betaLowerBound(1, 2) ≈ 0.075 < 0.3 → trip
+  const trip = seededRegistry([deepEligibleRow({ uses: 6 })]);
+  assert.equal(AS_SOURCE_MIN_REPORTS, 3);
+  const acc = await trip.registry.applyAsSource("github", { success: true });
+  assert.equal(acc.ok, true);
+  assert.deepEqual(acc.as_source, { reports: 1, accepted: 1 });
+  assert.equal(acc.decayed, false);
+  await trip.registry.applyAsSource("github", { rejection: true });
+  const tripped = await trip.registry.applyAsSource("github", { rejection: true });
+  assert.equal(tripped.decayed, true, "1 accept / 2 rejects after 3 reports trips");
+  const row = trip.registryStore._state().tools.find((x) => x.tool === "github");
+  assert.equal(row.asSourceDecayed, true);
+  assert.equal(row.decayedAtUses, 6);
+  assert.ok(trip.ledger.rows.some((r) => r.kind === "cto.tool.as_source_decayed" && r.reports === 3));
+  // access/decay effects never enter the counters
+  const noFold = seededRegistry([deepEligibleRow()]);
+  const access = await noFold.registry.applyAsSource("github", { access: true, decay: true });
+  assert.deepEqual(access, { ok: true, changed: false });
+  const cleanRow = noFold.registryStore._state().tools.find((x) => x.tool === "github");
+  assert.deepEqual(cleanRow.as_source, { reports: 0, accepted: 0 });
+  // 3 accepts / 1 reject after 4 reports: LB ≈ 0.43 > 0.3 → no trip
+  // (2 accepts / 1 reject after 3 DOES trip: LB ≈ 0.279)
+  const hold = seededRegistry([deepEligibleRow()]);
+  await hold.registry.applyAsSource("github", { success: true });
+  await hold.registry.applyAsSource("github", { success: true });
+  await hold.registry.applyAsSource("github", { success: true });
+  const fourth = await hold.registry.applyAsSource("github", { rejection: true });
+  assert.equal(fourth.decayed, false);
+  assert.ok(betaLowerBound(3, 1) >= 0.3);
+  // unknown tool / missing id
+  assert.equal((await hold.registry.applyAsSource("nope", { success: true })).ok, false);
+  assert.equal((await hold.registry.applyAsSource("", { success: true })).ok, false);
+});
+
+test("decay chain: a tripped tool stops deep asks and probes weekly; fresh engagement revives it", async () => {
+  const tripped = deepEligibleRow({ asSourceDecayed: true, decayedAtUses: 6, uses: 6 });
+  const { registry, registryStore, cards, ledger } = seededRegistry([tripped]);
+  // deep asks suppressed while decayed
+  await registry.dailyScan();
+  assert.equal(cards.calls.upserts.length, 0);
+  // probing caps at weekly — the chain's source of truth lives here
+  assert.equal(await registry.probeCadenceCapMs("github"), CADENCE_WEEKLY_MS);
+  assert.equal(await registry.probeCadenceCapMs("nope"), null);
+  // revival: fresh engagement beyond the trip's snapshot (uses > decayedAtUses + 2).
+  // The row is deep-consented (the trip came from dismissed REPORTS, which
+  // only exist under deep consent) so no new ask fires over the revival.
+  const revivedStore = memStore({
+    tools: [deepEligibleRow({ asSourceDecayed: true, decayedAtUses: 6, uses: 9, consent: { metadata: "yes", deep_read: "yes", write: null } })],
+    lastScanTs: W0,
+    lastAskDay: null,
+    lastDeepAskDay: null,
+  });
+  const revCards = fakeCards();
+  const revLedger = fakeLedger();
+  const rev = createToolRegistry({ registryStore: revivedStore, usageStore: memStore({ rows: [] }), cards: revCards, ledger: revLedger, now: () => W0 + DAY });
+  await rev.dailyScan();
+  const revivedRow = revivedStore._state().tools.find((x) => x.tool === "github");
+  assert.equal(revivedRow.asSourceDecayed, false);
+  assert.equal(revivedRow.decayedAtUses, 0);
+  assert.equal(revivedRow.deepReArmAt, W0 + DAY + 30 * DAY);
+  assert.ok(revLedger.rows.some((r) => r.kind === "cto.tool.as_source_revived"));
+  // and the deep ask front door re-opens after the timer
+  assert.equal(await rev.probeCadenceCapMs("github"), null);
+  // not-yet-fresh engagement does NOT revive (uses <= decayedAtUses + 2)
+  const stale = seededRegistry([deepEligibleRow({ asSourceDecayed: true, decayedAtUses: 6, uses: 8 })]);
+  await stale.registry.dailyScan();
+  assert.equal(stale.registryStore._state().tools.find((x) => x.tool === "github").asSourceDecayed, true);
+});
+
+test("listTools exposes the §7.6 chain state + relevance map (no dead state)", async () => {
+  const { registry } = seededRegistry([deepEligibleRow({ asSourceDecayed: true, as_source: { reports: 4, accepted: 1 } })]);
+  const view = await registry.listTools();
+  assert.equal(view.length, 1);
+  assert.deepEqual(view[0].asSource, { reports: 4, accepted: 1 });
+  assert.equal(view[0].asSourceDecayed, true);
+  assert.deepEqual(view[0].relevance, { alpha: 0.7, beta: 0.3 });
+});

--- a/src/server/ctoVerdicts.mjs
+++ b/src/server/ctoVerdicts.mjs
@@ -155,6 +155,60 @@ export function thompsonDraw(a, b, rng = Math.random) {
   return total > 0 ? x / total : betaMean(aa, bb);
 }
 
+// One-sided lower confidence bound of the Beta(a,b) mean, using the same
+// normal approximation as `betaTailAbove` (μ = a/(a+b), σ² = ab/((a+b)²(a+b+1))):
+// L = μ + σ·Φ⁻¹(1-conf), so P(μ > L) ≈ conf. With §9.4's 0.95 convention this
+// is the "Beta lower bound" the dismissal-decay gates test (spec §7.6: trip
+// when the as_source lower bound drops below 0.3). Degenerate Beta → 0.
+// Φ⁻¹ is bisected on the existing `standardNormalCdf` — monotone, and the
+// ~1e-3 CDF accuracy is far finer than any ledger-count decision.
+export function betaLowerBound(a, b, conf = 0.95) {
+  const aa = a || 0;
+  const bb = b || 0;
+  const n = aa + bb;
+  if (!(n > 0)) return 0;
+  const mu = betaMean(aa, bb);
+  const sigma = Math.sqrt((aa * bb) / (n * n * (n + 1)));
+  if (!(sigma > 0)) return mu; // a or b is 0: the mean is known exactly
+  const target = 1 - (conf || 0.95);
+  let lo = -8;
+  let hi = 8;
+  for (let i = 0; i < 60; i++) {
+    const mid = (lo + hi) / 2;
+    if (standardNormalCdf(mid) < target) lo = mid;
+    else hi = mid;
+  }
+  return mu + sigma * ((lo + hi) / 2);
+}
+
+// ---------------------------------------------------------------------------
+// Tool as-source counters (spec §7.6) — the counter sink for data-source
+// analyses
+// ---------------------------------------------------------------------------
+
+// The verdict subject class report reviews use: `{type: "tool", id: <toolId>,
+// class: AS_SOURCE_SUBJECT_CLASS}`. A verdict on this subject is a judgment
+// of a data-analysis REPORT the CTO produced from that tool's data (the
+// §7.6 experiment-first verdict seeds the same counters).
+export const AS_SOURCE_SUBJECT_CLASS = "tool-as-source";
+
+// Counter sink factory (§9.5 sink registry): folds tool-as-source verdict
+// effects into the tool registry's `as_source` Beta counters. Effects map per
+// the §9.5 table — accept/edit (`success`) → accepted+1 & reports+1;
+// dismiss/veto/correct/never (`rejection`) → reports+1; `access`/`decay`
+// (open/expire) never enter the acceptance counters. Best-effort like every
+// sink: a failing counter write never breaks verdict recording.
+export function createAsSourceSink({ registry } = {}) {
+  if (!registry || typeof registry.applyAsSource !== "function") {
+    throw new Error("createAsSourceSink requires a tool registry with applyAsSource()");
+  }
+  return (effects, entry) => {
+    const subject = entry?.subject;
+    if (subject?.type !== "tool" || subject?.class !== AS_SOURCE_SUBJECT_CLASS) return;
+    void Promise.resolve(registry.applyAsSource(subject.id, effects ?? {})).catch(() => {});
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Counter sink registry
 // ---------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -4665,6 +4665,7 @@ const handleRequest = async (req, res) => {
         const result = await adaptiveCto.tools.resolveConnect({
           tool: body?.tool,
           answer: body?.answer,
+          ring: body?.ring,
         });
         if (result?.ok) void bus.publish({ kind: "ctoState" });
         respondJson(res, result?.ok ? 200 : 400, result);

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1415,6 +1415,9 @@ export interface Api {
   ctoToolConnect(input: {
     tool: string;
     answer: "connect" | "not-now" | "never";
+    // BET-1404: which ring the ask was about — "metadata" (default) or
+    // "deep_read" (the deep-read ask's connect grants deep read access).
+    ring?: "metadata" | "deep_read";
   }): Promise<{ ok: boolean; error?: string; tool?: string; answer?: string }>;
 }
 


### PR DESCRIPTION
## BET-1404 — Data-source deep analyses

Closes BET-1404. Base: `origin/main` @ `03fb8900`.

### Approved design decisions (recorded per the on-call answer, 2026-08-29 22:11 UTC)

- **Q1 — "vitality EWMA high" = `ewma > 0`** (option a). No invented floor
  constant; selectivity belongs to the relevance half (`max(relevance) ≥ 0.5`).
  Implemented exactly so in `deepReadBar`.
- **Q2 — staging = one-shot cascade, then the standard lifecycle.** The Beta
  trip immediately stops deep analyses AND caps metadata probing at weekly;
  "dormant" is the §7.3 dead condition under the standard lifecycle (no second
  dormancy state, no time-based D constant); revival per §7.3/B7 (fresh
  engagement re-promotes).
- Approved reads: category id **`data-source`**; **one candidate per
  deep-consented tool** targeting the argmax-relevance project, emitted only
  when a relevance score exists.

### Deliverables (all five, with tests)

1. **Deep-read ring asks** — `deepReadBar` eligibility (metadata consent +
   `ewma > 0` + argmax relevance ≥ 0.5) is now wired: `lifecycleStep` raises
   ONE concrete ask per day ("analyze <tool>'s data about <project> overnight
   and report findings"), ≤ MAX_ASK_ROUNDS ever, never/not-now rules identical
   per §7.4 (30-day timer re-arm only on the vitality path), chain-tripped
   tools excluded. `resolveConnect` gains a `ring` param: `connect` grants
   `deep_read` (metadata backstop), `not-now` re-arms on the 30-day timer,
   `never` kills all rings either way; the verdict class names the ring
   (`tool-deep-read` vs `tool-metadata`). Cards: `upsertConnect({ring})` gives
   the deep ask its own stable card id and ring-tagged action payloads;
   the ring threads through the API type, httpApi, CtoPanel, and the route.
2. **Overnight `data-source` candidates** — `dataAnalysisCandidatesFromTools`
   in `ctoOvernight.mjs` (pure, tested): one candidate per deep-consented,
   integrated, chain-untripped tool at argmax relevance, emitted only when a
   relevance score exists; `p_use = vitality.ewma × max(relevance)`;
   `requestShaped: true` so §11.2 batch routing picks them up where a provider
   adapter supports a batch pool; wired into `overnightTick`.
3. **Experiment-first** — a tool with zero `as_source` reports runs the
   forced-small first analysis: prompt carries the single-probe-window +
   halved-context constraints, predicted cost halved; its verdict seeds the
   counters via the §9.5 sink.
4. **Dismissal decay chain** — `registry.applyAsSource` folds the §9.5
   effects (success → accepted+reports, rejection → reports, access/decay
   no-op) and evaluates the trip: ≥3 reports AND `betaLowerBound < 0.3` flips
   `asSourceDecayed` (ledger row + `decayedAtUses` snapshot). The cascade:
   deep asks suppressed, overnight candidates excluded, probing capped at
   weekly (`probeCadenceCapMs` — the registry is the chain's source of truth,
   the runner asks it). Dormant stays the §7.3 dead condition (Q2 — no second
   state). Revival: fresh engagement beyond the trip's snapshot clears the
   flag and re-arms the deep ask on the 30-day timer. `listTools` exposes
   `asSource`/`asSourceDecayed`/`relevance` (no dead state).
5. **Deep-ring probes** — authoring gate unchanged; run-time now re-checks
   the live deep-consent source of truth (`consentFor(tool,"deep_read")==="yes"`)
   before a deep-ring probe fires, and `validSpecFor` drops ring-escalated
   probes instead of invalidating the whole spec — revoking deep consent stops
   deep probes WITHOUT killing the tool's metadata probes.

### Verification results

- PR branch (`multica/BET-1404-deep-analyses` @ `348c6666`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, **3650** pass / 0 fail / 0 skip. log sha256: `503af2da3feab57f28e61b6e831b691efd0566fc7e30fe8404fe2e2d713fa23e`
- Base (`main` @ `03fb8900`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, **3632** pass / 0 fail / 0 skip. log sha256: `a5381d5c0816ea18d5d42a30713e07f95c9d900b85915360a580304546e0493e`
- **Conclusion:** 0 failures on either branch; the PR adds 18 tests
  (3650 − 3632), all green: eligibility bar, p_use composition,
  experiment-first, decay chain incl. revival, deep-ring probe
  characterization (permit / refuse / revoke / weekly cap), cards ring
  payload, resolveConnect ring semantics.

### Reviewer blocks addressed (cycle 1)

- B1 partial scope → all five deliverables landed (above).
- B2 dead scaffolding → ask generation wired in `lifecycleStep`; every
  `deepAsk*` field now read or written by a lifecycle path.
- B3 dead/broken sink → `applyAsSource` implemented + `createAsSourceSink`
  registered in `ctoEngine.mjs` (late-bound registry handle, best-effort).
- B4 constants without behavior → trip computation calls `betaLowerBound`;
  cascade + revival implemented and tested.
- Nits → both former dead imports now used; Q1/Q2 recorded above.

Relates to BET-1404.
