### PR TITLE
feat(server): per-project relevance rollup context (BET-1439)

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1120,28 +1120,25 @@ export function createCtoEngine(deps = {}) {
       isThrifty: () => thrifty,
       listProjects: () => getFactsEngine().listProjects(),
       getTopFacts: (project, k) => getFactsEngine().topFacts(project, { k }),
-      getRollups: probesRollupLines,
+      getRollups: () => loadRecentDayRollups(7),
+      resolveSegment: resolveSegmentProject,
       runEphemeral: toolsRunEphemeral ?? null,
     });
     return probesEngine;
   }
 
-  // §7.6 relevance context: the most recent day-rollup's bullet lines (the
-  // blackboard's freshest summarized work). Cross-project attribution of
-  // rollup bullets needs segment resolution (ctoRollups' proposal mapper) —
-  // deliberately not paid for a nano context; the project's own top facts
-  // (which rollups are fused into) carry the per-project signal.
-  async function probesRollupLines() {
+  // §7.6 relevance context (BET-1439): the probes runner receives the RAW
+  // recent day-rollup payloads and projects them per project itself, using
+  // this resolver to attribute each rollup bullet's leaf segment refs to
+  // their project (the same mapper the day-level fact sync runs). Best-effort:
+  // an unreadable segment attributes to nothing, which the runner treats as
+  // the facts-only fallback.
+  async function resolveSegmentProject(id) {
     try {
-      const rollups = await loadRecentDayRollups(7);
-      const latest = rollups[rollups.length - 1];
-      return (latest?.bullets ?? [])
-        .map((b) => (typeof b?.text === "string" ? b.text.trim() : ""))
-        .filter(Boolean)
-        .slice(0, 5)
-        .join("\n");
+      const s = await segmentsStore.load(id);
+      return s && s.project ? { project: s.project } : null;
     } catch {
-      return "";
+      return null;
     }
   }
 

--- a/src/server/ctoProbes.mjs
+++ b/src/server/ctoProbes.mjs
@@ -1406,7 +1406,7 @@ export function createProbes(deps = {}) {
       `Tool "${tool}" provides external data (evidence: ${domain}).`,
       `Project "${project}" blackboard facts:`,
       factLines(facts) || "(none)",
-      rollupLines(rollups) ? `Recent rollups:\n${rollupLines(rollups)}` : "",
+      rollupLines(rollups) ? `Recent rollups for this project:\n${rollupLines(rollups)}` : "",
       "",
       "Score how relevant this tool's data domain is to the project's active work: 0.0 (unrelated) to 1.0 (core data source for this work).",
       "Reply with ONLY the number.",

--- a/src/server/ctoProbes.mjs
+++ b/src/server/ctoProbes.mjs
@@ -72,6 +72,7 @@ import https from "node:https";
 import dns from "node:dns/promises";
 import { probesStore, probeStateStore } from "./ctoStores.mjs";
 import { provideSecret } from "./secrets.mjs";
+import { proposalsFromRollup } from "./ctoRollups.mjs";
 import {
   PROBE_SOURCE_KIND,
   probeBlockerCopy,
@@ -649,7 +650,15 @@ export function evidenceHost(detail) {
  *   isThrifty     — () => boolean (live engine thrifty flag).
  *   listProjects  — async () => [projectName] (active projects for §7.6).
  *   getTopFacts   — async (project, k) => [{statement}].
- *   getRollups    — async (project) => string lines (recent rollup facts).
+ *   getRollups    — async () => raw recent day-rollup payloads (the box-wide
+ *                   store contents, oldest-first, each {level, window, bullets:
+ *                   [{text, refs}]}); the runner projects them per project
+ *                   itself (BET-1439 — the relevance context is per-project).
+ *   resolveSegment— async (segmentId) => {project} | null — rollup-bullet
+ *                   attribution through the canonical segment resolver (the
+ *                   same seam the day-level fact sync uses). Absent → no
+ *                   bullet ever attributes → every project falls back to a
+ *                   facts-only rollup context.
  *   runEphemeral  — the pre-gated ephemeral session call (nano classify /
  *                   relevance score / BET-1438 spec authoring).
  */
@@ -674,7 +683,8 @@ export function createProbes(deps = {}) {
     isThrifty = () => false,
     listProjects = async () => [],
     getTopFacts = async () => [],
-    getRollups = async () => "",
+    getRollups = async () => [],
+    resolveSegment = null,
     runEphemeral,
   } = deps;
   if (!registry || typeof registry.consentFor !== "function" || typeof registry.applyProbeResult !== "function") {
@@ -1235,7 +1245,9 @@ export function createProbes(deps = {}) {
 
   /**
    * Weekly per consented tool × active project: one nano call matching the
-   * tool's data domain against the project's top facts + recent rollups →
+   * tool's data domain against the project's top facts + the project's OWN
+   * recent rollups (BET-1439 — the context is per-project, never the box-wide
+   * slice) →
    * `relevance[project] ∈ [0,1]`. Pacing bounds ATTEMPTS: every call —
    * success or failure — consumes the RELEVANCE_PER_DAY budget, and a failed
    * call also sets a RELEVANCE_FAILURE_RETRY_MS watermark so a persistently
@@ -1271,6 +1283,14 @@ export function createProbes(deps = {}) {
     let budget = RELEVANCE_PER_DAY - (st.todayCount ?? 0);
     let ran = 0;
     let attempts = 0;
+    // The raw box-wide day-rollup source is fetched at most once per scan and
+    // only on first need (a resting pair never pays for the read); the
+    // per-project projection happens per pair below.
+    let rawRollups = null;
+    const rollupSource = async () => {
+      if (rawRollups === null) rawRollups = await getRollups().catch(() => []);
+      return Array.isArray(rawRollups) ? rawRollups : [];
+    };
     for (const tool of tools) {
       if (budget <= 0) break;
       if ((await registry.consentFor(tool, "metadata")) !== "yes") continue;
@@ -1286,7 +1306,7 @@ export function createProbes(deps = {}) {
         const restMs = entry?.ok ? RELEVANCE_WEEK_MS : RELEVANCE_FAILURE_RETRY_MS;
         if (entry && typeof entry.at === "number" && ts - entry.at < restMs) continue;
         const facts = await getTopFacts(project, 5).catch(() => []);
-        const rollups = await getRollups(project).catch(() => "");
+        const rollups = await projectRollupContext(await rollupSource(), project, resolveSegment);
         if (!factLines(facts) && !rollupLines(rollups)) {
           relAt[project] = { at: ts, ok: true }; // nothing to match against — do not retry all week
           toolTouched = true;
@@ -1318,6 +1338,39 @@ export function createProbes(deps = {}) {
       await saveToolState("_relevance", st);
     }
     return { ran, attempts };
+  }
+
+  /**
+   * §7.6 relevance context selection (BET-1439): the project's OWN rollup
+   * lines, projected from the box-wide day-rollup store through the canonical
+   * segment-attribution mapper (`ctoRollups.proposalsFromRollup` — the same
+   * mapper the day-level fact sync uses). Newest rollup first, early stop at
+   * five lines. A bullet that resolves to no project — or to a different
+   * project — never enters the context: a cross-project slice would actively
+   * mislead the per-project scoring. Returns "" when nothing attributes, which
+   * is the documented fallback: the nano call then runs on the project's top
+   * facts alone rather than a misleading box-wide rollup.
+   */
+  async function projectRollupContext(dayRollups, project, resolveSegmentFn) {
+    if (!Array.isArray(dayRollups) || dayRollups.length === 0) return "";
+    const resolve = resolveSegmentFn ?? (async () => null);
+    const out = [];
+    for (let i = dayRollups.length - 1; i >= 0 && out.length < 5; i--) {
+      const rollup = dayRollups[i];
+      if (!rollup || rollup.level !== "day" || !Array.isArray(rollup.bullets)) continue;
+      let proposals;
+      try {
+        proposals = await proposalsFromRollup(rollup, { resolveSegment: resolve });
+      } catch {
+        continue;
+      }
+      for (const p of proposals) {
+        if (p?.project !== project || typeof p?.statement !== "string" || !p.statement) continue;
+        out.push(p.statement);
+        if (out.length >= 5) break;
+      }
+    }
+    return out.join("\n");
   }
 
   function factLines(facts) {

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -165,7 +165,7 @@ function githubSpec(overrides = {}) {
   };
 }
 
-function build({ rows, specs, state, cards, ledger, http, now, thrifty, runEphemeral, projects, getTopFacts, getRollups } = {}) {
+function build({ rows, specs, state, cards, ledger, http, now, thrifty, runEphemeral, projects, getTopFacts, getRollups, resolveSegment } = {}) {
   return createProbes({
     registry: fakeRegistry(rows ?? [consentedTool()]),
     probes: memProbesStore(specs ?? { github: githubSpec() }),
@@ -179,7 +179,8 @@ function build({ rows, specs, state, cards, ledger, http, now, thrifty, runEphem
     isThrifty: thrifty ?? (() => false),
     listProjects: async () => projects ?? ["proj"],
     getTopFacts: getTopFacts ?? (async () => [{ statement: "ships the parser" }]),
-    getRollups: getRollups ?? (async () => "did a thing"),
+    getRollups: getRollups ?? (async () => []),
+    resolveSegment: resolveSegment ?? null,
     runEphemeral: runEphemeral ?? null,
   });
 }
@@ -757,7 +758,7 @@ test("relevanceScan: projects with nothing on the blackboard are watermarked, no
     rows,
     projects: ["empty"],
     getTopFacts: async () => [],
-    getRollups: async () => "",
+    getRollups: async () => [],
     runEphemeral: async () => {
       calls += 1;
       return { text: "0.5" };
@@ -790,6 +791,67 @@ test("relevanceScan: paces at 6 calls/day across tools and pairs", async () => {
   assert.equal(calls, 6, "the same UTC day gets no further calls");
   await eng.relevanceScan({ ts: day0 + 24 * 3_600_000 });
   assert.equal(calls, 12, "the next day gets a fresh budget");
+});
+
+test("relevanceScan: rollup context is the PROJECT'S OWN rollups, not the box-wide slice", async () => {
+  const rows = [consentedTool()];
+  const prompts = [];
+  const t = 1_700_000_000_000;
+  const eng = build({
+    rows,
+    projects: ["projA", "projB"],
+    getRollups: async () => [
+      {
+        level: "day",
+        window: [t - 86_400_000, t],
+        bullets: [
+          { text: "alpha work item", refs: ["seg-alpha"] },
+          { text: "beta work item", refs: ["seg-beta"] },
+        ],
+      },
+    ],
+    resolveSegment: async (id) =>
+      id === "seg-alpha" ? { project: "projA" } : id === "seg-beta" ? { project: "projB" } : null,
+    runEphemeral: async ({ context }) => {
+      prompts.push(context.map((c) => c.text).join("\n"));
+      return { text: "0.5" };
+    },
+  });
+  await eng.relevanceScan({ ts: t });
+  assert.equal(prompts.length, 2);
+  const a = prompts.find((p) => p.includes('"projA"'));
+  const b = prompts.find((p) => p.includes('"projB"'));
+  assert.ok(a, "projA prompt captured");
+  assert.ok(b, "projB prompt captured");
+  assert.ok(a.includes("alpha work item"), "projA sees its own rollup line");
+  assert.ok(!a.includes("beta work item"), "projA does not see projB's rollup line");
+  assert.ok(b.includes("beta work item"), "projB sees its own rollup line");
+  assert.ok(!b.includes("alpha work item"), "projB does not see projA's rollup line");
+});
+
+test("relevanceScan: no project-attributable rollups → facts-only fallback (no cross-project rollup block)", async () => {
+  const rows = [consentedTool()];
+  const prompts = [];
+  const t = 1_700_000_000_000;
+  const eng = build({
+    rows,
+    getRollups: async () => [
+      {
+        level: "day",
+        window: [t - 86_400_000, t],
+        bullets: [{ text: "someone else's work", refs: ["seg-other"] }],
+      },
+    ],
+    resolveSegment: async () => ({ project: "unrelated" }),
+    runEphemeral: async ({ context }) => {
+      prompts.push(context.map((c) => c.text).join("\n"));
+      return { text: "0.5" };
+    },
+  });
+  await eng.relevanceScan({ ts: t });
+  assert.equal(prompts.length, 1);
+  assert.ok(prompts[0].includes("ships the parser"), "the project's top facts still carried");
+  assert.ok(!prompts[0].includes("Recent rollups"), "no cross-project rollup block leaks into the prompt");
 });
 
 // ---------------------------------------------------------------------------
@@ -1018,7 +1080,7 @@ test("runOne: a chain-tripped tool's probing cadence is capped at weekly (regist
     isThrifty: () => false,
     listProjects: async () => ["proj"],
     getTopFacts: async () => [],
-    getRollups: async () => "",
+    getRollups: async () => [],
     runEphemeral: null,
   });
   const results = await eng.runDue();
@@ -1053,7 +1115,7 @@ function authoringHarness({ rows = [consentedTool()], specs, runEphemeral = null
     isThrifty: () => false,
     listProjects: async () => ["proj"],
     getTopFacts: async () => [],
-    getRollups: async () => "",
+    getRollups: async () => [],
     runEphemeral: runEphemeral
       ? async (opts) => {
           calls.push(opts);


### PR DESCRIPTION
# BET-1439 — Relevance rollup context: per-project attribution

Follow-up to BET-1396 (PR #1421): the §7.6 relevance nano call now scores against **the project's own rollups** instead of the box-wide latest-day rollup slice. Spec §7.6.

## What changed

**`src/server/ctoProbes.mjs` — context selection (the relevance path)**
- New `projectRollupContext(dayRollups, project, resolveSegmentFn)`: projects the raw box-wide day-rollup payloads through the canonical segment-attribution mapper (`ctoRollups.proposalsFromRollup` — the same mapper the day-level fact sync uses), newest rollup first, ≤5 lines, early stop. A bullet resolving to no project — or to another project — never enters the context.
- `relevanceScan` fetches the raw source at most once per scan (lazy, only on the first due pair — a resting pair never pays for the read) and projects per pair.
- Prompt copy updated: `Recent rollups for this project:`.
- Deps contract: `getRollups` is now `async () => rawDayRollup[]`; new `resolveSegment` dep `async (segmentId) => {project} | null`. No new module — reuses the already-exported pure mapper.

**`src/server/ctoEngine.mjs`**
- The engine hands the runner the raw recent day-rollup payloads (`loadRecentDayRollups(7)`) plus a segment resolver (`resolveSegmentProject` via `segmentsStore.load`); the old box-wide `probesRollupLines()` pre-renderer is deleted (its only consumer was this seam).

**`src/server/ctoProbes.test.mjs`**
- Two new tests: per-project attribution (each project's prompt carries only its own rollup lines), and the facts-only fallback (no cross-project rollup block leaks into any prompt). Existing tests migrated to the raw `getRollups` contract.

## Fallback (documented, as the issue asks)

When nothing attributes to the requested project (bullet refs resolve to no segment, to another project, or no `resolveSegment` dep), the rollup context is **empty and the nano call runs on the project's top facts alone** — the box-wide slice is deliberately NOT re-used: a cross-project rollup in a per-project scoring prompt actively misleads the model. Facts-only still satisfies the existing no-content watermark (facts+rollups emptiness gates the call).

Out of scope per the issue: deep-read analyses + overnight candidates (P3), no registry/vitality changes, no authoring-pass changes (BET-1438).

**Base: origin/main @ 60418590**

## Verification results

- PR branch (`multica/BET-1439-perproject-relevance-rollup` @ 09743239):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3660 pass / 0 fail / 0 skip. Failures: none. log sha256: `afa14e567da7aa34f1f6d377e8e0fb0b19e8b7e9ac2604de16463eb5f6385274`
- Base (`main` @ 60418590):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3658 pass / 0 fail / 0 skip. Failures: none. log sha256: `811d3a7cfa29d8d05d1d76173dabac1b2c1a102151cc22b1bcea37838bdfa91b`
- **Conclusion:** 0 new failures; 2 new tests added pinning per-project attribution and the facts-only fallback.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
