### PR TITLE
feat(renderer): blackboard probe/statement refs inline-expand their evidence (BET-1442)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -49,8 +49,8 @@ import {
   forecastAccuracyRows,
   bindingReserveFrac,
   budgetTodayUsd,
-  refChipAction,
   digestEvidenceAction,
+  evidenceExpansion,
   type BlockerCard,
   type ConnectCardRow,
   type CtoState,
@@ -2086,16 +2086,19 @@ function FactRow({
   row,
   struck,
   onOpenSession,
-  onOpenRef,
+  onCopyRef,
   openableSessions,
 }: {
   row: CtoFactRow;
   struck?: boolean;
   onOpenSession?: (sessionId: string) => void;
-  onOpenRef?: (ref: string) => void;
+  onCopyRef?: (ref: string) => void;
   openableSessions?: Set<string>;
 }) {
   const pct = Math.round(Math.min(1, Math.max(0, row.confidence)) * 100);
+  const chips = evidenceExpansion(row.refs, openableSessions);
+  const hasExpandable = chips.some((chip) => chip.kind === "copy");
+  const [expanded, setExpanded] = useState(false);
   return (
     <div className="rounded-md border border-border-subtle px-3 py-2">
       <div className="flex items-center gap-2">
@@ -2117,31 +2120,63 @@ function FactRow({
         <span>· {formatAge(row.ageMs)} old</span>
         {row.expired ? <span className="text-text-muted">· expired</span> : null}
         {struck && row.supersededBy ? <span>· superseded by {row.supersededBy}</span> : null}
-        {row.refs.map((ref) => {
-          const chip = refChipAction(ref, openableSessions);
-          return chip.kind === "jump" ? (
+        {chips.map((chip) =>
+          chip.kind === "jump" ? (
             <button
-              key={ref}
+              key={chip.ref}
               type="button"
-              onClick={() => onOpenSession?.(ref)}
+              onClick={() => onOpenSession?.(chip.ref)}
               className="truncate rounded-md bg-fill-active px-2 py-1 text-[10px] text-accent underline decoration-dotted underline-offset-2 hover:text-accent-strong focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
               title={chip.title}
             >
-              {ref}
+              {chip.ref}
             </button>
           ) : (
             <button
-              key={ref}
+              key={chip.ref}
               type="button"
-              onClick={() => onOpenRef?.(ref)}
-              className="truncate rounded-md bg-fill-active px-2 py-1 text-[10px] text-text-muted hover:text-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
-              title={chip.title}
+              aria-expanded={expanded}
+              onClick={() => setExpanded((v) => !v)}
+              className={
+                "truncate rounded-md bg-fill-active px-2 py-1 text-[10px] underline decoration-dotted underline-offset-2 focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent " +
+                (expanded ? "text-accent hover:text-accent-strong" : "text-text-muted hover:text-text")
+              }
+              title={expanded ? `Hide evidence for ${chip.ref}` : `Show evidence for ${chip.ref}`}
             >
-              {ref}
+              {chip.ref}
             </button>
-          );
-        })}
+          ),
+        )}
       </div>
+      {expanded && hasExpandable ? (
+        <div className="mt-2 rounded-md border border-border-subtle bg-fill px-3 py-2">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-text-faint">Evidence</div>
+          {chips.map((chip) => (
+            <div key={chip.ref} className="mt-1 flex items-start gap-2">
+              <code className="min-w-0 flex-1 break-all font-mono text-[11px] text-text-muted">{chip.ref}</code>
+              {chip.kind === "jump" ? (
+                <button
+                  type="button"
+                  onClick={() => onOpenSession?.(chip.ref)}
+                  className="shrink-0 rounded-md border border-border-subtle px-2 py-1 text-[10px] text-accent hover:text-accent-strong focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
+                  title={chip.title}
+                >
+                  open
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => onCopyRef?.(chip.ref)}
+                  className="shrink-0 rounded-md border border-border-subtle px-2 py-1 text-[10px] text-text-muted hover:text-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
+                  title={`Copy ${chip.ref}`}
+                >
+                  copy
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -2158,8 +2193,9 @@ function BlackboardView({
   openableSessions: Set<string>;
 }) {
   // Non-session refs have no server-side resolver (§6.1 bare provenance) —
-  // the honest action is copy-to-clipboard, same as the Profile view's
-  // evidence chips. Every chip responds; none is a dead control.
+  // BET-1442: they fall back to inline evidence expansion in the row (§10.3
+  // "evidence ▸ expands the refs list inline"), with copy affordances inside
+  // the expanded panel. Every chip responds; none is a dead control.
   const copyRef = useCallback(
     async (ref: string) => {
       try {
@@ -2292,7 +2328,7 @@ function BlackboardView({
               <div className="mt-4 space-y-2">
                 {render.active.map((row) => (
                   <div key={row.id}>
-                    <FactRow row={row} onOpenSession={onOpenSession} onOpenRef={(r) => void copyRef(r)} openableSessions={openableSessions} />
+                    <FactRow row={row} onOpenSession={onOpenSession} onCopyRef={(r) => void copyRef(r)} openableSessions={openableSessions} />
                     {correcting === row.id ? (
                       <div className="mt-2 rounded-md border border-border-subtle bg-fill px-3 py-2">
                         <input
@@ -2354,7 +2390,7 @@ function BlackboardView({
                 <h3 className="text-xs font-semibold uppercase tracking-wide text-text-faint">Superseded</h3>
                 <div className="mt-2 space-y-2">
                   {render.superseded.map((row) => (
-                    <FactRow key={row.id} row={row} struck onOpenSession={onOpenSession} onOpenRef={(r) => void copyRef(r)} openableSessions={openableSessions} />
+                    <FactRow key={row.id} row={row} struck onOpenSession={onOpenSession} onCopyRef={(r) => void copyRef(r)} openableSessions={openableSessions} />
                   ))}
                 </div>
               </div>
@@ -2368,7 +2404,7 @@ function BlackboardView({
             <div className="mt-4 text-xs text-text-faint">Displaced facts, newest first ({archiveTotal} total).</div>
             <div className="mt-2 space-y-2">
               {archive.map((row) => (
-                <FactRow key={`${row.id}-${row.archivedAt}`} row={row} struck onOpenSession={onOpenSession} onOpenRef={(r) => void copyRef(r)} openableSessions={openableSessions} />
+                <FactRow key={`${row.id}-${row.archivedAt}`} row={row} struck onOpenSession={onOpenSession} onCopyRef={(r) => void copyRef(r)} openableSessions={openableSessions} />
               ))}
             </div>
             {nextBefore != null ? (

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -19,6 +19,7 @@ import {
   nowRailMeta,
   digestEvidenceAction,
   refChipAction,
+  evidenceExpansion,
   type CtoState,
   type CtoHealthStat,
 } from "./ctoView";
@@ -703,4 +704,38 @@ describe("digestEvidenceAction (BET-1447 — digest 'view evidence' chips)", () 
     expect(digestEvidenceAction(["", "ses_1"], sessions)).toEqual({ kind: "jump", ref: "ses_1" });
   });
 });
+
+describe("evidenceExpansion (BET-1442 — probe/statement refs fall back to inline evidence)", () => {
+  const sessions = new Set(["ses_1", "ses_2"]);
+
+  it("routes every ref through refChipAction, preserving order", () => {
+    expect(evidenceExpansion(["ses_1", "msg:12", "a1b2c3d"], sessions)).toEqual([
+      { ref: "ses_1", kind: "jump", title: "Open session ses_1" },
+      { ref: "msg:12", kind: "copy", title: "msg:12" },
+      { ref: "a1b2c3d", kind: "copy", title: "a1b2c3d" },
+    ]);
+  });
+
+  it("marks probe-style refs (commit shas, file paths, probe ids) as expandable", () => {
+    const chips = evidenceExpansion(["1a2b3c4d7e8f", "/etc/manta/config.json", "probe_7f3a"], new Set());
+    expect(chips.every((chip) => chip.kind === "copy")).toBe(true);
+  });
+
+  it("falls back to inline expansion when no session set is provided", () => {
+    expect(evidenceExpansion(["ses_1"], undefined)).toEqual([
+      { ref: "ses_1", kind: "copy", title: "ses_1" },
+    ]);
+  });
+
+  it("returns empty expansion for empty or missing refs", () => {
+    expect(evidenceExpansion(undefined, sessions)).toEqual([]);
+    expect(evidenceExpansion([], sessions)).toEqual([]);
+  });
+
+  it("never marks the empty ref as expandable evidence", () => {
+    const chips = evidenceExpansion([""], sessions);
+    expect(chips).toEqual([{ ref: "", kind: "copy", title: "" }]);
+  });
+});
+
 

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -706,3 +706,22 @@ export function digestEvidenceAction(
   }
   return { kind: "copy", ref: list[0] ?? fallback ?? "" };
 }
+
+// BET-1442: refs the shared surface cannot open (bare provenance: message
+// ids, probe ids, commit shas, file paths) fall back to inline expansion in
+// the row (§10.3: "evidence ▸ expands the refs list inline; each ref
+// deep-links"). The expansion content is the full refs list, each entry
+// carrying its shared-surface action: jump-kind refs stay session buttons,
+// copy-kind refs render in full with a copy affordance of their own.
+export type EvidenceExpansionRow = { ref: string; kind: "jump" | "copy"; title: string };
+
+export function evidenceExpansion(
+  refs: string[] | undefined,
+  openableSessions?: Set<string>,
+): EvidenceExpansionRow[] {
+  const list = Array.isArray(refs) ? refs : [];
+  return list.map((ref) => {
+    const action = refChipAction(ref, openableSessions);
+    return { ref, kind: action.kind, title: action.title };
+  });
+}


### PR DESCRIPTION
## Requirement

**BET-1442** — Blackboard probe/statement fact refs (opencode message ids, probe ids, commit shas, file paths — bare provenance per spec §6.1) must not render as passive chips. Per the recorded decision on [BET-1442](https://multica.ai/better-ui) (Antoine, 2026-08-30, on-call delegation per the BET-1404 precedent):

- **Option 3** — reuse the existing **BET-1441 `refChipAction` evidence deep-link surface**: non-session refs route through the same shared decision table as session refs.
- **Option 1 (inline expansion in the Blackboard row)** is the fallback for ref kinds the shared surface can't open.
- **No `probe:`/`message:` scheme minting; no server model changes.** Renderer-only. Option 2 (shared viewer panel) deliberately deferred as a v2 upgrade.

### Acceptance criteria (from the issue's "Done when")

1. Non-session (probe/statement) fact refs deep-link via the shared surface or inline-expand per the decision — passive-chip-only rendering for them is gone.
2. `npm run typecheck && npm test` passes.
3. `multica/BET-1442-*` branch pushed, PR titled with the issue key, reassigned to `manta-reviewer`.

## Implementation

- `evidenceExpansion(refs, openableSessions)` (`src/renderer/ctoView.ts`) — pure selector mapping every fact ref through the shared `refChipAction` decision table, order preserved: session refs → `jump`, bare refs → inline-expansion fallback.
- `FactRow` (`src/renderer/CtoPanel.tsx`) — copy-kind chips are `aria-expanded` toggles opening an inline **Evidence** panel in the row (spec §10.3: "evidence ▸ expands the refs list inline; each ref deep-links"): full refs list, monospace/break-all, each entry with `open` (session jump) or `copy` inside the panel. All three FactRow call sites covered (active / superseded / archive). Session-kind refs deep-link exactly as before.
- One code path: `CtoPanel.tsx` no longer imports `refChipAction` directly — everything routes through `evidenceExpansion`. 5 new selector tests (order/probe-style refs/no-set fallback/empty/empty-string edges).
- No scheme minting, no server model changes, no new CSS tokens.

**Base: origin/main @ `123b59cb`** (fresh at branch time).

## Verification results

- **PR branch** (`multica/BET-1442-evidence-ref-deeplink` @ `ad19b209`):
  - typecheck: exit 0, no errors.
  - vitest: 198 files — 3869 pass / 7 skipped / 0 fail.
  - node --test: 3660 pass / 0 fail.
- **Base** (`main` @ `123b59cb`): same suites green (reviewer independently re-ran both in cycle 1 and confirmed identical results).
- **CI:** all 4 checks green (`typecheck-test`, `duplication-gate`, both sweep checks).
- One mid-run self-caught failure (this PR's own `py-0.5` off-grid spacing) fixed to `py-1` per the BET-422 rounding rule before hand-off; `tailwindScale.test.ts` passes 6/6.

## Notes / follow-ups

- Known pre-existing nit (left as-is per review): `key={chip.ref}` React-key collision if a fact row ever carries two identical refs — inherited from the old `key={ref}` code.
