### PR TITLE
BET-1446: docs(agents): incremental-commit discipline + worktree-hijack recovery (BET-1445 mitigation)

### DIFF
--- a/.multica/agents/manta-dev.md
+++ b/.multica/agents/manta-dev.md
@@ -105,8 +105,37 @@ starts from zero. Therefore:
    a specific reason to look at CI, take ONE snapshot (`gh pr checks <n>`
    without `--watch`), say what it showed, and continue or hand off. Never loop.
 
-   Observed live 2026-08-01: BET-472 died twice this way, ~45 minutes of wall
-   clock, both times with the work already pushed and the PR already green.
+    Observed live 2026-08-01: BET-472 died twice this way, ~45 minutes of wall
+    clock, both times with the work already pushed and the PR already green.
+
+6. **Worktree hijack — a sibling checkout can hard-reset YOUR worktree mid-run
+   (BET-1445).** `multica repo checkout` keys its checkout directory by REPO,
+   not per run: a sibling session's checkout can resolve to the same worktree
+   you are actively editing and run `git fetch && git reset --hard origin/main
+   && git checkout -b …` inside it — discarding your uncommitted edits and
+   switching your branch out from under you. This killed the BET-1439 rerun
+   mid-implementation (~45 min lost). The mechanic that makes recovery
+   possible: checkouts are **git worktrees of the daemon's bare clone cache —
+   all worktrees share the object store**, so branch refs live in the shared
+   repo. **Committed work on your named branch survives a hijack; only
+   uncommitted work is lost.** Two defenses:
+
+   - **Commit incrementally — tighter than rule 2 above.** While implementing,
+     commit to your `multica/BET-<N>-…` task branch after every coherent unit,
+     and never leave more than a few minutes of work uncommitted. The unit of
+     safety is the COMMIT, not the run: a hijack between your commits costs
+     minutes, a hijack before one costs the whole implementation.
+   - **Hijack recovery — don't assume loss, recover the branch.** If your
+     worktree suddenly looks reset or switched (unexpected `origin/main` HEAD,
+     a foreign branch checked out, your in-progress edits gone):
+     1. `git branch --show-current` — see where you actually are.
+     2. Your task branch lives in the shared repo. Recover it IN PLACE with
+        `git checkout multica/BET-<N>-…`, or in a fresh worktree with
+        `git worktree add /tmp/recovery multica/BET-<N>-…` if the in-place
+        checkout is disturbed.
+     3. `git log --oneline -5` — verify your commits are all still there (they
+        will be, if you committed them). Only the uncommitted delta since your
+        last commit is gone; redo just that and continue.
 
 ## Coding Standards
 

--- a/.multica/agents/manta-pm.md
+++ b/.multica/agents/manta-pm.md
@@ -504,6 +504,16 @@ There are two distinct reviewer outcomes. Only one crosses the human boundary an
   gh pr merge --merge <N>                                # merge to main
   ```
 
+  **Shared-checkout hazard (BET-1445):** your `multica repo checkout` /
+  `gh pr checkout` worktree is keyed by repo, so it can collide with an ACTIVE
+  implementer run — your checkout's reset/switch can wipe an implementer's
+  uncommitted work, and a sibling checkout can do the same to yours mid-merge
+  (your typecheck/test result is committed-branch state, which survives;
+  only uncommitted scratch is lost). If the worktree suddenly looks reset or
+  switched mid-verification, recover with `git checkout <branch>` and re-run
+  the gate. Prefer the reviewer's reported verification before re-running the
+  full suite in a possibly-contended worktree.
+
 - **You DO:** confirm the reviewer PASS, ready the PR, verify typecheck+tests locally, confirm `mergeable_state ∈ {clean, unstable}`, then `gh pr merge --merge` and confirm it actually merged (`gh pr view <N> --json state` → `MERGED`).
 - **You do NOT:** merge a PR the reviewer hasn't routed forward to you (status not `in_review`, or still assigned to an implementer). No exceptions for "small", "urgent", or "obviously fine".
 - **Respect dependency order.** If issue B consumes a shape issue A introduces, get A merged + on `main` first, then hand over B. Don't batch interdependent PRs.

--- a/.multica/agents/manta-reviewer.md
+++ b/.multica/agents/manta-reviewer.md
@@ -58,6 +58,16 @@ Therefore, before any PASS:
    gh pr checkout <N>
    ```
 
