### PR TITLE
feat(server): durable chat-window topology snapshot (BET-1452 S1)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -294,20 +294,17 @@ const BUS_PUBLISH_DEPS = { publish: (evt) => bus.publish(evt) };
 // missed. `refreshNow()` is driven by the poller below; `tmux:list` lazily
 // guarantees a first tick before serving anything.
 // BET-1452: durable chat-window topology snapshot (~/.manta/topology.json) —
-// hydrated by a later stage across box-server restarts. Wrapping the
-// `listProjects` DEP (not the poller) means every refresh path — the startup
-// lazy tick, the 2s poller, the rename-session re-materialize — snapshots the
-// exact same tree syncState applies, including a tmux fault aborting before
-// any persist (the dep throws first). A persist failure is swallowed so it
-// can never flip refreshNow into stale=true.
-const persistTopology = createTopologyPersister({});
+// hydrated by a later stage across box-server restarts. The persister is an
+// OPTIONAL dep of createSyncState, so refreshNow's success branch is the
+// single choke point (no new timer, no second tmux code path): every refresh
+// path — the startup lazy tick, the 2s poller, the rename-session
+// re-materialize — snapshots the exact tree it just applied. Persist
+// failures are warned + swallowed inside syncState and can never flip a good
+// refresh to stale; a failed listing never reaches the persister at all.
 const syncState = createSyncState({
-  listProjects: async () => {
-    const projects = await tmux.listProjects();
-    await persistTopology(projects).catch(() => {});
-    return projects;
-  },
+  listProjects: () => tmux.listProjects(),
   publish: (env) => bus.publish(env),
+  persistTopology: createTopologyPersister(),
 });
 // Seed the config baseline at startup so the first snapshot already carries it.
 syncState.applyConfig(await local.configGet());

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -74,6 +74,7 @@ import { attachCallWs, createCallRegistry } from "./callWs.mjs";
 import { buildHandlers, handleRpcRequest } from "./rpc.mjs";
 import { startStatusPoller } from "./status.mjs";
 import { createSyncState } from "./syncState.mjs";
+import { createTopologyPersister } from "./topology.mjs";
 import { createStreamInterpreter } from "./streamInterp.mjs";
 import { enrichProviderError } from "../shared/streamInterpretation.mjs";
 import { providerStateLabel } from "../shared/providerHealthLabel.mjs";
@@ -292,8 +293,20 @@ const BUS_PUBLISH_DEPS = { publish: (evt) => bus.publish(evt) };
 // published on the bus as state changes so clients can recover just what they
 // missed. `refreshNow()` is driven by the poller below; `tmux:list` lazily
 // guarantees a first tick before serving anything.
+// BET-1452: durable chat-window topology snapshot (~/.manta/topology.json) —
+// hydrated by a later stage across box-server restarts. Wrapping the
+// `listProjects` DEP (not the poller) means every refresh path — the startup
+// lazy tick, the 2s poller, the rename-session re-materialize — snapshots the
+// exact same tree syncState applies, including a tmux fault aborting before
+// any persist (the dep throws first). A persist failure is swallowed so it
+// can never flip refreshNow into stale=true.
+const persistTopology = createTopologyPersister({});
 const syncState = createSyncState({
-  listProjects: () => tmux.listProjects(),
+  listProjects: async () => {
+    const projects = await tmux.listProjects();
+    await persistTopology(projects).catch(() => {});
+    return projects;
+  },
   publish: (env) => bus.publish(env),
 });
 // Seed the config baseline at startup so the first snapshot already carries it.

--- a/src/server/syncState.mjs
+++ b/src/server/syncState.mjs
@@ -34,8 +34,9 @@ function defaultGenId() {
  * @param {() => Promise<Array>} deps.listProjects   one tmux listing tick
  * @param {(env: object) => void} deps.publish        pushes `{kind:"sync", payload:{gen,seq,changed}}` envelopes on the bus
  * @param {() => string} [deps.genId]                 injectable gen generator (default: crypto)
+ * @param {(projects: Array) => Promise} [deps.persistTopology]  optional BET-1452 hook — persists the chat-window topology snapshot. Called ONLY on a successful listing; a persist failure must never turn a good refresh into stale.
  */
-export function createSyncState({ listProjects, publish, genId = defaultGenId }) {
+export function createSyncState({ listProjects, publish, genId = defaultGenId, persistTopology = null }) {
   const gen = genId();
   let seq = 1;
   let projects = [];
@@ -67,6 +68,18 @@ export function createSyncState({ listProjects, publish, genId = defaultGenId })
         if (stale) {
           stale = false;
           bump("stale", false);
+        }
+        // BET-1452: persist the chat-window topology snapshot. Runs in the
+        // SUCCESS branch — a failed listing never reaches the snapshot — and
+        // its own try/catch swallows persist errors: the in-memory list is
+        // still correct, we only lost a restore point, so a good refresh must
+        // never be flipped to `stale` by a snapshot failure.
+        if (persistTopology) {
+          try {
+            await persistTopology(p);
+          } catch (e) {
+            console.warn("[topology] snapshot failed — restore point not updated:", e?.message ?? e);
+          }
         }
       } catch {
         // A fault is recorded as stale but NEVER clobbers the last-known-good

--- a/src/server/syncState.test.mjs
+++ b/src/server/syncState.test.mjs
@@ -167,3 +167,42 @@ test("publish envelope shape is pinned {kind, payload:{gen, seq, changed}}", asy
   assert.ok("projects" in env.payload.changed);
   assert.equal(env.payload.seq, state.snapshot().seq);
 });
+
+// BET-1452: the topology snapshot must only ever be fed a SUCCESSFUL listing.
+test("a listing that THROWS must not call persistTopology", async () => {
+  const persisted = [];
+  let failList = false;
+  const state = createSyncState({
+    listProjects: async () => {
+      if (failList) throw new Error("tmux fault");
+      return P1;
+    },
+    publish: () => {},
+    persistTopology: async (projects) => {
+      persisted.push(projects);
+    },
+  });
+  failList = true;
+  await state.refreshNow(); // failure: stale path, persister untouched
+  assert.equal(persisted.length, 0);
+  assert.equal(state.snapshot().stale, true);
+
+  failList = false;
+  await state.refreshNow(); // success: persister gets the applied tree
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0], P1);
+});
+
+test("a persistTopology failure never turns a good refresh into stale", async () => {
+  const state = createSyncState({
+    listProjects: async () => P1,
+    publish: () => {},
+    persistTopology: async () => {
+      throw new Error("disk full");
+    },
+  });
+  await state.refreshNow();
+  const snap = state.snapshot();
+  assert.equal(snap.stale, false); // in-memory list is still correct
+  assert.equal(snap.projects, P1); // we only lost a restore point
+});

