### PR TITLE
refactor(server): extract shared tool-row resolve preamble in ctoToolRegistry (BET-1440)

### DIFF
--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -324,6 +324,19 @@ export function createToolRegistry(deps = {}) {
     await registryStore.save(payload);
   }
 
+  // Shared preamble for the tool-scoped writers: normalize the toolId, load
+  // the whole-payload store, find the row. Returns `{ ok: false, error }` on
+  // failure or `{ ok: true, id, payload, t }` on success. Single source for
+  // the block the duplication gate flagged file↔file (BET-1440).
+  async function resolveToolRow(toolId) {
+    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
+    if (!id) return { ok: false, error: "missing tool" };
+    const payload = await loadPayload();
+    const t = payload.tools.find((x) => x?.tool === id);
+    if (!t) return { ok: false, error: `unknown tool "${id}"` };
+    return { ok: true, id, payload, t };
+  }
+
   // Serializes the registry's mutating writers (dailyScan / resolveConnect /
   // unNever) — all load→mutate→save the same whole-payload store, and the
   // scan holds its snapshot across seconds-long awaits (db batch, LLM
@@ -658,11 +671,9 @@ export function createToolRegistry(deps = {}) {
   // exists to prevent). The server rule ships here; the drill-down UI/route
   // is B11's.
   async function unNever(toolId) {
-    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
-    if (!id) return { ok: false, error: "missing tool" };
-    const payload = await loadPayload();
-    const t = payload.tools.find((x) => x?.tool === id);
-    if (!t) return { ok: false, error: `unknown tool "${id}"` };
+    const r = await resolveToolRow(toolId);
+    if (!r.ok) return r;
+    const { id, payload, t } = r;
     if (t.consent?.metadata !== "never") return { ok: false, error: `tool "${id}" is not never'd` };
     t.consent = emptyConsent();
     t.status = "observed";
@@ -733,11 +744,9 @@ export function createToolRegistry(deps = {}) {
   // NOTE: the body does NOT self-serialize — the exported wrapper already
   // routes through `serialized` (nesting would deadlock the write chain).
   async function applyProbeResult(toolId, { fields, probedAt, cadenceMs } = {}) {
-    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
-    if (!id) return { ok: false, error: "missing tool" };
-    const payload = await loadPayload();
-    const t = payload.tools.find((x) => x?.tool === id);
-    if (!t) return { ok: false, error: `unknown tool "${id}"` };
+    const r = await resolveToolRow(toolId);
+    if (!r.ok) return r;
+    const { id, payload, t } = r;
     const vit = vitalityOf(fields);
     t.vitality = t.vitality ?? { last_event: null, inflow_rate: null, ewma: null, last_probed: null };
     const v = t.vitality;


### PR DESCRIPTION
Fixes BET-1440 (duplication-gate follow-up from BET-1396 / PR #1421).

## What
The advisory `duplication-gate` check flagged one 6-line clone inside `src/server/ctoToolRegistry.mjs` (file ↔ itself): the toolId-normalize → load-payload → find-row preamble repeated in `unNever` and `applyProbeResult`. Extracted it into one shared helper, `resolveToolRow(toolId)`, returning `{ ok: false, error }` on failure or `{ ok: true, id, payload, t }` on success; both sites now call it and pass the error object straight through.

**Files changed:** `src/server/ctoToolRegistry.mjs` (19+/10−). No other files.

## Duplicate-site accounting (anti-spaghetti contract)
- Flagged contiguous clone: `unNever` ↔ `applyProbeResult` → both extracted to the helper (this PR).
- Near-miss sites deliberately untouched — none are contiguous clones (jscpd flags only the two above), so rewriting them is churn with no gate benefit:
  - `resolveConnect` — interleaves answer validation between id-normalize and payload-load.
  - `revokeConsent` — interleaves ring validation.
  - `applyRelevance` — interleaves project/score validation.
  - `appendEvidence` — interleaves entry validation.
  - `consentFor` / `toolRow` — read-only, return `null` (different return contract).
- Out of scope respected: no changes to `scripts/duplication-gate-ignore.txt`, no functional changes to the registry, no test edits.

## Verification results
- Duplication gate (local, `bash scripts/check-duplication-gate.sh origin/main`): `scanning 1 changed file(s) … PASS — no clones` (direct jscpd on the file: 0 clones, was 1).
- PR branch (`multica/BET-1440-dedup-cto-tool-registry` @ `d17c012b`):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e…
  - test: exit 0, 3632 pass / 0 fail / 0 skip. Failures: none. log sha256: 3ab1b92580d2…
- Base (`main` @ `bd3a01a6`):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e…
  - test: exit 0, 3632 pass / 0 fail / 0 skip. Failures: none. log sha256: 8febf5f12a6f…
- **Conclusion:** 0 new failures, 0 pre-existing — identical results on both branches.

**Base: origin/main @ bd3a01a6**