### PR TITLE
feat(server): ephemeral authoring pass fills scaffolded probe-spec templates (BET-1438)

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1145,11 +1145,14 @@ export function createCtoEngine(deps = {}) {
     }
   }
 
-  // The §7.5 probe tick (BET-1396): due probes + weekly relevance, behind the
-  // master toggle, thrifty-shed, paused with the rest of the tick.
+  // The §7.5 probe tick (BET-1396; template authoring BET-1438): fill still-
+  // empty scaffolded probe specs (before the runner sees them, so consent →
+  // fill → first probe can land inside one tick), then due probes + weekly
+  // relevance, behind the master toggle, thrifty-shed, paused with the tick.
   async function probesTick() {
     const eng = getProbes();
     if (!eng) return;
+    await eng.authorSpecs().catch(() => {});
     await eng.runDue().catch(() => {});
     await eng.relevanceScan().catch(() => {});
   }

--- a/src/server/ctoProbes.mjs
+++ b/src/server/ctoProbes.mjs
@@ -42,6 +42,14 @@
 // tool's data domain against the project's top facts + recent rollups into
 // `relevance[project] ∈ [0,1]`.
 //
+// Spec authoring (BET-1438, §7.5): the engine scaffolds `{tool, probes: []}`
+// at consent time; an ephemeral nano session (the SAME §3.3-gated seam the
+// registry's classifier rides) proposes probe entries from the tool's evidence
+// rows — evidenced hosts + credential presence only — and fills the template
+// through writeSpec, the ONE validated engine-written path. A refused
+// candidate surfaces on the tool's evidence trail (the trail the connect ask
+// and drill-down read) — never silently.
+//
 // Failure escalation (§10.6-7): consecutive auth-shaped failures (401/403, or
 // a secret that no longer materializes — the same "key may have been rotated"
 // failure mode) ≥ 3 → ONE blocker card per probe (idempotent upsert; the body
@@ -94,6 +102,14 @@ export const RELEVANCE_WEEK_MS = 7 * 24 * 3_600_000;
 export const RELEVANCE_PER_DAY = 6;
 export const RELEVANCE_FAILURE_RETRY_MS = 3_600_000;
 export const RELEVANCE_TASK_CLASS = "ambient-summarize";
+// §7.5 authoring (BET-1438): the ephemeral session that FILLS scaffolded
+// templates. Pacing mirrors the relevance scan — attempts (not successes) are
+// the paced resource; a filled (or not-derivable) template rests for the week.
+export const AUTHORING_PER_DAY = 4;
+export const AUTHORING_WEEK_MS = 7 * 24 * 3_600_000;
+export const AUTHORING_FAILURE_RETRY_MS = 3_600_000;
+export const AUTHORING_TASK_CLASS = "ambient-summarize";
+export const AUTHOR_MAX_PROBES = 5;
 
 // Consent rings (D13). Probes only ever declare metadata | deep_read — the
 // write ring creates no standing specs (§7.4). Ordering matters: a probe's
@@ -275,6 +291,50 @@ export function vitalityOf(fields) {
   const out = {};
   if (lastEvent !== undefined && lastEvent !== null && lastEvent !== "") out.last_event = lastEvent;
   if (typeof rate === "number" && Number.isFinite(rate)) out.inflow_rate = rate;
+  return out;
+}
+
+/**
+ * Parse the authoring model's reply (BET-1438) into normalized §7.5 probe
+ * entries, or null when nothing parseable came back. Tolerates a fenced block
+ * and stray prose around the array; strips every key the validator does not
+ * know; forces `method: "GET"` (the model is never trusted to say otherwise)
+ * and defaults an omitted ring DOWN to "metadata" (the lowest ring — never
+ * the reverse). Structurally broken entries are dropped; whatever survives
+ * still faces the full validator inside writeSpec. An empty array is a valid
+ * "nothing derivable" answer (distinct from null, the parse failure).
+ */
+export function parseProposedProbes(text) {
+  if (text == null) return null;
+  let s = String(text).trim();
+  const fence = /```(?:json)?\s*([\s\S]*?)\s*```/.exec(s);
+  if (fence) s = fence[1].trim();
+  const start = s.indexOf("[");
+  const end = s.lastIndexOf("]");
+  if (start === -1 || end === -1 || end < start) return null;
+  let arr;
+  try {
+    arr = JSON.parse(s.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(arr)) return null;
+  const out = [];
+  for (const item of arr.slice(0, AUTHOR_MAX_PROBES)) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const p = {};
+    if (typeof item.name === "string" && item.name.trim()) p.name = item.name.trim();
+    if (typeof item.url === "string" && item.url.trim()) p.url = item.url.trim();
+    if (typeof item.cadence === "string" && item.cadence.trim()) p.cadence = item.cadence.trim();
+    if (item.ring === "metadata" || item.ring === "deep_read") p.ring = item.ring;
+    else p.ring = "metadata";
+    if (item.extract && typeof item.extract === "object" && !Array.isArray(item.extract)) {
+      p.extract = item.extract;
+    }
+    if (!p.name || !p.url || !p.cadence) continue;
+    p.method = "GET";
+    out.push(p);
+  }
   return out;
 }
 