--- a/src/server/topology.mjs
+++ b/src/server/topology.mjs
@@ -1,0 +1,182 @@
+// topology.mjs — BET-1452 Stage 1 (server-side): the durable chat-window
+// topology snapshot at `~/.manta/topology.json`.
+//
+// WHY IT EXISTS. Stage 2 (agent-relaunch preview) needs the list of a box's
+// chat windows — index, tmux window name, opencode session id, cwd — BEFORE
+// the user reconnects, i.e. when nothing can be asked of the live box state
+// the renderer already has. Today that list only exists inside the in-memory
+// syncState (src/server/syncState.mjs), which evaporates on every box-server
+// restart. This module persists the same tree, CHAT WINDOWS ONLY, to disk so
+// a later stage can hydrate from it.
+//
+// Data source: the exact `listProjects()` tree (src/server/tmux.mjs) that
+// syncState already consumes — windows carry `opencodeSessionId` iff the
+// window is a chat-mode window holding an opencode session, so "has an
+// opencodeSessionId" is THE chat-window discriminator. Non-chat windows are
+// dropped, projects left with zero windows are dropped.
+//
+// Safety contract (why the persister is so cautious about empty writes):
+// the snapshot must NEVER regress to "zero chat windows" while one still
+// exists. Two failure modes are guarded:
+//   1. `shouldPersist` — a zero-window snapshot never overwrites a non-empty
+//      file ("would-clobber"), only an already-empty one.
+//   2. byte-identical skip — the 2s poller runs this on every tick; the write
+//      happens once per actual topology change, not 43,200 times a day.
+//
+// Pure + injected-I/O, mirroring src/server/syncState.mjs. The only
+// functions that touch disk by default are loadTopology / saveTopology,
+// both of which accept an `io` override for tests — the suite never writes
+// production data (see the MANTA_STATE_HOME note in src/shared/paths.mjs).
+
+import { readFile } from "node:fs/promises";
+import { atomicWrite } from "./storeUtils.mjs";
+import { statePath } from "../shared/paths.mjs";
+
+// Where the snapshot lives. Routed through statePath so the test sandbox
+// (MANTA_STATE_HOME) applies, like every other state file on the box.
+export const TOPOLOGY_PATH = statePath("topology.json");
+
+// Bump when the snapshot shape changes incompatibly; loadTopology rejects
+// anything else so a Stage-2 reader can trust the shape it sees.
+export const TOPOLOGY_VERSION = 1;
+
+// Default I/O: real fs read + the shared atomic-write primitive (temp file +
+// rename, parent-dir creating — see src/server/jsonStore.mjs).
+const defaultIo = {
+  readFile: (path) => readFile(path, "utf-8"),
+  writeFile: (path, data) => atomicWrite(path, data),
+};
+
+// Build a snapshot from a `listProjects()` tree. `now` (epoch ms) is stamped
+// as `capturedAt`. Pure — never touches disk.
+//
+// Per-window mapping rules:
+//   - keep only windows with a truthy string `opencodeSessionId` (chat)
+//   - `name` ← the LIVE tmux window name (rename drift, BET-1364, flows in)
+//   - `cwd` ← the window's `paneCurrentPath`, falling back to the project
+//     `defaultCwd` (first window's cwd — which for a chat-first window is
+//     the same value; the fallback only matters for malformed input)
+//   - `worktreePath` ← as observed, or null. NEVER invented here.
+//   - `mantaOwned` / `active` normalized to real booleans.
+// Projects with no surviving windows are dropped entirely.
+export function snapshotFrom(projects, now = Date.now()) {
+  const sessions = [];
+  for (const p of projects ?? []) {
+    const windows = [];
+    for (const w of p?.windows ?? []) {
+      if (typeof w?.opencodeSessionId !== "string" || w.opencodeSessionId === "") continue;
+      windows.push({
+        index: w.index,
+        name: w.name,
+        opencodeSessionId: w.opencodeSessionId,
+        cwd: w.paneCurrentPath || p.defaultCwd,
+        worktreePath: w.worktreePath ?? null,
+        active: w.active === true,
+      });
+    }
+    if (windows.length === 0) continue;
+    sessions.push({
+      tmuxSession: p.tmuxSession,
+      defaultCwd: p.defaultCwd,
+      mantaOwned: p.mantaOwned === true,
+      windows,
+    });
+  }
+  return { version: TOPOLOGY_VERSION, capturedAt: now, sessions };
+}
+
+// Total chat-window count across a snapshot. Tolerates null / malformed
+// input (→ 0) because callers compare raw loaded values against fresh ones.
+export function countWindows(snapshot) {
+  if (!snapshot || !Array.isArray(snapshot.sessions)) return 0;
+  return snapshot.sessions.reduce(
+    (n, s) => n + (Array.isArray(s?.windows) ? s.windows.length : 0),
+    0,
+  );
+}
+
+// Write gate. True when the incoming snapshot has at least one window.
+// Otherwise true ONLY when the previous snapshot had zero windows as well —
+// so an empty box can converge to an empty file exactly once, but a
+// transient empty observation can never clobber a non-empty snapshot.
+// `prev === null` (no file / unparsable) counts as zero windows.
+export function shouldPersist(prev, next) {
+  if (countWindows(next) > 0) return true;
+  return countWindows(prev) === 0;
+}
+
+// Read + validate the snapshot at `path`. Returns null on: missing file,
+// unreadable file, invalid JSON, wrong `version`, or non-array `sessions`.
+// Never throws. The injected `io` returns/throws like fs.readFile(path, "utf-8").
+export async function loadTopology(path = TOPOLOGY_PATH, io = defaultIo) {
+  let raw;
+  try {
+    raw = await io.readFile(path);
+  } catch {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || parsed.version !== TOPOLOGY_VERSION) return null;
+  if (!Array.isArray(parsed.sessions)) return null;
+  return parsed;
+}
+
+// Serialize + write the snapshot atomically. Pretty-printed so manual
+// inspection and diffs of the file stay readable. Propagates write errors —
+// callers decide whether persistence failure is fatal (the poller wrapper
+// in src/server/index.mjs swallows it so the sync path is never poisoned).
+export async function saveTopology(snapshot, path = TOPOLOGY_PATH, io = defaultIo) {
+  await io.writeFile(path, JSON.stringify(snapshot, null, 2));
+}
+
+// The per-refresh entry point wired into the server's tmux poller. Takes the
+// freshly fetched `listProjects()` tree, hydrates the previous snapshot from
+// disk ONCE on the first call (lazily — never at import), then:
+//   1. would-clobber guard (shouldPersist) → {persisted:false, reason}
+//   2. byte-identical skip — the freshly captured snapshot vs the last write
+//   3. otherwise persist
+// Returns {persisted, reason}: "would-clobber" / "unchanged" / "written".
+//
+// The churn comparison deliberately covers the `sessions` payload ONLY,
+// excluding `capturedAt`: the poller ticks every 2s with a moving clock, so a
+// whole-snapshot compare would rewrite the file forever. On disk,
+// `capturedAt` therefore means "when the topology last actually changed" —
+// strictly more useful to a Stage-2 staleness check.
+//
+// `save`/`load`/`now` are the test seams (resolve to the default io + clock).
+export function createTopologyPersister({ save, load, now } = {}) {
+  const io = {
+    readFile: load ?? defaultIo.readFile,
+    writeFile: save ?? defaultIo.writeFile,
+  };
+  const stamp = now ?? (() => Date.now());
+  let hydrated = false;
+  let prev = null;
+  let lastSessionsJson = null;
+
+  return async function persistTopology(projects) {
+    if (!hydrated) {
+      hydrated = true;
+      prev = await loadTopology(TOPOLOGY_PATH, io).catch(() => null);
+      lastSessionsJson = prev ? JSON.stringify(prev.sessions, null, 2) : null;
+    }
+    const snapshot = snapshotFrom(projects, stamp());
+    if (!shouldPersist(prev, snapshot)) {
+      return { persisted: false, reason: "would-clobber" };
+    }
+    const nextSessionsJson = JSON.stringify(snapshot.sessions, null, 2);
+    if (nextSessionsJson === lastSessionsJson) {
+      prev = snapshot;
+      return { persisted: false, reason: "unchanged" };
+    }
+    await saveTopology(snapshot, TOPOLOGY_PATH, io);
+    prev = snapshot;
+    lastSessionsJson = nextSessionsJson;
+    return { persisted: true, reason: "written" };
+  };
+}

