### PR TITLE
BET-1437: deep-link probe blocker cards to secrets surface

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -359,6 +359,26 @@ function Shell() {
     : null;
   const activeChatSessionId = activeWin?.opencodeSessionId ?? null;
 
+  // BET-1437: probe blocker cards deep-link to the secrets surface. The chat
+  // panels stay mounted under the CTO pane, so dispatching the existing
+  // manta-open-secrets bridge with the ACTIVE session id opens the SecretsCard
+  // there (key pre-filled via the detail's `key`); closing the pane reveals it.
+  // Returns false when there is no active chat session — the caller falls back
+  // to the ledger modal.
+  const onOpenSecretsFromCto = useCallback(
+    (key: string | null): boolean => {
+      if (!activeChatSessionId) return false;
+      window.dispatchEvent(
+        new CustomEvent("manta-open-secrets", {
+          detail: { sessionId: activeChatSessionId, key: key ?? undefined },
+        }),
+      );
+      setCtoOpen(false);
+      return true;
+    },
+    [activeChatSessionId],
+  );
+
   // BET-730: record the active chat in an effect, not during render (render-
   // time ref mutation is a StrictMode hazard). A re-render that just touches
   // unrelated fields must never mutate the visited set.
@@ -2186,7 +2206,7 @@ function Shell() {
                   panels above are suppressed while it is open (their `active`
                   flips on !ctoOpen). Selecting a session closes it. */}
               <PanelShell key="cto" active={ctoOpen}>
-                <CtoPanel state={ctoState} onOpenSession={onOpenSessionFromCto} />
+                <CtoPanel state={ctoState} onOpenSession={onOpenSessionFromCto} onOpenSecrets={onOpenSecretsFromCto} />
               </PanelShell>
               {/* New-session DRAFT layer: shown over the always-mounted
                   session panels when a draft is the active view (user hit +

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -3172,6 +3172,7 @@ export function ChatPanel({
             secrets={secrets}
             error={secretError}
             sessionId={sessionId}
+            prefillKey={resources.secretKeyHint}
             onClose={closePanel}
             onSave={(input) => window.api.secretsSet(input).then((r) => {
               if (r && r.ok === false) { setSecretError(r.error || "save failed"); return false; }

--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -132,9 +132,13 @@ const DEFAULT_NIGHT_CAP_USD = 5;
 export function CtoPanel({
   state,
   onOpenSession,
+  onOpenSecrets,
 }: {
   state: CtoState | null;
   onOpenSession: (sessionId: string) => void;
+  /** BET-1437: open the secrets surface (active session, key pre-filled).
+      Returns false when there is no active chat session to open it in. */
+  onOpenSecrets?: (key: string | null) => boolean;
 }) {
   const [view, setView] = useState<"overview" | "settings" | "ledger" | "profile" | "blackboard" | "tools">("overview");
   const pushToast = useStore((s) => s.pushAppToast);
@@ -269,8 +273,17 @@ export function CtoPanel({
       );
       return;
     }
-    // ledger fallback (target/session missing, or an inbox/health source whose
-    // fix surface isn't in the renderer yet — §10.3 keeps the control honest).
+    // BET-1437: probe blockers deep-link to the secrets surface on the active
+    // chat session (key pre-filled/highlighted in the SecretsCard when the
+    // body names one). The App-side handler closes the CTO pane and dispatches
+    // manta-open-secrets; with no active chat session it returns false and the
+    // ledger fallback keeps the control honest (§10.3).
+    if (target.action === "secrets") {
+      if (onOpenSecrets?.(target.key)) return;
+    }
+    // ledger fallback (target/session missing, an inbox/health source whose
+    // fix surface isn't in the renderer yet, or a probe with no session to
+    // open the secrets card in — §10.3 keeps the control honest).
     setLedgerCard(card);
   };
 

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -10,7 +10,7 @@
 // All three are cards (not footer items) so they render on BOTH desktop and
 // mobile with no mobile-CSS edits.
 
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Clock, Bell, Webhook, Key, Bot, ArrowLeft, Square, X } from "lucide-react";
 import type {
   DelegateApproval,
@@ -223,6 +223,7 @@ export const SecretsCard = memo(function SecretsCard({
   secrets,
   error,
   sessionId,
+  prefillKey,
   onSave,
   onDelete,
   onClose,
@@ -230,6 +231,11 @@ export const SecretsCard = memo(function SecretsCard({
   secrets: SecretMeta[];
   error: string | null;
   sessionId: string;
+  /** BET-1437: vault KEY NAME to pre-fill (deep-linked from a CTO probe
+      blocker). The card treats the fix as a rotation: the key lands in the
+      add/update form (save is an upsert), the input gets an accent ring, a
+      matching existing row is highlighted, and the value input is focused. */
+  prefillKey?: string | null;
   onSave: (input: {
     key: string;
     value: string;
@@ -245,6 +251,15 @@ export const SecretsCard = memo(function SecretsCard({
   const [scope, setScope] = useState<SecretScope>("shared");
   const [hint, setHint] = useState("");
   const [saving, setSaving] = useState(false);
+  const valueRef = useRef<HTMLInputElement>(null);
+
+  // Deep-link pre-fill (BET-1437). Re-runs when the hint changes (the card
+  // mounts only when open, so this fires once per open in practice).
+  useEffect(() => {
+    if (!prefillKey) return;
+    setKey(prefillKey);
+    valueRef.current?.focus();
+  }, [prefillKey]);
 
   const keyValid = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/.test(key);
   const canSave = keyValid && value.length > 0 && !saving;
@@ -306,6 +321,11 @@ export const SecretsCard = memo(function SecretsCard({
             className={`min-w-0 flex-1 rounded-xs border bg-bg px-2 py-1 font-mono text-text outline-none ${
               key && !keyValid ? "border-danger/60" : "border-border"
             }`}
+            style={
+              prefillKey
+                ? { borderColor: "rgb(var(--accent-rgb) / 0.7)" }
+                : undefined
+            }
           />
           <select
             value={scope}
@@ -319,6 +339,7 @@ export const SecretsCard = memo(function SecretsCard({
           </select>
         </div>
         <input
+          ref={valueRef}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
@@ -369,7 +390,18 @@ export const SecretsCard = memo(function SecretsCard({
       ) : (
         <div className="flex flex-col gap-2 border-t border-border pt-2 max-h-[40vh] overflow-y-auto">
           {secrets.map((s) => (
-            <div key={s.id} className="flex items-center gap-2">
+            <div
+              key={s.id}
+              className="flex items-center gap-2 rounded-xs px-1 -mx-1"
+              style={
+                s.key === prefillKey
+                  ? {
+                      backgroundColor: "rgb(var(--accent-rgb) / 0.08)",
+                      boxShadow: "inset 2px 0 0 rgb(var(--accent-rgb) / 0.53)",
+                    }
+                  : undefined
+              }
+            >
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   <span className="text-text font-mono truncate">{s.key}</span>

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -9,6 +9,7 @@ import {
   formatEta,
   relativeTime,
   blockerTarget,
+  probeSecretKey,
   finishedVariant,
   digestTone,
   digestExpandable,
@@ -250,6 +251,30 @@ describe("blockerTarget (§10.3 Answer-now routing)", () => {
   });
   it("a null/absent session with an unknown kind → ledger", () => {
     expect(blockerTarget({ ...card(), sessionID: null }, new Set(["s1"]))).toEqual({ action: "ledger" });
+  });
+  it("probe source → secrets action with the key named in the body (BET-1437)", () => {
+    const probe = card({
+      sourceKind: "probe",
+      sourceId: "github/repo_events",
+      sessionID: null,
+      body: 'The "repo_events" probe for github failed auth 3 times in a row (HTTP 401/403 or the credential is gone), so the digest\'s view of github is degraded. If the key was rotated, update "GITHUB_PAT" on the secrets surface (⚙ Settings → Secrets).',
+    });
+    expect(blockerTarget(probe, new Set([]))).toEqual({ action: "secrets", key: "GITHUB_PAT" });
+  });
+  it("probe source without a named key → secrets action with a null key", () => {
+    const probe = card({
+      sourceKind: "probe",
+      sessionID: null,
+      body: 'The "tool_ping" probe for tool failed auth 3 times in a row (HTTP 401/403 or the credential is gone), so the digest\'s view of tool is degraded. Check the tool\'s credential on the secrets surface (⚙ Settings → Secrets).',
+    });
+    expect(blockerTarget(probe, new Set(["s1"]))).toEqual({ action: "secrets", key: null });
+  });
+  it("probe key extraction tolerates an absent body", () => {
+    const probe = card({ sourceKind: "probe", sessionID: null, body: "" });
+    expect(blockerTarget(probe, new Set([]))).toEqual({ action: "secrets", key: null });
+  });
+  it("a quoted phrase elsewhere in the body is not mistaken for the key", () => {
+    expect(probeSecretKey('The "repo_events" probe failed. Check the credential on the secrets surface.')).toBeNull();
   });
 });
 

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -345,19 +345,39 @@ export function relativeTime(ts: number, now: number): string {
 //   - question/permission → navigate to the owning session (the in-session
 //     question card is focused via the existing manta-scroll-to-question
 //     bridge in the component).
+//   - probe (BET-1437 / §10.6-7) → open the secrets surface on the active
+//     chat session via the manta-open-secrets bridge, carrying the vault KEY
+//     NAME extracted from the card body when one is named (pre-fill/highlight).
+//     Probe cards are box-level (sessionID null), so knownSessions is
+//     irrelevant; the component's handler falls back to the ledger when there
+//     is no active chat session to open the card in.
 //   - inbox-note / health → no fix-surface navigation exists in the renderer
 //     yet, so these resolve to the ledger fallback (the §10.3 honest route).
 // When the card's target session no longer exists (or is absent), fall back
 // to opening the matching ledger entry via an inline modal.
 export type BlockerAction =
   | { action: "session"; sessionID: string }
+  | { action: "secrets"; key: string | null }
   | { action: "ledger" };
+
+// Extract the vault KEY NAME a probe blocker card names in its body (§10.6-7).
+// The server copy (ctoCards.mjs probeBlockerCopy) embeds it as
+// `update "KEY" on the secrets surface`; nothing else in the body is quoted
+// before that phrase, and the generic branch quotes nothing at all. Returns
+// null when no key is named.
+export function probeSecretKey(body: string): string | null {
+  const m = body?.match(/"([^"]+)"\s+on the secrets surface/);
+  return m ? m[1] : null;
+}
 
 export function blockerTarget(
   card: BlockerCard,
   knownSessions: Set<string>,
 ): BlockerAction {
   const sourceKind = card?.sourceKind ?? "";
+  if (sourceKind === "probe") {
+    return { action: "secrets", key: probeSecretKey(card.body ?? "") };
+  }
   const isSessionTarget = sourceKind !== "inbox" && sourceKind !== "health";
   if (isSessionTarget) {
     return card.sessionID && knownSessions.has(card.sessionID)

--- a/src/renderer/hooks/useSessionResources.ts
+++ b/src/renderer/hooks/useSessionResources.ts
@@ -42,6 +42,10 @@ export type SessionResources = {
   secretError: string | null;
   setSecretError: React.Dispatch<React.SetStateAction<string | null>>;
   refreshSecrets: () => Promise<void>;
+  /** BET-1437: vault KEY NAME to pre-fill/highlight in the SecretsCard, or
+      null. Latched from a manta-open-secrets bridge detail; cleared when the
+      card closes. */
+  secretKeyHint: string | null;
 
   // Inbound webhooks (🪝).
   webhooks: WebhookMeta[];
@@ -70,19 +74,25 @@ type ResourceCardConfig<T> = {
   backgroundPoll: boolean;
   /** Error message when the server is unreachable. */
   unreachable: string;
+  /** BET-1437: consume extra fields of the bridge detail (e.g. the secrets
+      opener's `key`). Receives the detail on every matching open. */
+  onOpenDetail?: (detail: { sessionId?: string; key?: string } | undefined) => void;
 };
 
 function useResourceCard<T>({
-  panelName, sessionId, isActive, openPanel, setOpenPanel, fetch, empty, backgroundPoll, unreachable,
+  panelName, sessionId, isActive, openPanel, setOpenPanel, fetch, empty, backgroundPoll, unreachable, onOpenDetail,
 }: ResourceCardConfig<T>) {
   const [items, setItems] = useState<T[]>(empty);
   const [error, setError] = useState<string | null>(null);
-  // fetch/empty are passed inline (recreated each render); hold them in refs so
-  // `refresh` keeps a stable identity and the reset effect doesn't re-fire.
+  // fetch/empty/onOpenDetail are passed inline (recreated each render); hold
+  // them in refs so `refresh` keeps a stable identity and the reset effect
+  // doesn't re-fire.
   const fetchRef = useRef(fetch);
   fetchRef.current = fetch;
   const emptyRef = useRef(empty);
   emptyRef.current = empty;
+  const onOpenDetailRef = useRef(onOpenDetail);
+  onOpenDetailRef.current = onOpenDetail;
 
   const refresh = useCallback(() => {
     return fetchRef.current(sessionId)
@@ -120,11 +130,18 @@ function useResourceCard<T>({
 
   // Open this card from an out-of-panel `manta-open-*` bridge. Open-only —
   // never a toggle, because the dispatcher has no idea what is open.
+  // `onOpenDetail` (BET-1437) lets a card consume extra detail fields (e.g. the
+  // secrets bridge's `key`) without the generic listener knowing about them.
   useEffect(() => {
     const type = `manta-open-${panelName}`;
     const onOpen = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { sessionId?: string } | undefined;
-      if (detail?.sessionId === sessionId) setOpenPanel(panelName);
+      const detail = (e as CustomEvent).detail as
+        | { sessionId?: string; key?: string }
+        | undefined;
+      if (detail?.sessionId === sessionId) {
+        setOpenPanel(panelName);
+        onOpenDetailRef.current?.(detail);
+      }
     };
     window.addEventListener(type, onOpen);
     return () => window.removeEventListener(type, onOpen);
@@ -153,10 +170,16 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
 
   // Secrets (🔑): server-owned (values never leave the box). list returns
   // METADATA ONLY (no values). Refetch-driven like schedules.
+  // BET-1437: the manta-open-secrets bridge may carry a `key` — the vault KEY
+  // NAME a CTO probe blocker asks the user to rotate. Latched here, consumed
+  // by the SecretsCard as a pre-fill/highlight, and cleared when the card
+  // closes (a stale highlight would keep pointing at an old fix).
+  const [secretKeyHint, setSecretKeyHint] = useState<string | null>(null);
   const secrets = useResourceCard<SecretMeta>({
     panelName: "secrets", sessionId, isActive, openPanel, setOpenPanel,
     fetch: (sid) => window.api.secretsList(sid), empty: [], backgroundPoll: false,
     unreachable: "secrets server unreachable",
+    onOpenDetail: (d) => setSecretKeyHint(d?.key ?? null),
   });
 
   // Inbound webhooks (🪝): server-owned (external POSTs wake the session).
@@ -174,8 +197,16 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
     setOpenPanel(null);
   }, [sessionId]);
 
+  // BET-1437: clear the deep-link hint whenever the secrets card is not the
+  // open panel (closed, or another card took over) — a stale highlight would
+  // keep pointing at an old fix.
+  useEffect(() => {
+    if (openPanel !== "secrets") setSecretKeyHint(null);
+  }, [openPanel]);
+
   return {
     openPanel, togglePanel, closePanel,
+    secretKeyHint,
     schedules: schedules.items, setSchedules: schedules.setItems,
     scheduleError: schedules.error, setScheduleError: schedules.setError,
     refreshSchedules: schedules.refresh,


### PR DESCRIPTION
## Summary
Extends the renderer's blocker action mapping so `sourceKind: "probe"` cards (BET-1396 / §10.6-7) deep-link to the secrets surface instead of falling into the ledger fallback.

## Changes
- `src/renderer/ctoView.ts`: `BlockerAction` gains `{ action: "secrets"; key: string | null }`; `blockerTarget` maps probe cards to it; new pure helper `probeSecretKey(body)` extracts the vault KEY NAME the server copy embeds (`update "KEY" on the secrets surface`).
- `src/renderer/CtoPanel.tsx`: `handleAnswer` handles the secrets action via a new `onOpenSecrets` prop; falls back to the ledger modal if the handler returns false.
- `src/renderer/App.tsx`: `onOpenSecretsFromCto` dispatches the existing `manta-open-secrets` bridge with the active chat session id + key, and closes the CTO pane (chat panels stay mounted underneath). Returns false with no active session → ledger fallback.
- `src/renderer/hooks/useSessionResources.ts`: bridge detail may now carry `key`; latched as `secretKeyHint`, exposed to the chat panel, cleared when the card closes or another panel opens.
- `src/renderer/PanelCards.tsx` (`SecretsCard`): new `prefillKey` prop — pre-fills the add/update form's KEY field, focuses the value input, highlights the input with an accent border, and highlights the matching existing row.
- `src/renderer/ChatPanel.tsx`: passes `prefillKey` through to `SecretsCard`.
- `src/renderer/ctoView.test.ts`: tests for probe → secrets with key named, without key, empty body, and no false extraction.

Base: origin/main @ 55d896c2

## Verification results
(to follow in issue comment)