### PR TITLE
fix(renderer): blackboard fact-ref chips are never dead controls (BET-1441)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -49,6 +49,7 @@ import {
   forecastAccuracyRows,
   bindingReserveFrac,
   budgetTodayUsd,
+  refChipAction,
   type BlockerCard,
   type ConnectCardRow,
   type CtoState,
@@ -2066,11 +2067,13 @@ function FactRow({
   row,
   struck,
   onOpenSession,
+  onOpenRef,
   openableSessions,
 }: {
   row: CtoFactRow;
   struck?: boolean;
   onOpenSession?: (sessionId: string) => void;
+  onOpenRef?: (ref: string) => void;
   openableSessions?: Set<string>;
 }) {
   const pct = Math.round(Math.min(1, Math.max(0, row.confidence)) * 100);
@@ -2096,21 +2099,27 @@ function FactRow({
         {row.expired ? <span className="text-text-muted">· expired</span> : null}
         {struck && row.supersededBy ? <span>· superseded by {row.supersededBy}</span> : null}
         {row.refs.map((ref) => {
-          const openable = onOpenSession != null && openableSessions?.has(ref);
-          return openable ? (
+          const chip = refChipAction(ref, openableSessions);
+          return chip.kind === "jump" ? (
             <button
               key={ref}
               type="button"
-              onClick={() => onOpenSession(ref)}
+              onClick={() => onOpenSession?.(ref)}
               className="truncate rounded-md bg-fill-active px-2 py-1 text-[10px] text-accent underline decoration-dotted underline-offset-2 hover:text-accent-strong focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
-              title={`Open session ${ref}`}
+              title={chip.title}
             >
               {ref}
             </button>
           ) : (
-            <span key={ref} className="truncate rounded-md bg-fill-active px-2 py-1 text-[10px] text-text-muted" title={ref}>
+            <button
+              key={ref}
+              type="button"
+              onClick={() => onOpenRef?.(ref)}
+              className="truncate rounded-md bg-fill-active px-2 py-1 text-[10px] text-text-muted hover:text-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
+              title={chip.title}
+            >
               {ref}
-            </span>
+            </button>
           );
         })}
       </div>
@@ -2129,6 +2138,20 @@ function BlackboardView({
   onOpenSession: (sessionId: string) => void;
   openableSessions: Set<string>;
 }) {
+  // Non-session refs have no server-side resolver (§6.1 bare provenance) —
+  // the honest action is copy-to-clipboard, same as the Profile view's
+  // evidence chips. Every chip responds; none is a dead control.
+  const copyRef = useCallback(
+    async (ref: string) => {
+      try {
+        await navigator.clipboard.writeText(ref);
+      } catch {
+        /* clipboard can be denied; the chip still responds */
+      }
+      pushToast({ id: `bb-ref-${ref}`, message: `Copied evidence ref: ${ref}` });
+    },
+    [pushToast],
+  );
   const [render, setRender] = useState<CtoFactsRender | null>(null);
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState<"facts" | "archive">("facts");
@@ -2250,7 +2273,7 @@ function BlackboardView({
               <div className="mt-4 space-y-2">
                 {render.active.map((row) => (
                   <div key={row.id}>
-                    <FactRow row={row} onOpenSession={onOpenSession} openableSessions={openableSessions} />
+                    <FactRow row={row} onOpenSession={onOpenSession} onOpenRef={(r) => void copyRef(r)} openableSessions={openableSessions} />
                     {correcting === row.id ? (
                       <div className="mt-2 rounded-md border border-border-subtle bg-fill px-3 py-2">
                         <input
@@ -2312,7 +2335,7 @@ function BlackboardView({
                 <h3 className="text-xs font-semibold uppercase tracking-wide text-text-faint">Superseded</h3>
                 <div className="mt-2 space-y-2">
                   {render.superseded.map((row) => (
-                    <FactRow key={row.id} row={row} struck onOpenSession={onOpenSession} openableSessions={openableSessions} />
+                    <FactRow key={row.id} row={row} struck onOpenSession={onOpenSession} onOpenRef={(r) => void copyRef(r)} openableSessions={openableSessions} />
                   ))}
                 </div>
               </div>
@@ -2326,7 +2349,7 @@ function BlackboardView({
             <div className="mt-4 text-xs text-text-faint">Displaced facts, newest first ({archiveTotal} total).</div>
             <div className="mt-2 space-y-2">
               {archive.map((row) => (
-                <FactRow key={`${row.id}-${row.archivedAt}`} row={row} struck onOpenSession={onOpenSession} openableSessions={openableSessions} />
+                <FactRow key={`${row.id}-${row.archivedAt}`} row={row} struck onOpenSession={onOpenSession} onOpenRef={(r) => void copyRef(r)} openableSessions={openableSessions} />
               ))}
             </div>
             {nextBefore != null ? (

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -644,3 +644,58 @@ describe("forecastAccuracyRows", () => {
     expect(forecastAccuracyRows(null)).toEqual([]);
   });
 });
+
+describe("refChipAction (BET-1441 — blackboard fact-ref chips)", () => {
+  const sessions = new Set(["ses_1", "ses_2"]);
+
+  it("jumps when the ref is a known openable session", () => {
+    expect(refChipAction("ses_1", sessions)).toEqual({
+      kind: "jump",
+      title: "Open session ses_1",
+    });
+  });
+
+  it("copies when the ref is bare provenance (msg:/ref:/file paths)", () => {
+    expect(refChipAction("msg:12", sessions)).toEqual({ kind: "copy", title: "msg:12" });
+    expect(refChipAction("ref:9", sessions)).toEqual({ kind: "copy", title: "ref:9" });
+    expect(refChipAction("/srv/app/src/x.ts", sessions)).toEqual({
+      kind: "copy",
+      title: "/srv/app/src/x.ts",
+    });
+  });
+
+  it("copies when no openable-session set is provided", () => {
+    expect(refChipAction("ses_1", undefined)).toEqual({ kind: "copy", title: "ses_1" });
+    expect(refChipAction("ses_1", new Set())).toEqual({ kind: "copy", title: "ses_1" });
+  });
+
+  it("never jumps on an empty ref", () => {
+    expect(refChipAction("", sessions).kind).toBe("copy");
+  });
+});
+
+// --- BET-1441: blackboard fact-ref chip decisions --------------------------
+
+import { refChipAction } from "./ctoView";
+
+describe("refChipAction", () => {
+  const sessions = new Set(["ses_1", "ses_2"]);
+  it("jumps when the ref is a known openable session", () => {
+    expect(refChipAction("ses_1", sessions)).toEqual({
+      kind: "jump",
+      title: "Open session ses_1",
+    });
+  });
+  it("copies bare provenance refs (no server-side resolver)", () => {
+    expect(refChipAction("msg:12", sessions)).toEqual({ kind: "copy", title: "msg:12" });
+    expect(refChipAction("ref:9", sessions)).toEqual({ kind: "copy", title: "ref:9" });
+    expect(refChipAction("/srv/x.ts", sessions)).toEqual({ kind: "copy", title: "/srv/x.ts" });
+  });
+  it("copies when no session set is provided", () => {
+    expect(refChipAction("ses_1").kind).toBe("copy");
+    expect(refChipAction("ses_1", new Set()).kind).toBe("copy");
+  });
+  it("never jumps on an empty ref", () => {
+    expect(refChipAction("", sessions).kind).toBe("copy");
+  });
+});

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -668,3 +668,23 @@ export async function executeSuggestionOption({
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
 }
+
+// ---------------------------------------------------------------------------
+// Blackboard fact-ref chips (BET-1441, §10.5 row 1 + §6.1)
+// ---------------------------------------------------------------------------
+// A fact's refs are bare provenance strings (§6.1): some are opencode session
+// ids (jumpable), the rest have no server-side resolver in the render model —
+// same precedent as the Profile view's top-3 evidence chips. Every chip still
+// responds: jump when the target session exists, copy-the-ref otherwise —
+// never a dead control.
+
+export type RefChipAction =
+  | { kind: "jump"; title: string }
+  | { kind: "copy"; title: string };
+
+export function refChipAction(ref: string, openableSessions?: Set<string>): RefChipAction {
+  if (ref && openableSessions?.has(ref)) {
+    return { kind: "jump", title: `Open session ${ref}` };
+  }
+  return { kind: "copy", title: ref };
+}


### PR DESCRIPTION
## BET-1441 — Blackboard drill-down: fact refs deep-link to evidence

**Base:** origin/main @ 60418590

### What this does

The session deep-link threading (the core BET-1441 dispatch — thread
`onOpenSession` + `openableSessions` into `BlackboardView`, ref chip → button)
already landed via dbda53de during the parent issue's (BET-1399) review cycle.
This PR completes the issue's remaining gap so every shipped chip honors the
parent's **no-dead-controls** ground rule:

- **Session refs** (in `openableSessions`): button → `onOpenSession(ref)` —
  jump to transcript (unchanged, reviewed path).
- **Bare-provenance refs** (`msg:12`, `ref:9`, file paths — §6.1 refs are bare
  strings with no server-side resolver in the render model): now buttons that
  copy the ref to the clipboard with a toast, the exact precedent of the
  Profile view's top-3 evidence chips (`CtoPanel.tsx` `copyRef`, documented
  there as the honest action absent a resolver). Was a dead `<span>`.
- Decision extracted into a pure helper `refChipAction(ref, openableSessions)`
  (`ctoView.ts`) + decision-table test in `ctoView.test.ts`.

Applies to all three FactRow render sites: active, superseded, archive.

### Honest finding: the digest's onOpen is telemetry-only

While implementing I verified the flow the issue points at: the digest's
`onOpen` → `handleItemOpen` fires `ctoDigestOpened`, which server-side is ONLY
a §14.1 verdict-ledger "open" record (`src/server/index.mjs:4575`) — it does
NOT jump to transcript. So the blackboard's session-jump path is actually
AHEAD of the digest. E2E smoke confirms the renderer mounts without crashing.

### Verification results
- PR branch (`multica/BET-1441-blackboard-ref-deeplink` @ `1067dfe9`):
  - typecheck: exit 0. Errors: none.
  - vitest: exit 0, 198 files, 3863 pass / 0 fail / 7 skip. Failures: none.
  - node:test: exit 0, 3658 pass / 0 fail / 0 skip. Failures: none.
  - e2e smoke (Playwright electron launcher): PASS — renderer mounts, 0 uncaught errors.
- Base (`main` @ 60418590): suite fully green (verified during BET-1399/BET-1404 review cycles); this PR adds one new test block only, no shared code touched.
- **Conclusion:** 0 new failures, 0 pre-existing. All gates green.