### PR TITLE
refactor(renderer): dedupe refChipAction describe blocks in ctoView.test.ts (BET-1448)

### DIFF
--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -17,6 +17,8 @@ import {
   stateTone,
   nowCostLabel,
   nowRailMeta,
+  digestEvidenceAction,
+  refChipAction,
   type CtoState,
   type CtoHealthStat,
 } from "./ctoView";
@@ -674,10 +676,6 @@ describe("refChipAction (BET-1441 — blackboard fact-ref chips)", () => {
   });
 });
 
-// --- BET-1441: blackboard fact-ref chip decisions --------------------------
-
-import { refChipAction, digestEvidenceAction } from "./ctoView";
-
 describe("digestEvidenceAction (BET-1447 — digest 'view evidence' chips)", () => {
   const sessions = new Set(["ses_1", "ses_2"]);
 
@@ -706,24 +704,3 @@ describe("digestEvidenceAction (BET-1447 — digest 'view evidence' chips)", () 
   });
 });
 
-describe("refChipAction", () => {
-  const sessions = new Set(["ses_1", "ses_2"]);
-  it("jumps when the ref is a known openable session", () => {
-    expect(refChipAction("ses_1", sessions)).toEqual({
-      kind: "jump",
-      title: "Open session ses_1",
-    });
-  });
-  it("copies bare provenance refs (no server-side resolver)", () => {
-    expect(refChipAction("msg:12", sessions)).toEqual({ kind: "copy", title: "msg:12" });
-    expect(refChipAction("ref:9", sessions)).toEqual({ kind: "copy", title: "ref:9" });
-    expect(refChipAction("/srv/x.ts", sessions)).toEqual({ kind: "copy", title: "/srv/x.ts" });
-  });
-  it("copies when no session set is provided", () => {
-    expect(refChipAction("ses_1").kind).toBe("copy");
-    expect(refChipAction("ses_1", new Set()).kind).toBe("copy");
-  });
-  it("never jumps on an empty ref", () => {
-    expect(refChipAction("", sessions).kind).toBe("copy");
-  });
-});


### PR DESCRIPTION
## Summary

Dedupes the two near-identical `describe("refChipAction…")` blocks in `src/renderer/ctoView.test.ts` (BET-1441 review nit, BET-1448).

- Kept the more complete block ("refChipAction (BET-1441 — blackboard fact-ref chips)") — it additionally covers `refChipAction("ses_1", undefined)` and a longer file path.
- Deleted the exact-duplicate block and the mid-file import; both `refChipAction` and (post-rebase) `digestEvidenceAction` now import at the top of the file.
- **Rebased onto origin/main @ `101f1b78`** (second delivery): absorbed BET-1447's `digestEvidenceAction` describe block unchanged (new coverage, kept in full) while removing the duplicate `refChipAction` block BET-1447's merge had carried alongside it. No behavior or coverage changes beyond removing the exact duplicate.

**Base:** origin/main @ 101f1b78

**Files changed:** 1 file, +2/−25 — `src/renderer/ctoView.test.ts`

**Verification results** (rebased branch @ `e1f9af54`):
- typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
- test: exit 0 — vitest 3864 pass / 0 fail / 7 skip (198 files); node:test 3660 pass / 0 fail. Failures: none. log sha256: `3e75e1f14911821da95ead676a51d8402b2c32eea9741578c8129cffe86c4070`
- **Conclusion:** 0 new failures, 0 pre-existing failures. Test-count delta vs base is exactly the 4 removed duplicate `it` blocks (base 3868 → branch 3864); verbose run confirms all 4 surviving `refChipAction` tests and all 5 of BET-1447's `digestEvidenceAction` tests pass.

Closes BET-1448.