@@ -590,7 +650,8 @@ export function evidenceHost(detail) {
  *   listProjects  — async () => [projectName] (active projects for §7.6).
  *   getTopFacts   — async (project, k) => [{statement}].
  *   getRollups    — async (project) => string lines (recent rollup facts).
- *   runEphemeral  — the pre-gated ephemeral session call (nano classify).
+ *   runEphemeral  — the pre-gated ephemeral session call (nano classify /
+ *                   relevance score / BET-1438 spec authoring).
  */
 export function createProbes(deps = {}) {
   const {
@@ -777,6 +838,155 @@ export function createProbes(deps = {}) {
     if (!check.ok) return { ok: false, errors: check.errors };
     await probes.save(tool, candidate);
     return { ok: true, errors: [] };
+  }
+
+  // ---- §7.5 spec authoring (BET-1438) ---------------------------------------
+
+  // A refused authored candidate (or an unparseable model reply) must surface
+  // on the tool's evidence trail — the trail the connect ask and the §10.5
+  // drill-down read — plus a ledger row. Never silent. The row never widens
+  // the host allowlist (`spec-refused:` is not an evidenceHost channel) and
+  // dedupes naturally on the refusal key.
+  async function surfaceRefusal(tool, reason, ts, errorCount = 1) {
+    try {
+      await registry.appendEvidence?.(tool, { channel: "probe", detail: `spec-refused:${reason}`.slice(0, 200), ts });
+    } catch {
+      /* best-effort */
+    }
+    if (ledger && typeof ledger.append === "function") {
+      try {
+        await ledger.append({ actor: "cto", kind: "cto.probe.author", tool, ok: false, refused: reason, errors: errorCount, ts });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
+  // One nano call (the SAME §3.3-gated seam the registry's classifier rides):
+  // the tool's evidence rows → a JSON array of probe proposals. Untrusted
+  // context, structured-only output — the validator inside writeSpec is the
+  // only thing that makes any of it real. Returns null on a gate rejection /
+  // transport / parse failure, [] when nothing is derivable.
+  async function proposeProbes({ tool, row, allowedHosts, ring, auth }) {
+    const evidenceLines = (row?.evidence ?? [])
+      .map((e) => (typeof e?.detail === "string" ? `- ${e.channel}: ${e.detail.slice(0, 120)}` : ""))
+      .filter(Boolean)
+      .slice(0, 8);
+    const prompt = [
+      `Fill the probe-spec template for external tool "${tool}".`,
+      `Evidenced hosts (a probe URL may use ONLY one of these, exactly): ${allowedHosts.join(", ") || "(none)"}`,
+      auth?.secret
+        ? `A credential is evidenced; the template's auth section already names its vault key (${auth.secret}) — do not propose auth content.`
+        : "No credential is evidenced — propose only unauthenticated endpoints.",
+      ring === "deep_read"
+        ? 'Consented access ring is deep_read: probes may declare ring "metadata" or "deep_read".'
+        : 'Consented access ring is metadata: every probe must declare ring "metadata".',
+      "Observed evidence for this tool:",
+      ...evidenceLines,
+      "",
+      `Propose up to ${AUTHOR_MAX_PROBES} declarative GET probes reading small, useful JSON (counts, latest timestamps, status fields) from the evidenced hosts.`,
+      'Reply with ONLY a JSON array, each element {"name": "<kebab-case-id>", "url": "https://<evidenced-host>/...", "cadence": "<n>m|h|d (>=5m)", "ring": "metadata" or "deep_read", "extract": {"<field>": "<json.path"}}. No prose.',
+    ].join("\n");
+    let text = null;
+    try {
+      const out = await runEphemeral({ taskClass: AUTHORING_TASK_CLASS, context: [{ priority: 10, text: prompt }] });
+      text = typeof out === "string" ? out : (out?.text ?? out?.output ?? null);
+    } catch {
+      return null;
+    }
+    return parseProposedProbes(text);
+  }
+
+  /**
+   * The ephemeral authoring pass: per consented tool whose spec is still the
+   * EMPTY scaffold (`probes: []`), propose probe entries from the evidence
+   * rows and fill the template through writeSpec — the ONE validated,
+   * engine-written path. Pacing mirrors the relevance scan: the daily budget
+   * bounds ATTEMPTS (a failed or gate-rejected call consumes it too and sets
+   * a retry watermark), a filled or not-derivable template rests for the
+   * week, and the pass is one-shot — once a spec carries probes it is never
+   * rewritten here. Refused candidates are never silent (surfaceRefusal).
+   * Not thrifty-shed: a still-empty template is at most one paced nano call,
+   * not a fan-out.
+   */
+  async function authorSpecs({ ts = now(), todayKey = dayKeyOf(ts) } = {}) {
+    if (typeof runEphemeral !== "function") return { ran: 0, attempts: 0, skipped: "no-ephemeral" };
+    let tools;
+    try {
+      tools = await probes.list();
+    } catch {
+      return { ran: 0, attempts: 0 };
+    }
+    let st;
+    try {
+      st = (await state.load("_authoring")) ?? {};
+    } catch {
+      st = {};
+    }
+    if (st.day !== todayKey) {
+      st.day = todayKey;
+      st.todayCount = 0;
+    }
+    let budget = AUTHORING_PER_DAY - (st.todayCount ?? 0);
+    let ran = 0;
+    let attempts = 0;
+    for (const tool of tools) {
+      if (budget <= 0) break;
+      if ((await registry.consentFor(tool, "metadata")) !== "yes") continue;
+      let raw;
+      try {
+        raw = await probes.load(tool);
+      } catch {
+        continue;
+      }
+      // Target ONLY the empty scaffold; a spec that already carries probes is
+      // user/engine content this pass must never rewrite.
+      if (!raw || typeof raw !== "object" || raw.tool !== tool || !Array.isArray(raw.probes) || raw.probes.length > 0) {
+        continue;
+      }
+      const entry = st.relAt?.[tool] ?? {};
+      const restMs = entry.ok ? AUTHORING_WEEK_MS : AUTHORING_FAILURE_RETRY_MS;
+      if (typeof entry.at === "number" && ts - entry.at < restMs) continue;
+      st.relAt = { ...(st.relAt ?? {}), [tool]: entry };
+      const ctx = await consentContext(tool);
+      budget -= 1; // the attempt itself is the paced resource
+      attempts += 1;
+      const proposals = await proposeProbes({
+        tool,
+        row: ctx.row,
+        allowedHosts: ctx.allowedHosts,
+        ring: ctx.consentedRing,
+        auth: raw.auth ?? null,
+      });
+      entry.at = ts;
+      if (proposals === null) {
+        entry.ok = false;
+        await surfaceRefusal(tool, "unparseable-reply", ts);
+        continue;
+      }
+      if (proposals.length === 0) {
+        entry.ok = true; // nothing derivable — rest for the week, no write
+        if (ledger && typeof ledger.append === "function") {
+          await ledger.append({ actor: "cto", kind: "cto.probe.author", tool, ok: true, probes: 0, ts }).catch(() => {});
+        }
+        continue;
+      }
+      const res = await writeSpec(tool, { tool, ...(raw.auth ? { auth: raw.auth } : {}), probes: proposals });
+      entry.ok = res.ok === true;
+      if (res.ok) {
+        ran += 1;
+        if (ledger && typeof ledger.append === "function") {
+          await ledger.append({ actor: "cto", kind: "cto.probe.author", tool, ok: true, probes: proposals.length, ts }).catch(() => {});
+        }
+      } else {
+        await surfaceRefusal(tool, res.errors?.[0]?.key ?? "invalid", ts, res.errors?.length ?? 1);
+      }
+    }
+    if (attempts > 0) {
+      st.todayCount = (st.todayCount ?? 0) + attempts;
+      await saveToolState("_authoring", st);
+    }
+    return { ran, attempts };
   }
 
   // ---- one probe execution -------------------------------------------------
@@ -1166,5 +1376,5 @@ export function createProbes(deps = {}) {
     return Math.max(0, Math.min(1, n));
   }
 
-  return { scaffoldSpec, writeSpec, runDue, relevanceScan, healthSnapshot, probeKey, consentContext, loadToolState, probeSummary };
+  return { scaffoldSpec, writeSpec, authorSpecs, runDue, relevanceScan, healthSnapshot, probeKey, consentContext, loadToolState, probeSummary };
 }

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -6,6 +6,8 @@ import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
 import {
+  AUTHORING_FAILURE_RETRY_MS,
+  AUTHOR_MAX_PROBES,
   AUTH_FAIL_ESCALATE,
   CADENCE_DAILY_MS,
   CADENCE_FLOOR_MS,
@@ -23,6 +25,7 @@ import {
   hostAllowed,
   isPrivateAddress,
   parseProbeUrl,
+  parseProposedProbes,
   publicAddresses,
   stepFailureState,
   validateProbeSpec,
@@ -1009,4 +1012,167 @@ test("runOne: a chain-tripped tool's probing cadence is capped at weekly (regist
   assert.equal(results.length, 1);
   const st = await eng.loadToolState("github");
   assert.equal(st.probes.repo_events.nextRunAt, 1_700_000_000_000 + CADENCE_WEEKLY_MS, "30m spec capped at weekly while decayed");
+});
+
+// ---------------------------------------------------------------------------
+// BET-1438 — the §7.5 authoring pass: parseProposedProbes + authorSpecs
+// ---------------------------------------------------------------------------
+
+// A standalone harness for the authoring pass: keeps the raw store/state/
+// ledger/registry references so the tests can assert what landed on disk.
+function authoringHarness({ rows = [consentedTool()], specs, runEphemeral = null, nowTs = 1_700_000_000_000 } = {}) {
+  const scaffold = (tool) => ({ tool, probes: [] });
+  const store = memProbesStore(specs ?? { github: { ...scaffold("github"), auth: githubSpec().auth } });
+  const state = memStateStore();
+  const ledger = fakeLedger();
+  const registry = fakeRegistry(rows);
+  const calls = [];
+  const eng = createProbes({
+    registry,
+    probes: store,
+    stateStore: state,
+    cards: fakeCards(),
+    ledger,
+    now: () => nowTs,
+    httpRequest: async () => ({ status: 200, bodyText: "[]" }),
+    getSecretPath: async () => "/tmp/secret-file",
+    readSecret: async () => "v",
+    isThrifty: () => false,
+    listProjects: async () => ["proj"],
+    getTopFacts: async () => [],
+    getRollups: async () => "",
+    runEphemeral: runEphemeral
+      ? async (opts) => {
+          calls.push(opts);
+          return runEphemeral(opts);
+        }
+      : null,
+  });
+  return { eng, store, state, ledger, registry, calls };
+}
+
+test("parseProposedProbes: fences + prose tolerated, unknown keys stripped, GET forced, ring defaults down, cap 5", () => {
+  const reply = [
+    "Here is my proposal:",
+    "```json",
+    JSON.stringify([
+      { name: "repo_events", url: "https://api.github.com/x", cadence: "30m", ring: "metadata", extract: { a: "0.b" }, surprise: true },
+      { name: "bad", url: "https://api.github.com/y", cadence: "10m", ring: "deep_read", method: "DELETE" },
+      { url: "https://api.github.com/z", cadence: "1h" },
+    ]),
+    "```",
+    "Hope that helps!",
+  ].join("\n");
+  const out = parseProposedProbes(reply);
+  assert.equal(out.length, 2);
+  assert.deepEqual(out[0], { name: "repo_events", url: "https://api.github.com/x", cadence: "30m", ring: "metadata", extract: { a: "0.b" }, method: "GET" });
+  assert.equal(out[1].method, "GET", "a model-proposed method is never trusted");
+  assert.equal(out[1].ring, "deep_read");
+  assert.ok(!("surprise" in out[0]), "unknown keys are stripped before the validator ever sees them");
+  assert.equal(parseProposedProbes(JSON.stringify([{ name: "b", url: "https://api.github.com/x", cadence: "1h" }]))[0].ring, "metadata", "omitted ring defaults DOWN to metadata");
+  const many = Array.from({ length: 9 }, (_, i) => ({ name: `p${i}`, url: "https://api.github.com/x", cadence: "1h" }));
+  assert.equal(parseProposedProbes(JSON.stringify(many)).length, AUTHOR_MAX_PROBES);
+  assert.deepEqual(parseProposedProbes("[]"), [], "an empty array is a valid 'nothing derivable' answer");
+  assert.equal(parseProposedProbes("I cannot help with that."), null);
+  assert.equal(parseProposedProbes(null), null);
+});
+
+test("authorSpecs: fills an empty scaffold through writeSpec — probe lands, auth preserved, prompt carries hosts + key name, ledger row, state ok", async () => {
+  let sawPrompt = "";
+  const h = authoringHarness({
+    runEphemeral: async ({ context }) => {
+      sawPrompt = context[0].text;
+      return { text: JSON.stringify([{ name: "repo_events", url: "https://api.github.com/users/octocat/events", cadence: "30m", ring: "metadata", extract: { inflow_rate: "length" } }]) };
+    },
+  });
+  const r = await h.eng.authorSpecs({ ts: 1_700_000_000_000 });
+  assert.deepEqual(r, { ran: 1, attempts: 1 });
+  const spec = h.store._files.github;
+  assert.equal(spec.probes.length, 1);
+  assert.equal(spec.probes[0].method, "GET");
+  assert.equal(spec.probes[0].url, "https://api.github.com/users/octocat/events");
+  assert.deepEqual(spec.auth, githubSpec().auth, "the engine-written auth section is preserved verbatim");
+  assert.ok(sawPrompt.includes("api.github.com"), "the prompt carries the evidenced hosts");
+  assert.ok(sawPrompt.includes("GITHUB_TOKEN"), "the prompt names the evidenced vault key (a KEY NAME, never a value)");
+  assert.ok(sawPrompt.includes('ring "metadata"'));
+  assert.ok(h.ledger.rows.some((row) => row.kind === "cto.probe.author" && row.tool === "github" && row.ok === true && row.probes === 1));
+  const st = await h.state.load("_authoring");
+  assert.equal(st.relAt.github.ok, true);
+  assert.equal(st.todayCount, 1);
+});
+
+test("authorSpecs: refused proposal (off-allowlist host) surfaces as evidence on the tool row; template left empty", async () => {
+  const h = authoringHarness({
+    runEphemeral: async () => ({ text: JSON.stringify([{ name: "exfil", url: "https://evil.example.com/x", cadence: "30m", ring: "metadata" }]) }),
+  });
+  const r = await h.eng.authorSpecs({ ts: 1_700_000_000_000 });
+  assert.deepEqual(r, { ran: 0, attempts: 1 });
+  assert.equal(h.store._files.github.probes.length, 0, "the refused candidate never lands");
+  const row = h.registry._rows.get("github");
+  const refusal = (row.evidence ?? []).find((e) => e.channel === "probe");
+  assert.ok(refusal, "the refusal is on the tool's evidence trail");
+  assert.equal(refusal.detail, "spec-refused:probes[0].url");
+  assert.ok(h.ledger.rows.some((x) => x.kind === "cto.probe.author" && x.ok === false && x.refused === "probes[0].url"));
+  const st = await h.state.load("_authoring");
+  assert.equal(st.relAt.github.ok, false, "a refused fill retries on the failure watermark");
+});
+
+test("authorSpecs: unparseable reply → evidence row + failure watermark; no write, no re-attempt until the watermark elapses", async () => {
+  const h = authoringHarness({ runEphemeral: async () => ({ text: "I could not derive any probes." }) });
+  let r = await h.eng.authorSpecs({ ts: 1_700_000_000_000 });
+  assert.deepEqual(r, { ran: 0, attempts: 1 });
+  const row = h.registry._rows.get("github");
+  assert.ok((row.evidence ?? []).some((e) => e.detail === "spec-refused:unparseable-reply"));
+  assert.equal(h.store._files.github.probes.length, 0);
+  // failure watermark: a minute later nothing is re-attempted…
+  r = await h.eng.authorSpecs({ ts: 1_700_000_000_000 + 60_000 });
+  assert.deepEqual(r, { ran: 0, attempts: 0 });
+  assert.equal(h.calls.length, 1);
+  // …but after the watermark elapses the pass runs again
+  r = await h.eng.authorSpecs({ ts: 1_700_000_000_000 + AUTHORING_FAILURE_RETRY_MS });
+  assert.deepEqual(r, { ran: 0, attempts: 1 });
+  assert.equal(h.calls.length, 2);
+});
+
+test("authorSpecs: empty model array rests for the week with no write and no evidence noise", async () => {
+  const h = authoringHarness({ runEphemeral: async () => ({ text: "[]" }) });
+  const r = await h.eng.authorSpecs({ ts: 1_700_000_000_000 });
+  assert.deepEqual(r, { ran: 0, attempts: 1 });
+  assert.equal(h.store._files.github.probes.length, 0);
+  const row = h.registry._rows.get("github");
+  assert.equal((row.evidence ?? []).length, 1, "the pre-existing secret evidence row is untouched — no refusal row");
+  assert.ok(h.ledger.rows.some((x) => x.kind === "cto.probe.author" && x.ok === true && x.probes === 0));
+  const r2 = await h.eng.authorSpecs({ ts: 1_700_000_000_000 + 3_600_000 });
+  assert.deepEqual(r2, { ran: 0, attempts: 0 }, "an ok-but-empty pass rests for the week");
+});
+
+test("authorSpecs: one-shot — a filled spec is never rewritten; unconsented tools are skipped; no seam → skipped", async () => {
+  const filled = authoringHarness({ specs: { github: githubSpec() }, runEphemeral: async () => ({ text: "[]" }) });
+  assert.deepEqual(await filled.eng.authorSpecs({ ts: 1_700_000_000_000 }), { ran: 0, attempts: 0 });
+  assert.equal(filled.calls.length, 0, "a spec that already carries probes is never touched");
+  const unconsented = authoringHarness({
+    rows: [{ ...consentedTool(), consent: { metadata: "no", deep_read: null, write: null } }],
+    runEphemeral: async () => ({ text: "[]" }),
+  });
+  assert.deepEqual(await unconsented.eng.authorSpecs({ ts: 1_700_000_000_000 }), { ran: 0, attempts: 0 });
+  assert.equal(unconsented.calls.length, 0);
+  const noSeam = authoringHarness({});
+  assert.deepEqual(await noSeam.eng.authorSpecs({ ts: 1_700_000_000_000 }), { ran: 0, attempts: 0, skipped: "no-ephemeral" });
+});
+
+test("authorSpecs: the daily attempt budget bounds the calls box-wide, not per tool", async () => {
+  const tools = ["t1", "t2", "t3", "t4", "t5", "t6"];
+  const h = authoringHarness({
+    rows: tools.map((tool) => consentedTool(tool, ["api.github.com"])),
+    specs: Object.fromEntries(tools.map((tool) => [tool, { tool, probes: [] }])),
+    runEphemeral: async () => ({ text: JSON.stringify([{ name: "p", url: "https://api.github.com/x", cadence: "1h", ring: "metadata" }]) }),
+  });
+  const r = await h.eng.authorSpecs({ ts: 1_700_000_000_000 });
+  assert.equal(r.attempts, 4, "only AUTHORING_PER_DAY attempts are made");
+  assert.equal(h.calls.length, 4);
+  const r2 = await h.eng.authorSpecs({ ts: 1_700_000_000_000 + 60_000 });
+  assert.deepEqual(r2, { ran: 0, attempts: 0 }, "the budget is spent for the day");
+  const r3 = await h.eng.authorSpecs({ ts: 1_700_000_000_000 + 24 * 3_600_000 });
+  assert.equal(r3.attempts, 2, "the next day fills the remaining templates");
+  assert.deepEqual(r3, { ran: 2, attempts: 2 });
 });

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -1140,7 +1140,7 @@ test("authorSpecs: empty model array rests for the week with no write and no evi
   assert.deepEqual(r, { ran: 0, attempts: 1 });
   assert.equal(h.store._files.github.probes.length, 0);
   const row = h.registry._rows.get("github");
-  assert.equal((row.evidence ?? []).length, 1, "the pre-existing secret evidence row is untouched — no refusal row");
+  assert.equal((row.evidence ?? []).filter((e) => e.channel === "probe").length, 0, "no refusal row — an ok-but-empty pass stays silent on the trail");
   assert.ok(h.ledger.rows.some((x) => x.kind === "cto.probe.author" && x.ok === true && x.probes === 0));
   const r2 = await h.eng.authorSpecs({ ts: 1_700_000_000_000 + 3_600_000 });
   assert.deepEqual(r2, { ran: 0, attempts: 0 }, "an ok-but-empty pass rests for the week");


### PR DESCRIPTION
Closes the BET-1396 gap: nothing filled the scaffolded probe-spec templates. Adds the §7.5 authoring step to the probe runner.

## What

- **`src/server/ctoProbes.mjs`** — new `authorSpecs()` pass on the probe runner: per consented tool whose spec is still the empty scaffold (`{tool, probes: []}`), one nano `runEphemeral` call proposes probe entries from the tool's evidence rows (evidenced hosts + credential presence only), and the proposals are submitted through `writeSpec` — the ONE validated, engine-written path.
  - `parseProposedProbes()` (pure, exported): tolerates fenced JSON + stray prose, strips unknown keys, forces `method: "GET"`, defaults an omitted ring DOWN to `metadata`, caps at 5 probes. Structurally broken entries are dropped; survivors still face full validation inside `writeSpec`.
  - `surfaceRefusal()`: a refused candidate (or unparseable reply) lands as a `probe: spec-refused:<key>` row on the tool's evidence trail — the trail the connect ask and §10.5 drill-down read — plus a `cto.probe.author` ledger row. Never silent; the row never widens the host allowlist (`spec-refused:` is not an `evidenceHost` channel).
  - Auth is never authored by the model: the scaffold's engine-written `auth` section is preserved verbatim; the prompt names the vault key (a key NAME, never a value) so the model doesn't invent auth content.
  - Pacing mirrors the relevance scan: attempts are the paced resource (`AUTHORING_PER_DAY` = 4/day box-wide), failures set an hourly retry watermark, filled or not-derivable templates rest a week, and the pass is one-shot — a spec that carries probes is never rewritten. Not thrifty-shed: a still-empty template is at most one paced nano call, not a fan-out.
- **`src/server/ctoEngine.mjs`** — `authorSpecs` wired into `probesTick` ahead of `runDue`, so consent → fill → first probe can land within a single tick. Inherits the master-toggle/pause gates automatically.
- **`src/server/ctoToolRegistry.mjs`** — unchanged: the consent path already calls `scaffoldProbes`; no registry change was needed.
- **`src/server/ctoProbes.test.mjs`** — 7 new tests: parser hardening, fill-success, refusal→evidence, unparseable→watermark, empty-array-rest-week, one-shot/skip/no-seam, and the box-wide daily attempt budget.

## Verification results

- **Files changed:** 3 files. `src/server/ctoProbes.mjs`, `src/server/ctoProbes.test.mjs`, `src/server/ctoEngine.mjs`
- **Verification results:**
  - PR branch (`multica/BET-1438-probe-authoring` @ `ad634ba2`):
    - typecheck: exit 0. Errors: none. log sha256: `c697e014c2559844c5ccc853999c234f8429bd4585639356f28aafc8029c298b`
    - test: exit 0, 3657 pass / 0 fail / 0 skip. Failures: none. log sha256: `59a68d47589887b787e0527db2b2044b6f29ed52635c24a09e13e8619fab0dff`
  - Base (`main` @ `bac9cdfb`):
    - typecheck: exit 0. Errors: none. log sha256: `c697e014c2559844c5ccc853999c234f8429bd4585639356f28aafc8029c298b`
    - test: exit 0, 3650 pass / 0 fail / 0 skip. Failures: none. log sha256: `15fb0348f9dd6e6ac11518aaaf9f54037d603c84feb36d1feecc192226bb8395`
  - **Conclusion:** 0 new failures, 0 pre-existing failures; +7 new tests, all passing.

Base: origin/main @ bac9cdfb (includes BET-1404's merge — the shared `ctoProbes.mjs`/`ctoEngine.mjs` write surface is free; one cell in flight honored).

Refs: BET-1396 (scaffold + writeSpec seams), spec §7.5 / §3.3.
