### PR TITLE
BET-1443: fix(server): probe blocker copy names the real secrets surface (chat SecretsCard)

### DIFF
--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -257,7 +257,7 @@ describe("blockerTarget (§10.3 Answer-now routing)", () => {
       sourceKind: "probe",
       sourceId: "github/repo_events",
       sessionID: null,
-      body: 'The "repo_events" probe for github failed auth 3 times in a row (HTTP 401/403 or the credential is gone), so the digest\'s view of github is degraded. If the key was rotated, update "GITHUB_PAT" on the secrets surface (⚙ Settings → Secrets).',
+      body: 'The "repo_events" probe for github failed auth 3 times in a row (HTTP 401/403 or the credential is gone), so the digest\'s view of github is degraded. If the key was rotated, update "GITHUB_PAT" on the secrets surface — the 🔑 secrets card in your chat session.',
     });
     expect(blockerTarget(probe, new Set([]))).toEqual({ action: "secrets", key: "GITHUB_PAT" });
   });
@@ -265,7 +265,7 @@ describe("blockerTarget (§10.3 Answer-now routing)", () => {
     const probe = card({
       sourceKind: "probe",
       sessionID: null,
-      body: 'The "tool_ping" probe for tool failed auth 3 times in a row (HTTP 401/403 or the credential is gone), so the digest\'s view of tool is degraded. Check the tool\'s credential on the secrets surface (⚙ Settings → Secrets).',
+      body: 'The "tool_ping" probe for tool failed auth 3 times in a row (HTTP 401/403 or the credential is gone), so the digest\'s view of tool is degraded. Check the tool\'s credential on the secrets surface — the 🔑 secrets card in your chat session.',
     });
     expect(blockerTarget(probe, new Set(["s1"]))).toEqual({ action: "secrets", key: null });
   });

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -79,11 +79,15 @@ export const PROBE_SOURCE_KIND = "probe";
 // §10.6-7 probe-auth-failure card copy (3 consecutive auth failures — the
 // runner's AUTH_FAIL_ESCALATE). `secretKey` is the vault KEY NAME (not a
 // value) when the spec declared one — naming the exact key the user should
-// update is the deep-link to the secrets surface in words.
+// update is the deep-link to the secrets surface in words. The body keeps the
+// literal phrase "on the secrets surface" — the renderer's probeSecretKey
+// parse anchor (ctoView.ts) — and names the REAL surface after the dash: the
+// 🔑 SecretsCard in the chat session (BET-1437 deep-link target), never
+// "Settings → Secrets" (that Settings section does not exist).
 export function probeBlockerCopy(tool, probeName, secretKey = null) {
   const secret = secretKey
-    ? ` If the key was rotated, update "${secretKey}" on the secrets surface (⚙ Settings → Secrets).`
-    : " Check the tool's credential on the secrets surface (⚙ Settings → Secrets).";
+    ? ` If the key was rotated, update "${secretKey}" on the secrets surface — the 🔑 secrets card in your chat session.`
+    : " Check the tool's credential on the secrets surface — the 🔑 secrets card in your chat session.";
   return {
     title: `Probe failing — ${tool} key may have been rotated`,
     body: `The "${probeName}" probe for ${tool} failed auth 3 times in a row (HTTP 401/403 or the credential is gone), so the digest's view of ${tool} is degraded.${secret}`,

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -847,6 +847,19 @@ test("probeBlockerCopy names the key + the secrets surface; titles name the rota
   assert.ok(!noKey.body.includes("GITHUB_TOKEN"), "no cross-tool key leakage");
 });
 
+test("probeBlockerCopy names the REAL secrets surface (the chat SecretsCard), never Settings → Secrets (BET-1443)", () => {
+  const withKey = probeBlockerCopy("github", "repo_events", "GITHUB_TOKEN");
+  const noKey = probeBlockerCopy("gitlab", "issues");
+  for (const copy of [withKey, noKey]) {
+    // The real surface: the 🔑 secrets card in the chat session (the
+    // BET-1437 deep-link target — probeSecretKey still parses the key name
+    // from the "on the secrets surface" phrase).
+    assert.match(copy.body, /secrets card/);
+    assert.match(copy.body, /chat session/);
+    assert.ok(!copy.body.includes("Settings"), "no phantom Settings → Secrets section");
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Registry vitality fold (§7.3 math) — through the real registry
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes BET-1443.

## What

Probe blocker cards' body copy told the user to update the rotated key under "(⚙ Settings → Secrets)" — but the main Settings modal has no Secrets section (sections: general/box/accounts/models/sessions/files/extensions/voice/cto). The BET-1437 deep-link correctly lands in the chat SecretsCard; only the server-generated copy drifted.

`probeBlockerCopy()` in `src/server/ctoCards.mjs` now says: `…on the secrets surface — the 🔑 secrets card in your chat session.`

## Deliberate design decisions

- **Kept the phrase `on the secrets surface`** — it is the machine-readable parse anchor the renderer uses to extract the vault key name (`probeSecretKey` in `src/renderer/ctoView.ts:369`, which routes the key into the `manta-open-secrets` bridge for pre-fill/highlight). Changing it would break key pre-fill; it also remains accurate (the SecretsCard *is* the secrets surface).
- **Fixed the source of truth only** — `probeBlockerCopy()` is the single writer of this copy; no other code path embeds it (grep verified). Renderer test fixtures that embed the body verbatim were updated to match.

## Duplicate-site scan

- `src/server/ctoCards.mjs` — source of truth (fixed)
- `src/server/ctoProbes.test.mjs:581,844,846` — `/secrets surface/` assertions, still pass; added a pinning test for the new copy
- `src/renderer/ctoView.ts:363-371` — comment + regex, still accurate, no change
- `src/renderer/ctoView.test.ts:260,268` — fixtures embedding the body verbatim, updated

No actionable follow-ups filed: option 2 from the issue (a Secrets section in the main Settings modal) is a product-direction call the issue itself gated on "only worth it if other secrets UX moves to Settings too" — not an actionable gap from this change.

**Files changed:** 3 files. `src/server/ctoCards.mjs`, `src/server/ctoProbes.test.mjs`, `src/renderer/ctoView.test.ts`

**Verification results:**
- PR branch (`multica/BET-1443-probe-blocker-secrets-copy` @ `87fcf996`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, node:test 3651 pass / 0 fail; vitest 198 files, 3855 pass / 7 skip / 0 fail. Failures: none.
- Base (`main` @ `bac9cdfb`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, node:test 3650 pass / 0 fail; vitest 198 files, 3855 pass / 7 skip / 0 fail. Failures: none.
- **Conclusion:** 0 test failures on either branch; the +1 node:test count is the new BET-1443 pinning test. No pre-existing failures.

Base: origin/main @ bac9cdfb