--- a/src/server/topology.mjs
+++ b/src/server/topology.mjs
@@ -128,15 +128,17 @@ export async function loadTopology(path = TOPOLOGY_PATH, io = defaultIo) {
 
 // Serialize + write the snapshot atomically. Pretty-printed so manual
 // inspection and diffs of the file stay readable. Propagates write errors —
-// callers decide whether persistence failure is fatal (the poller wrapper
-// in src/server/index.mjs swallows it so the sync path is never poisoned).
+// callers decide whether persistence failure is fatal (the refreshNow hook
+// in src/server/syncState.mjs warns + swallows so the sync path is never
+// poisoned).
 export async function saveTopology(snapshot, path = TOPOLOGY_PATH, io = defaultIo) {
   await io.writeFile(path, JSON.stringify(snapshot, null, 2));
 }
 
-// The per-refresh entry point wired into the server's tmux poller. Takes the
-// freshly fetched `listProjects()` tree, hydrates the previous snapshot from
-// disk ONCE on the first call (lazily — never at import), then:
+// The per-refresh entry point wired into syncState.refreshNow's success
+// branch (src/server/syncState.mjs — the single choke point, no new timer).
+// Takes the freshly fetched `listProjects()` tree, hydrates the previous
+// snapshot from disk ONCE on the first call (lazily — never at import), then:
 //   1. would-clobber guard (shouldPersist) → {persisted:false, reason}
 //   2. byte-identical skip — the freshly captured snapshot vs the last write
 //   3. otherwise persist

--- a/src/server/topology.test.mjs
+++ b/src/server/topology.test.mjs
@@ -10,8 +10,9 @@ import {
   createTopologyPersister,
 } from "./topology.mjs";
 
-// listProjects()-shaped fixture (src/server/tmux.mjs): one chat project, one
-// project with only terminal windows, one empty project.
+// listProjects()-shaped fixture (src/server/tmux.mjs): one chat project with
+// a TUI window + two chat windows (one worktree-backed), one TUI-only
+// project, one empty project.
 const P1 = [
   {
     tmuxSession: "alpha",
@@ -41,7 +42,7 @@ const P1 = [
         index: 2,
         name: "chat2",
         active: false,
-        paneCurrentPath: "",
+        paneCurrentPath: "/home/dev/alpha/.worktrees/fix",
         opencodeSessionId: "oc-2",
         worktreePath: "/home/dev/alpha/.worktrees/fix",
         owner: "user",
@@ -68,41 +69,76 @@ const P1 = [
   { tmuxSession: "empty", defaultCwd: "/home/dev/empty", mantaOwned: false, attached: false, windows: [] },
 ];
 
-test("snapshotFrom keeps only chat windows and drops empty projects", () => {
+// --- Required case 1: chat windows only; TUI window (null id) is dropped ---
+test("snapshotFrom records chat windows only — a TUI window (null opencodeSessionId) is dropped", () => {
   const snap = snapshotFrom(P1, 1234);
   assert.equal(snap.version, TOPOLOGY_VERSION);
   assert.equal(snap.capturedAt, 1234);
+  const alpha = snap.sessions.find((s) => s.tmuxSession === "alpha");
+  assert.ok(alpha, "chat project present");
+  assert.deepEqual(
+    alpha.windows.map((w) => w.opencodeSessionId),
+    ["oc-1", "oc-2"],
+  );
+  assert.ok(!alpha.windows.some((w) => w.name === "editor"), "TUI window dropped");
+});
+
+// --- Required case 2: a project left with no chat windows is dropped ---
+test("snapshotFrom drops a project left with no chat windows entirely", () => {
+  const snap = snapshotFrom(P1);
   assert.deepEqual(
     snap.sessions.map((s) => s.tmuxSession),
     ["alpha"],
   );
-  const s = snap.sessions[0];
-  assert.equal(s.defaultCwd, "/home/dev/alpha");
-  assert.equal(s.mantaOwned, true);
-  assert.deepEqual(
-    s.windows.map((w) => w.opencodeSessionId),
-    ["oc-1", "oc-2"],
-  );
+  assert.ok(!snap.sessions.some((s) => s.tmuxSession === "term-only"));
+  assert.ok(!snap.sessions.some((s) => s.tmuxSession === "empty"));
 });
 
-test("snapshotFrom maps per-window fields per the BET-1452 contract", () => {
+// --- Required case 3: index/name/cwd/worktreePath preserved verbatim ---
+test("snapshotFrom preserves index, name and worktreePath verbatim from the tmux listing", () => {
   const snap = snapshotFrom(P1);
-  const [w1, w2] = snap.sessions[0].windows;
-  // name ← live tmux window name; cwd ← paneCurrentPath, defaultCwd fallback
-  assert.deepEqual(w1, {
-    index: 1,
-    name: "chat",
-    opencodeSessionId: "oc-1",
-    cwd: "/home/dev/alpha",
-    worktreePath: null,
-    active: true,
+  const w2 = snap.sessions[0].windows[1];
+  assert.deepEqual(w2, {
+    index: 2,
+    name: "chat2",
+    opencodeSessionId: "oc-2",
+    cwd: "/home/dev/alpha/.worktrees/fix",
+    worktreePath: "/home/dev/alpha/.worktrees/fix",
+    active: false,
   });
-  // empty paneCurrentPath falls back to the project defaultCwd; observed
-  // worktreePath passes through untouched, never invented
-  assert.equal(w2.name, "chat2");
-  assert.equal(w2.cwd, "/home/dev/alpha");
-  assert.equal(w2.worktreePath, "/home/dev/alpha/.worktrees/fix");
-  assert.equal(w2.active, false);
+});
+
+// --- Required case 4: a non-worktree window keeps worktreePath: null ---
+test("snapshotFrom keeps worktreePath null for a non-worktree window (never invented)", () => {
+  const snap = snapshotFrom(P1);
+  const w1 = snap.sessions[0].windows[0];
+  assert.equal(w1.worktreePath, null);
+});
+
+// --- Required case 5: mantaOwned carried onto the snapshot session ---
+test("snapshotFrom carries mantaOwned onto the snapshot session", () => {
+  const snap = snapshotFrom(P1);
+  const alpha = snap.sessions[0];
+  assert.equal(alpha.mantaOwned, true);
+  assert.equal(alpha.defaultCwd, "/home/dev/alpha");
+});
+
+test("snapshotFrom maps cwd from paneCurrentPath with a defaultCwd fallback", () => {
+  const snap = snapshotFrom(
+    [
+      {
+        tmuxSession: "x",
+        defaultCwd: "/home/dev/x",
+        mantaOwned: false,
+        windows: [
+          { index: 0, name: "chat", active: true, paneCurrentPath: "", opencodeSessionId: "oc-9" },
+        ],
+      },
+    ],
+    7,
+  );
+  // empty paneCurrentPath falls back to the project defaultCwd
+  assert.equal(snap.sessions[0].windows[0].cwd, "/home/dev/x");
 });
 
 test("snapshotFrom normalizes mantaOwned/active strictly to === true from malformed input", () => {
@@ -140,13 +176,20 @@ test("countWindows counts across sessions; malformed input → 0", () => {
   assert.equal(countWindows({ version: 1, sessions: "nope" }), 0);
 });
 
-test("shouldPersist: windows present → true; empty→empty → true; non-empty→empty → false", () => {
+// --- Required case 6: shouldPersist REFUSES empty over non-empty ---
+test("shouldPersist refuses an empty listing over a non-empty snapshot", () => {
   const full = snapshotFrom(P1);
   const empty = { version: TOPOLOGY_VERSION, capturedAt: 0, sessions: [] };
-  assert.equal(shouldPersist(null, full), true);
-  assert.equal(shouldPersist(null, empty), true); // no file yet, empty box converges once
+  assert.equal(shouldPersist(full, empty), false);
+});
+
+// --- Required case 7: empty-over-empty allowed; any non-empty allowed ---
+test("shouldPersist allows empty-over-empty and any non-empty listing", () => {
+  const full = snapshotFrom(P1);
+  const empty = { version: TOPOLOGY_VERSION, capturedAt: 0, sessions: [] };
   assert.equal(shouldPersist(empty, empty), true);
-  assert.equal(shouldPersist(full, empty), false); // would-clobber
+  assert.equal(shouldPersist(null, full), true); // no file yet
+  assert.equal(shouldPersist(null, empty), true); // no file yet, empty box converges once
 });
 
 function makeIo({ initial = null, failRead = false } = {}) {
@@ -167,7 +210,7 @@ function makeIo({ initial = null, failRead = false } = {}) {
   };
 }
 
-test("loadTopology: valid file parses; missing/unparsable/version-mismatch/malformed → null", async () => {
+test("loadTopology: valid file parses; missing/unparsable/malformed/unreadable → null", async () => {
   const good = JSON.stringify(snapshotFrom(P1, 99));
   const ok = makeIo({ initial: good });
   const parsed = await loadTopology("/tmp/ignored.json", ok.io);
@@ -178,12 +221,17 @@ test("loadTopology: valid file parses; missing/unparsable/version-mismatch/malfo
   for (const bad of [
     makeIo({ initial: null }), // missing file
     makeIo({ initial: "{not json" }), // invalid JSON
-    makeIo({ initial: JSON.stringify({ version: 999, sessions: [] }) }), // version mismatch
     makeIo({ initial: JSON.stringify({ version: TOPOLOGY_VERSION, sessions: {} }) }), // non-array sessions
     makeIo({ failRead: true }), // unreadable
   ]) {
     assert.equal(await loadTopology("/tmp/ignored.json", bad.io), null);
   }
+});
+
+// --- Required case 10: loadTopology returns null for an unknown version ---
+test("loadTopology returns null for an unknown version (never guesses)", async () => {
+  const { io } = makeIo({ initial: JSON.stringify({ version: 999, sessions: [] }) });
+  assert.equal(await loadTopology("/tmp/ignored.json", io), null);
 });
 
 test("saveTopology writes pretty-printed JSON to the injected io", async () => {
@@ -197,12 +245,13 @@ test("saveTopology writes pretty-printed JSON to the injected io", async () => {
   assert.ok(data.includes('\n  "sessions"')); // pretty-printed, readable diffs
 });
 
-test("persister: first call hydrates lazily then writes; identical tick skips as unchanged", async () => {
+// --- Required case 8: persister skips an unchanged tick ---
+test("persister skips an unchanged tick — save fn ran once for two identical calls", async () => {
   const { calls, io } = makeIo();
   const persist = createTopologyPersister({ save: io.writeFile, load: io.readFile, now: () => 1234 });
   const r1 = await persist(P1);
   assert.deepEqual(r1, { persisted: true, reason: "written" });
-  assert.equal(calls.reads, 1); // hydrated exactly once
+  assert.equal(calls.reads, 1); // hydrated exactly once, lazily
   assert.equal(calls.writes.length, 1);
   assert.deepEqual(JSON.parse(calls.writes[0][1]).capturedAt, 1234);
 
@@ -215,24 +264,8 @@ test("persister: first call hydrates lazily then writes; identical tick skips as
   assert.equal(calls.reads, 1);
 });
 
-test("persister: changed topology writes again and updates the baseline", async () => {
-  const { calls, io } = makeIo();
-  const persist = createTopologyPersister({ save: io.writeFile, load: io.readFile, now: () => 1 });
-  await persist(P1);
-  const renamed = JSON.parse(JSON.stringify(P1));
-  renamed[0].windows[1].name = "renamed-by-user"; // BET-1364 rename drift flows in
-  const r2 = await persist(renamed);
-  assert.deepEqual(r2, { persisted: true, reason: "written" });
-  assert.equal(calls.writes.length, 2);
-  const saved = JSON.parse(calls.writes[1][1]);
-  // only the chat windows survive — "editor" (no opencodeSessionId) is gone
-  assert.deepEqual(
-    saved.sessions[0].windows.map((w) => w.name),
-    ["renamed-by-user", "chat2"],
-  );
-});
-
-test("persister: hydrating a non-empty file, zero-window tick → would-clobber, no write", async () => {
+// --- Required case 9: clobber refused against a snapshot hydrated from disk ---
+test("persister refuses the clobber against a snapshot hydrated from disk", async () => {
   const existing = JSON.stringify(snapshotFrom(P1, 77));
   const { calls, io } = makeIo({ initial: existing });
   const persist = createTopologyPersister({ save: io.writeFile, load: io.readFile, now: () => 2 });

--- a/src/server/topology.test.mjs
+++ b/src/server/topology.test.mjs
@@ -1,0 +1,274 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  TOPOLOGY_VERSION,
+  snapshotFrom,
+  countWindows,
+  shouldPersist,
+  loadTopology,
+  saveTopology,
+  createTopologyPersister,
+} from "./topology.mjs";
+
+// listProjects()-shaped fixture (src/server/tmux.mjs): one chat project, one
+// project with only terminal windows, one empty project.
+const P1 = [
+  {
+    tmuxSession: "alpha",
+    defaultCwd: "/home/dev/alpha",
+    mantaOwned: true,
+    attached: false,
+    windows: [
+      {
+        index: 0,
+        name: "editor",
+        active: false,
+        paneCurrentPath: "/home/dev/alpha",
+        opencodeSessionId: null,
+        worktreePath: null,
+        owner: "user",
+      },
+      {
+        index: 1,
+        name: "chat",
+        active: true,
+        paneCurrentPath: "/home/dev/alpha",
+        opencodeSessionId: "oc-1",
+        worktreePath: null,
+        owner: "user",
+      },
+      {
+        index: 2,
+        name: "chat2",
+        active: false,
+        paneCurrentPath: "",
+        opencodeSessionId: "oc-2",
+        worktreePath: "/home/dev/alpha/.worktrees/fix",
+        owner: "user",
+      },
+    ],
+  },
+  {
+    tmuxSession: "term-only",
+    defaultCwd: "/home/dev/term",
+    mantaOwned: false,
+    attached: true,
+    windows: [
+      {
+        index: 0,
+        name: "shell",
+        active: true,
+        paneCurrentPath: "/home/dev/term",
+        opencodeSessionId: null,
+        worktreePath: null,
+        owner: "user",
+      },
+    ],
+  },
+  { tmuxSession: "empty", defaultCwd: "/home/dev/empty", mantaOwned: false, attached: false, windows: [] },
+];
+
+test("snapshotFrom keeps only chat windows and drops empty projects", () => {
+  const snap = snapshotFrom(P1, 1234);
+  assert.equal(snap.version, TOPOLOGY_VERSION);
+  assert.equal(snap.capturedAt, 1234);
+  assert.deepEqual(
+    snap.sessions.map((s) => s.tmuxSession),
+    ["alpha"],
+  );
+  const s = snap.sessions[0];
+  assert.equal(s.defaultCwd, "/home/dev/alpha");
+  assert.equal(s.mantaOwned, true);
+  assert.deepEqual(
+    s.windows.map((w) => w.opencodeSessionId),
+    ["oc-1", "oc-2"],
+  );
+});
+
+test("snapshotFrom maps per-window fields per the BET-1452 contract", () => {
+  const snap = snapshotFrom(P1);
+  const [w1, w2] = snap.sessions[0].windows;
+  // name ← live tmux window name; cwd ← paneCurrentPath, defaultCwd fallback
+  assert.deepEqual(w1, {
+    index: 1,
+    name: "chat",
+    opencodeSessionId: "oc-1",
+    cwd: "/home/dev/alpha",
+    worktreePath: null,
+    active: true,
+  });
+  // empty paneCurrentPath falls back to the project defaultCwd; observed
+  // worktreePath passes through untouched, never invented
+  assert.equal(w2.name, "chat2");
+  assert.equal(w2.cwd, "/home/dev/alpha");
+  assert.equal(w2.worktreePath, "/home/dev/alpha/.worktrees/fix");
+  assert.equal(w2.active, false);
+});
+
+test("snapshotFrom normalizes mantaOwned/active strictly to === true from malformed input", () => {
+  const snap = snapshotFrom(
+    [
+      {
+        tmuxSession: "x",
+        defaultCwd: "/x",
+        mantaOwned: undefined,
+        windows: [
+          // active: 1 is not === true — pinned strict, matching the
+          // `active === true` contract (parseSessions emits real booleans)
+          { index: 0, name: "c", active: 1, paneCurrentPath: "/x", opencodeSessionId: "oc-9" },
+          { index: 1, name: "c2", active: true, paneCurrentPath: "/x", opencodeSessionId: "oc-8" },
+        ],
+      },
+    ],
+    7,
+  );
+  assert.equal(snap.sessions[0].mantaOwned, false);
+  assert.equal(snap.sessions[0].windows[0].active, false);
+  assert.equal(snap.sessions[0].windows[1].active, true);
+});
+
+test("snapshotFrom with no input → empty snapshot, null/empty tolerated", () => {
+  assert.deepEqual(snapshotFrom(null, 5), { version: TOPOLOGY_VERSION, capturedAt: 5, sessions: [] });
+  assert.equal(countWindows(snapshotFrom(undefined)), 0);
+});
+
+test("countWindows counts across sessions; malformed input → 0", () => {
+  const snap = snapshotFrom(P1);
+  snap.sessions.push({ tmuxSession: "y", windows: [{ index: 3, name: "c", opencodeSessionId: "oc-3" }] });
+  assert.equal(countWindows(snap), 3);
+  assert.equal(countWindows(null), 0);
+  assert.equal(countWindows({ version: 1, sessions: "nope" }), 0);
+});
+
+test("shouldPersist: windows present → true; empty→empty → true; non-empty→empty → false", () => {
+  const full = snapshotFrom(P1);
+  const empty = { version: TOPOLOGY_VERSION, capturedAt: 0, sessions: [] };
+  assert.equal(shouldPersist(null, full), true);
+  assert.equal(shouldPersist(null, empty), true); // no file yet, empty box converges once
+  assert.equal(shouldPersist(empty, empty), true);
+  assert.equal(shouldPersist(full, empty), false); // would-clobber
+});
+
+function makeIo({ initial = null, failRead = false } = {}) {
+  const calls = { reads: 0, writes: [] };
+  return {
+    calls,
+    io: {
+      readFile: async () => {
+        calls.reads += 1;
+        if (failRead) throw new Error("EACCES");
+        if (initial === null) throw new Error("ENOENT");
+        return initial;
+      },
+      writeFile: async (path, data) => {
+        calls.writes.push([path, data]);
+      },
+    },
+  };
+}
+
+test("loadTopology: valid file parses; missing/unparsable/version-mismatch/malformed → null", async () => {
+  const good = JSON.stringify(snapshotFrom(P1, 99));
+  const ok = makeIo({ initial: good });
+  const parsed = await loadTopology("/tmp/ignored.json", ok.io);
+  assert.equal(parsed.version, TOPOLOGY_VERSION);
+  assert.equal(parsed.capturedAt, 99);
+  assert.equal(countWindows(parsed), 2);
+
+  for (const bad of [
+    makeIo({ initial: null }), // missing file
+    makeIo({ initial: "{not json" }), // invalid JSON
+    makeIo({ initial: JSON.stringify({ version: 999, sessions: [] }) }), // version mismatch
+    makeIo({ initial: JSON.stringify({ version: TOPOLOGY_VERSION, sessions: {} }) }), // non-array sessions
+    makeIo({ failRead: true }), // unreadable
+  ]) {
+    assert.equal(await loadTopology("/tmp/ignored.json", bad.io), null);
+  }
+});
+
+test("saveTopology writes pretty-printed JSON to the injected io", async () => {
+  const { calls, io } = makeIo();
+  const snap = snapshotFrom(P1, 42);
+  await saveTopology(snap, "/state/topology.json", io);
+  assert.equal(calls.writes.length, 1);
+  const [path, data] = calls.writes[0];
+  assert.equal(path, "/state/topology.json");
+  assert.equal(data, JSON.stringify(snap, null, 2));
+  assert.ok(data.includes('\n  "sessions"')); // pretty-printed, readable diffs
+});
+
+test("persister: first call hydrates lazily then writes; identical tick skips as unchanged", async () => {
+  const { calls, io } = makeIo();
+  const persist = createTopologyPersister({ save: io.writeFile, load: io.readFile, now: () => 1234 });
+  const r1 = await persist(P1);
+  assert.deepEqual(r1, { persisted: true, reason: "written" });
+  assert.equal(calls.reads, 1); // hydrated exactly once
+  assert.equal(calls.writes.length, 1);
+  assert.deepEqual(JSON.parse(calls.writes[0][1]).capturedAt, 1234);
+
+  const r2 = await persist(P1); // identical topology → no write
+  assert.deepEqual(r2, { persisted: false, reason: "unchanged" });
+  assert.equal(calls.writes.length, 1);
+
+  const r3 = await persist(P1); // still hydrated once, not per call
+  assert.deepEqual(r3, { persisted: false, reason: "unchanged" });
+  assert.equal(calls.reads, 1);
+});
+
+test("persister: changed topology writes again and updates the baseline", async () => {
+  const { calls, io } = makeIo();
+  const persist = createTopologyPersister({ save: io.writeFile, load: io.readFile, now: () => 1 });
+  await persist(P1);
+  const renamed = JSON.parse(JSON.stringify(P1));
+  renamed[0].windows[1].name = "renamed-by-user"; // BET-1364 rename drift flows in
+  const r2 = await persist(renamed);
+  assert.deepEqual(r2, { persisted: true, reason: "written" });
+  assert.equal(calls.writes.length, 2);
+  const saved = JSON.parse(calls.writes[1][1]);
+  // only the chat windows survive — "editor" (no opencodeSessionId) is gone
+  assert.deepEqual(
+    saved.sessions[0].windows.map((w) => w.name),
+    ["renamed-by-user", "chat2"],
+  );
+});
+
+test("persister: hydrating a non-empty file, zero-window tick → would-clobber, no write", async () => {
+  const existing = JSON.stringify(snapshotFrom(P1, 77));
+  const { calls, io } = makeIo({ initial: existing });
+  const persist = createTopologyPersister({ save: io.writeFile, load: io.readFile, now: () => 2 });
+  const r = await persist([]); // box observed with zero chat windows
+  assert.deepEqual(r, { persisted: false, reason: "would-clobber" });
+  assert.equal(calls.writes.length, 0);
+});
+
+test("persister: zero-window tick after empty hydrate writes an empty snapshot once", async () => {
+  const { calls, io } = makeIo();
+  const persist = createTopologyPersister({ save: io.writeFile, load: io.readFile, now: () => 3 });
+  const r = await persist([]);
+  assert.deepEqual(r, { persisted: true, reason: "written" });
+  assert.deepEqual(JSON.parse(calls.writes[0][1]).sessions, []);
+  const r2 = await persist([]);
+  assert.deepEqual(r2, { persisted: false, reason: "unchanged" });
+});
+
+test("persister: identical sessions with a moved clock skip (churn guard); rename writes", async () => {
+  const { calls, io } = makeIo({ initial: JSON.stringify(snapshotFrom(P1, 5)) });
+  let tick = 6;
+  const persist = createTopologyPersister({
+    save: io.writeFile,
+    load: io.readFile,
+    now: () => tick++,
+  });
+  // identical topology, NEWER capturedAt → must still be "unchanged": a
+  // whole-snapshot compare would rewrite the file on every 2s poller tick
+  const r = await persist(P1);
+  assert.deepEqual(r, { persisted: false, reason: "unchanged" });
+  assert.equal(calls.writes.length, 0);
+
+  const renamed = JSON.parse(JSON.stringify(P1));
+  renamed[0].windows[1].name = "renamed-by-user";
+  const r2 = await persist(renamed);
+  assert.deepEqual(r2, { persisted: true, reason: "written" });
+  assert.equal(calls.writes.length, 1);
+  assert.deepEqual(JSON.parse(calls.writes[0][1]).capturedAt, 7); // stamp of the write
+});


### PR DESCRIPTION
## What

Server-side Stage 1 of the BET-1451 topology plan (BET-1452): persist the box's chat-window tree to `~/.manta/topology.json` so a later stage (S2) can hydrate it across box-server restarts.

- New `src/server/topology.mjs` — pure + injected-I/O, mirroring `syncState.mjs` (no tmux import, no bus, no timers):
  - `snapshotFrom(projects, now)` → `{version:1, capturedAt, sessions:[{tmuxSession, defaultCwd, mantaOwned, windows:[{index, name, opencodeSessionId, cwd, worktreePath, active}]}]}` — keeps only windows with a truthy string `opencodeSessionId` (the chat-window discriminator), drops projects left with zero windows, takes `name` from the live tmux window name, `cwd` from `paneCurrentPath` with a `defaultCwd` fallback, `worktreePath` as observed or null (never invented), `mantaOwned` carried off the project.
  - `countWindows` / `shouldPersist` — THE load-bearing rule: a zero-window listing never overwrites a non-empty file, so a crash that restarts tmux EMPTY can't erase the restore point at the moment it's needed.
  - `loadTopology(path?, io?)` — null on missing/unparsable/version-mismatch/non-array-sessions, never throws; `saveTopology` — pretty-printed JSON through the shared `atomicWrite` primitive (temp+rename).
  - `createTopologyPersister({save?, load?, now?})` — hydrates the previous snapshot from disk once, lazily on the first call; skips writes when `shouldPersist` is false (`{persisted:false, reason:"would-clobber"}`) and when the serialized `sessions` are byte-identical to the last write (`reason:"unchanged"`) — without the second check this would rewrite the file every 2s forever on an idle box. Returns the `{persisted, reason}` contract.
- `src/server/syncState.mjs` — the only edit: optional `persistTopology` dep, called inside `refreshNow`'s SUCCESS branch AFTER the projects/stale updates, in its own try/catch (`[topology] snapshot failed — restore point not updated:`). A failed listing never reaches the snapshot; a snapshot failure never turns a good refresh into stale.
- `src/server/index.mjs` — the only edit: passes `persistTopology: createTopologyPersister()` into the existing `createSyncState({...})` deps. No new timer, no new bus kind, no second tmux code path.
- Tests: 16 in `src/server/topology.test.mjs` (each of the 10 spec-required cases a distinct named test, plus cwd-fallback, strict-boolean, moved-clock churn-guard, and serialization cases) + 2 new in `src/server/syncState.test.mjs` (a throwing listing never calls `persistTopology`; a persist failure never flips `stale`). Fully injected I/O — no live-box writes.

## Design note for the S2 author

`capturedAt` on disk means **when the topology last actually changed**, not "last observation": the 2s poller ticks with a moving clock, so the churn guard compares the `sessions` payload only (whole-snapshot compare would rewrite the file forever). Treat an old `capturedAt` as "no change since", not staleness.

Base: origin/main @ 9d2a29ca

## Verification results
- PR branch (`multica/BET-1452-topology-snapshot` @ `0fc3240`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3680` pass / `0` fail / `0` skip (20 new vs base). Failures: none. log sha256: `5e8c8fc8f4263979005751136521beeb7d0ab377121e978bd446e6ee8853a6fb`
- Base (`main` @ `9d2a29ca`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3660` pass / `0` fail / `0` skip. Failures: none. log sha256: `cc9c875252728d894aea017cd956a3114e207faa3a4f161f656889456b249d9d`
- **Conclusion:** 0 pre-existing failures, 0 new failures caused by this PR, 20 passing tests added.