+   **Shared-checkout hazard (BET-1445):** `multica repo checkout` keys the
+   checkout dir by repo, so your checkout can collide with an ACTIVE
+   implementer run — your checkout's reset/switch can wipe an implementer's
+   uncommitted work, and a sibling checkout can do the same to yours. Two
+   rules: run the checkout once at the START of your review and treat it as
+   read-only (never leave meaningful local state you'd miss); and if the
+   worktree suddenly looks reset/switched mid-review, recover the branch with
+   `git checkout <branch>` — a review reads committed branches, which survive
+   hijacks (only uncommitted scratch state is gone).
+
    Do not modify any files. The repo is for static analysis + build only.
 
    **Base-freshness gate (TEN-134 antibody).** Before ANY substantive review, confirm the PR is branched off current `origin/main`. A stale base makes the diff *appear* to delete files that were merged upstream after the branch was cut, producing phantom "this PR deletes `<file>`" Blocks that no implementer fix can resolve.

--- a/.multica/skills/manta-pr-workflow/SKILL.md
+++ b/.multica/skills/manta-pr-workflow/SKILL.md
@@ -40,6 +40,22 @@ The standard implementer workflow for the MANTA agents.
 
 5. Implement. Add or update tests under `tests/` or `__tests__/`.
 
+5b. **Commit incrementally while you implement (BET-1445 — worktree-hijack
+    insurance).** A sibling session's `multica repo checkout` can resolve to
+    YOUR worktree mid-run and hard-reset it (`git reset --hard origin/main` +
+    branch switch), destroying uncommitted edits (killed the BET-1439 rerun,
+    ~45 min). Checkouts are git worktrees of a shared bare clone, so
+    **committed work on your task branch survives a hijack — only the
+    uncommitted delta is lost.** So: commit to your task branch after every
+    coherent unit and never leave more than a few minutes of work uncommitted
+    (then push per step 8). And if your worktree suddenly looks reset/switched
+    (unexpected origin/main HEAD, foreign branch, edits gone): run
+    `git branch --show-current`, then recover — `git checkout
+    multica/BET-N-<slug>` in place (or `git worktree add <dir>
+    multica/BET-N-<slug>` if checkout is disturbed) — verify with `git log`
+    that your commits are intact, redo only the lost delta, and CONTINUE. Do
+    not assume the work is lost and restart from zero.
+
 6. Run `npm run typecheck && npm test`. Both must pass.
 
 7. Commit with `feat(scope): …` / `fix(scope): …` / `refactor(scope): …`


### PR DESCRIPTION
Agent-instruction change only, per BET-1446 — no product code touched.

## What

Adds the two disciplines from the issue to the agent instructions under `.multica/`:

1. **Incremental-commit discipline** — commit to the task branch after every coherent unit; never leave more than a few minutes of work uncommitted. Rationale: a sibling session's `multica repo checkout` can hard-reset the shared worktree mid-run (BET-1445); committed work on a named branch survives a hijack, uncommitted work does not.
2. **Hijack recovery path** — if the worktree suddenly looks reset/switched: `git branch --show-current`, then recover the branch in place (`git checkout <branch>`) or in a fresh worktree (`git worktree add`), verify with `git log`, and continue. Only the uncommitted delta is gone.

Mirrored for the other agents' runs:
- `.multica/agents/manta-dev.md` — new item 6 under "Work durability" (mechanic + both defenses).
- `.multica/skills/manta-pr-workflow/SKILL.md` — step 5b (loads at implement time).
- `.multica/agents/manta-reviewer.md` — shared-checkout hazard note at the checkout step (reviewer runs collide with active implementer runs; reviews read committed branches, which survive).
- `.multica/agents/manta-pm.md` — same note at the merge-verification step.

## Verification results

- PR branch (`multica/BET-1446-incremental-commit-discipline` @ `0d8115a6`, rebased onto current `main`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce`
  - test: exit 0, 3660 pass / 0 fail / 0 skip. Failures: none. log sha256: `54868417e77ee95a`
- Base (`main` @ `25d5b3cd`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce`
  - test: exit 0, 3660 pass / 0 fail / 0 skip. Failures: none. log sha256: `f4ac2bfb4e58d86d`
- **Conclusion:** 0 new failures, 0 pre-existing. Docs-only diff (4 files under `.multica/`), both suites identical to base.

Base: origin/main @ 25d5b3cd

Follow-ups: none filed — nothing actionable surfaced beyond the issue scope.
