### PR TITLE
Topology S2a: rebuild chat windows at their exact tmux index (BET-1453)

### DIFF
--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -189,6 +189,9 @@ export const DEMO_UNIMPLEMENTED = [
   "tmuxRenameSession",
   "tmuxRenameWindow",
   "tmuxRestoreConfig",
+  // BET-1453: topology restore (S2a) — no capture exercises it; S3 wires the UI.
+  "tmuxRestorePreview",
+  "tmuxRestoreTopology",
   "tmuxSelectWindow",
   "tmuxSetupConfig",
   "uploadBuffer",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -728,6 +728,13 @@ export const httpApi: Api = {
   tmuxKillWindow: (input) => rpc(IPC.tmuxKillWindow, input),
   tmuxSelectWindow: (input) => rpc(IPC.tmuxSelectWindow, input),
 
+  // BET-1453: topology restore (S2a). No fail-fast timeout on purpose —
+  // apply runs one tmux op per window and preview shells out to tmux + the
+  // opencode session list, both of which can legitimately take seconds on a
+  // waking box. The affordance is S3's Settings > General > Backup section.
+  tmuxRestorePreview: () => rpc(IPC.tmuxRestorePreview),
+  tmuxRestoreTopology: () => rpc(IPC.tmuxRestoreTopology),
+
   // -- git --
   gitListWorktrees: (cwd) => rpc(IPC.gitListWorktrees, cwd),
   // BET-246: auto-create a sibling git worktree for a new chat session.

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -54,6 +54,7 @@ import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import { searchMessages } from "./messageSearch.mjs";
 import { ledgerSummary } from "./modelLedger.mjs";
 import { getDb } from "./opencodeDb.mjs";
+import { loadTopology, planRestore, executeRestore, describeRestore } from "./topology.mjs";
 import { createOptimizerSummary } from "./optimizer/summary.mjs";
 import { createOptimizerSeries } from "./optimizer/series.mjs";
 import { shipCtxEvent } from "./optimizer/telemetry.mjs";
@@ -310,6 +311,19 @@ function withCliProbeTimeout(promise, timeoutMs) {
       },
     );
   });
+}
+
+// BET-1453: the opencode session ids that actually exist on the box, for
+// planRestore's gone-session filter. The `null` is LOAD-BEARING: returning an
+// EMPTY SET for an unreachable opencode would make planRestore discard the
+// user's entire restore. Unknown must mean "do not filter", never "nothing
+// survives".
+async function knownOpencodeSessionIds(oc) {
+  try {
+    const sessions = await oc.listSessions();
+    if (!Array.isArray(sessions)) return null;
+    return new Set(sessions.map((s) => s?.id).filter(Boolean));
+  } catch { return null; }
 }
 
 export function buildHandlers({
@@ -809,6 +823,75 @@ export function buildHandlers({
         await syncState.refreshNow();
       }
       return syncState.payloadSince(sinceSeq, sinceGen);
+    },
+    // BET-1453: topology restore — rebuild the saved chat-window layout after
+    // a tmux server death, at the ORIGINAL indices (a surviving sidebar pin is
+    // `<tmuxSession>/<windowIndex>`; reproducing the exact pair is the point).
+    // NO opencode session is created — the ids in the snapshot are EXISTING
+    // sessions being re-adopted. Restore is NEVER automatic: these channels
+    // are user-initiated (Settings > General > Backup, S3).
+    //
+    // The live list feeds planRestore's idempotency checks. A dead tmux server
+    // is the headline restore scenario, so a failed listing plans against an
+    // EMPTY live tree ("nothing is live") instead of throwing — the honest
+    // basis when the box has nothing running.
+    //
+    // READ-ONLY. Same planRestore the apply channel runs, so the preview can
+    // never disagree with what apply does. Mutates NOTHING.
+    "tmux:restore-preview": async () => {
+      const snapshot = await loadTopology();
+      if (!snapshot) {
+        return { available: false, capturedAt: null, ops: [], skipped: [], restorable: 0 };
+      }
+      let liveProjects = [];
+      try {
+        liveProjects = await tmux.listProjects();
+      } catch {
+        liveProjects = [];
+      }
+      const known = await knownOpencodeSessionIds(oc);
+      const plan = planRestore(snapshot, liveProjects, known);
+      return {
+        available: true,
+        capturedAt: snapshot.capturedAt ?? null,
+        ops: plan.ops,
+        skipped: plan.skipped,
+        restorable: plan.ops.length,
+      };
+    },
+    // Apply the SAME plan the preview shows. One tmux op per window (a restore
+    // can take a while); a per-window throw is recorded, the rest proceed.
+    // refreshNow (which swallows into `stale`, never throws) pushes the
+    // restored windows to the sidebar without waiting for the 2s poll tick.
+    "tmux:restore-topology": async () => {
+      const snapshot = await loadTopology();
+      if (!snapshot) {
+        return { ok: false, error: "No saved window layout to restore from.", created: 0, failed: 0 };
+      }
+      let liveProjects = [];
+      try {
+        liveProjects = await tmux.listProjects();
+      } catch {
+        liveProjects = [];
+      }
+      const known = await knownOpencodeSessionIds(oc);
+      const plan = planRestore(snapshot, liveProjects, known);
+      const result = await executeRestore(plan, (op) =>
+        // Field-name adapter: plan ops carry the snapshot's vocabulary
+        // (tmuxSession/index/name); restoreChatWindow speaks tmux's
+        // (sessionName/windowIndex/windowName).
+        tmux.restoreChatWindow({
+          createSession: op.kind === "create-session",
+          sessionName: op.tmuxSession,
+          windowIndex: op.index,
+          windowName: op.name,
+          cwd: op.cwd,
+          opencodeSessionId: op.opencodeSessionId,
+          worktreePath: op.worktreePath,
+          mantaOwned: op.mantaOwned,
+        }));
+      await syncState.refreshNow();
+      return { ok: true, ...result, message: describeRestore(result) };
     },
     // chatMode (BET-113): when the new-session dialog's "chat mode (opencode)"
     // toggle is on, tmux.newSession must create an opencode session, launch a

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -548,6 +548,65 @@ export async function newWindow({ sessionName, windowName, cwd, chatMode, existi
   return { sessionId: sid ?? null, windowIndex: idx, projects: await listProjects() };
 }
 
+// BET-1453: rebuild ONE chat window from the topology snapshot at its
+// ORIGINAL tmux index. This is the dedicated restore primitive — it deliberately
+// does NOT branch inside newSession/newWindow, which carry unrelated semantics
+// (opencode session creation, createDir, forge stamps, missing-session
+// auto-heal); the restore path re-adopts an EXISTING opencode session id and
+// must never create one.
+//
+// Deliberately NOT automatic, NOT destructive: the caller (rpc's
+// tmux:restore-topology, via topology.executeRestore) only sends ops that the
+// plan proved free (index unoccupied, id unstamped). Failures are thrown to
+// the caller and reported per-window.
+//
+// `createSession` marks the FIRST window of a tmux session that does not
+// exist live. tmux's new-session cannot choose its first window's index —
+// it always uses the server's base-index (user-configurable, 0 by default,
+// 1 on many setups) — so create first, then move-window into the target
+// slot (verified on tmux 3.4; move to an explicit index works out of order).
+export async function restoreChatWindow({ createSession = false, sessionName,
+  windowIndex, windowName, cwd, opencodeSessionId, worktreePath = null,
+  mantaOwned = false }) {
+  // Fail loudly for a directory that no longer exists rather than letting
+  // tmux silently drop the window into $HOME — the caller reports it as a
+  // per-window failure (the same chokepoint newSession/newWindow use).
+  const dir = resolveCwdOrThrow(cwd);
+  if (createSession) {
+    const createdIdx = await newSessionGetIndex(sessionName, dir, windowName, true);
+    if (createdIdx !== windowIndex) {
+      await run("tmux", [
+        "move-window", "-s", `${sessionName}:${createdIdx}`, "-t", `${sessionName}:${windowIndex}`,
+      ]);
+    }
+    // Same survivability posture as newSession: the restored session must
+    // not evaporate when the last client detaches or the pane count dips.
+    await applySessionSurvivability(sessionName);
+  } else {
+    // new-window -t <sess>:<N> creates at an EXPLICIT index and works out of
+    // order (5 then 3 is fine) — appending is not required.
+    await run("tmux", [
+      "new-window", "-t", `${sessionName}:${windowIndex}`, "-n", windowName,
+      "-c", dir, "sh", "-c", CHAT_HOLDER_CMD,
+    ]);
+  }
+  // The stamp is what makes it a chat window — without it the renderer shows
+  // a Terminal over an inert pane.
+  await restampSessionId(sessionName, windowIndex, opencodeSessionId);
+  // Only when the snapshot recorded one — NEVER invent a worktree path
+  // (clean-on-close deletes what this option names; a guessed value could
+  // destroy a worktree manta never created).
+  if (worktreePath) {
+    await setWindowOption(sessionName, windowIndex, "@manta-worktree-path", worktreePath);
+  }
+  // Ownership normally lives in tmux-sessions.json, which a reboot that
+  // brings tmux back EMPTY prunes — re-add it so the restored session is
+  // recognized as Manta-owned again.
+  if (mantaOwned) {
+    await addOwnedSession(sessionName, { path: ownedSessionsCachePath });
+  }
+}
+
 export async function renameSession({ oldName, newName }) {
   await run("tmux", ["rename-session", "-t", oldName, newName]);
   // BET-348: keep the sidecar in sync with the rename — otherwise the

--- a/src/server/topology.mjs
+++ b/src/server/topology.mjs
@@ -27,6 +27,13 @@
 // functions that touch disk by default are loadTopology / saveTopology,
 // both of which accept an `io` override for tests — the suite never writes
 // production data (see the MANTA_STATE_HOME note in src/shared/paths.mjs).
+//
+// BET-1453 (Stage 2a) adds the restore half: planRestore / executeRestore /
+// describeRestore turn a snapshot back into tmux windows AT THEIR ORIGINAL
+// INDICES. The exact index is load-bearing, not cosmetic — a sidebar pin is
+// `<tmuxSession>/<windowIndex>` persisted in config.json and it SURVIVES the
+// crash, so appending rebuilt windows elsewhere would silently reattach a
+// surviving pin to whatever now occupies that slot: the wrong conversation.
 
 import { readFile } from "node:fs/promises";
 import { atomicWrite } from "./storeUtils.mjs";
@@ -181,4 +188,171 @@ export function createTopologyPersister({ save, load, now } = {}) {
     lastSessionsJson = nextSessionsJson;
     return { persisted: true, reason: "written" };
   };
+}
+
+// ---------------------------------------------------------------------------
+// BET-1453 — restore planning + execution (pure)
+// ---------------------------------------------------------------------------
+
+// True when `projects` (a listProjects() tree) has a live window at
+// (tmuxSession, index). ANY window occupies an index — chat or claude-TUI —
+// because the pin pair names the slot, not the kind of window in it.
+function liveIndexSet(liveProjects) {
+  const occupied = new Set();
+  for (const p of liveProjects ?? []) {
+    for (const w of p?.windows ?? []) {
+      if (p?.tmuxSession != null && w?.index != null) occupied.add(`${p.tmuxSession}/${w.index}`);
+    }
+  }
+  return occupied;
+}
+
+// The set of opencode session ids already stamped on ANY live window across
+// ALL sessions — an id restored under a different session than the snapshot
+// recorded still means "this conversation already has a window".
+function liveStampedIdSet(liveProjects) {
+  const stamped = new Set();
+  for (const p of liveProjects ?? []) {
+    for (const w of p?.windows ?? []) {
+      if (typeof w?.opencodeSessionId === "string" && w.opencodeSessionId !== "") {
+        stamped.add(w.opencodeSessionId);
+      }
+    }
+  }
+  return stamped;
+}
+
+// Plan the restore of a saved snapshot against the live tree. Pure.
+//
+// Emits ONLY creation ops — never a kill, rename, restamp or reorder — so
+// running the plan after a partial recovery is safe: whatever a previous run
+// managed to create is skipped, the remainder is completed.
+//
+// Per-window skip rules (checked in this order):
+//   - `opencode-session-gone` — `knownSessionIds` is a Set and the window's
+//     id is absent from it. Restoring one would produce a sidebar row that
+//     opens onto nothing. When `knownSessionIds` is null the filter is OFF
+//     (an unreachable opencode must mean "do not filter", never "drop all").
+//   - `already-restored` — the window's opencodeSessionId is already stamped
+//     on any live window (including under a different session), or the same
+//     id was claimed by an earlier op in THIS plan, so a duplicate id inside
+//     one snapshot cannot be created twice.
+//   - `index-occupied` — a live window already sits at (tmuxSession, index).
+//
+// Each session's windows are sorted ascending by index; the first op for a
+// session that does not exist live is `create-session` (tmux's new-session
+// cannot pick its first window's index — the caller moves it into place),
+// the rest are `create-window` (new-window -t accepts an explicit index and
+// works out of order). Tolerates null / `{sessions: []}` input.
+export function planRestore(snapshot, liveProjects, knownSessionIds = null) {
+  const occupied = liveIndexSet(liveProjects);
+  const stamped = liveStampedIdSet(liveProjects);
+  const ops = [];
+  const skipped = [];
+  const claimedIds = new Set();
+  for (const session of snapshot?.sessions ?? []) {
+    const tmuxSession = session?.tmuxSession;
+    if (tmuxSession == null) continue;
+    const windows = [...(session.windows ?? [])]
+      .filter((w) => w && w.index != null)
+      .sort((a, b) => a.index - b.index);
+    const sessionLive = (liveProjects ?? []).some((p) => p?.tmuxSession === tmuxSession);
+    let first = true;
+    for (const w of windows) {
+      const base = {
+        tmuxSession,
+        mantaOwned: session.mantaOwned === true,
+        index: w.index,
+        name: w.name,
+        opencodeSessionId: w.opencodeSessionId,
+        cwd: w.cwd,
+        worktreePath: w.worktreePath ?? null,
+      };
+      if (knownSessionIds instanceof Set && !knownSessionIds.has(w.opencodeSessionId)) {
+        skipped.push({ ...base, reason: "opencode-session-gone" });
+        continue;
+      }
+      // Stamp check BEFORE the index check on purpose: a window a previous
+      // restore run created is both stamped AND sits at its (reproduced)
+      // index — the truthful reason it is skipped is "already-restored",
+      // not the alarming "index-occupied".
+      if (stamped.has(w.opencodeSessionId) || claimedIds.has(w.opencodeSessionId)) {
+        skipped.push({ ...base, reason: "already-restored" });
+        continue;
+      }
+      if (occupied.has(`${tmuxSession}/${w.index}`)) {
+        skipped.push({ ...base, reason: "index-occupied" });
+        continue;
+      }
+      claimedIds.add(w.opencodeSessionId);
+      ops.push({
+        kind: !sessionLive && first ? "create-session" : "create-window",
+        ...base,
+      });
+      first = false;
+    }
+  }
+  return { ops, skipped };
+}
+
+// Execute a plan by awaiting `restoreWindow(op)` for each op IN ORDER. The
+// only I/O is the injected callback — pure for tests.
+//
+// A per-op throw is caught and recorded in `failures`; the loop CONTINUES
+// (parent decision 3: a window that cannot be rebuilt fails alone). EXCEPT
+// when a `create-session` op fails: the remaining ops for THAT tmux session
+// are failed immediately with "skipped — its tmux session could not be
+// created" — every one of them targets a session that does not exist, so
+// continuing would only bury the real cause under identical errors.
+//
+// Returns { created, failed, skipped, windows, failures }: `created` +
+// `failed` always equals the number of planned window ops (session-skipped
+// windows count as failed), `windows` lists the created identities, and
+// `skipped` carries the plan's pre-filtered entries through untouched.
+export async function executeRestore(plan, restoreWindow) {
+  const windows = [];
+  const failures = [];
+  const skippedSessions = new Set();
+  let created = 0;
+  let failed = 0;
+  for (const op of plan?.ops ?? []) {
+    const identity = {
+      tmuxSession: op.tmuxSession,
+      index: op.index,
+      name: op.name,
+      opencodeSessionId: op.opencodeSessionId,
+    };
+    if (skippedSessions.has(op.tmuxSession)) {
+      failed++;
+      failures.push({
+        ...identity,
+        error: "skipped — its tmux session could not be created",
+      });
+      continue;
+    }
+    try {
+      await restoreWindow(op);
+      created++;
+      windows.push(identity);
+    } catch (e) {
+      failed++;
+      failures.push({ ...identity, error: e?.message ?? String(e) });
+      if (op.kind === "create-session") skippedSessions.add(op.tmuxSession);
+    }
+  }
+  return { created, failed, skipped: plan?.skipped ?? [], windows, failures };
+}
+
+// One human line for the restore result. `created` and `failed` both zero
+// means every saved window was already open (the fully-restored box) — say
+// THAT rather than "Restored 0 windows", which reads like a malfunction.
+export function describeRestore(result) {
+  const created = result?.created ?? 0;
+  const failed = result?.failed ?? 0;
+  if (created === 0 && failed === 0) {
+    return "Nothing to restore — every saved window is already open.";
+  }
+  const noun = created === 1 ? "window" : "windows";
+  if (failed === 0) return `Restored ${created} ${noun}.`;
+  return `Restored ${created} ${noun} · ${failed} failed.`;
 }

--- a/src/server/topology.test.mjs
+++ b/src/server/topology.test.mjs
@@ -8,6 +8,9 @@ import {
   loadTopology,
   saveTopology,
   createTopologyPersister,
+  planRestore,
+  executeRestore,
+  describeRestore,
 } from "./topology.mjs";
 
 // listProjects()-shaped fixture (src/server/tmux.mjs): one chat project with
@@ -304,4 +307,232 @@ test("persister: identical sessions with a moved clock skip (churn guard); renam
   assert.deepEqual(r2, { persisted: true, reason: "written" });
   assert.equal(calls.writes.length, 1);
   assert.deepEqual(JSON.parse(calls.writes[0][1]).capturedAt, 7); // stamp of the write
+});
+
+// ---------------------------------------------------------------------------
+// BET-1453 — restore planning + execution (pure)
+// ---------------------------------------------------------------------------
+
+// A snapshot in the exact shape snapshotFrom writes: two chat sessions,
+// windows at NON-trivial indices (5 before 3 in the saved order) so the
+// ascending-sort and the explicit-index behaviour are both exercised.
+const SNAP = {
+  version: TOPOLOGY_VERSION,
+  capturedAt: 1234,
+  sessions: [
+    {
+      tmuxSession: "alpha",
+      defaultCwd: "/home/dev/alpha",
+      mantaOwned: true,
+      windows: [
+        { index: 5, name: "w5", opencodeSessionId: "oc-5", cwd: "/home/dev/alpha", worktreePath: null, active: false },
+        { index: 3, name: "w3", opencodeSessionId: "oc-3", cwd: "/home/dev/alpha", worktreePath: "/home/dev/alpha/.worktrees/fix", active: true },
+        { index: 4, name: "w4", opencodeSessionId: "oc-4", cwd: "/home/dev/alpha", worktreePath: null, active: false },
+      ],
+    },
+    {
+      tmuxSession: "beta",
+      defaultCwd: "/home/dev/beta",
+      mantaOwned: false,
+      windows: [
+        { index: 1, name: "b1", opencodeSessionId: "oc-b", cwd: "/home/dev/beta", worktreePath: null, active: false },
+      ],
+    },
+  ],
+};
+
+// A listProjects()-shaped live tree with one window, for idempotency checks.
+function liveWindow(tmuxSession, index, opencodeSessionId) {
+  return {
+    tmuxSession,
+    defaultCwd: "/home/dev/x",
+    mantaOwned: false,
+    windows: [{ index, name: "live", active: false, paneCurrentPath: "/home/dev/x", opencodeSessionId, worktreePath: null, owner: "user" }],
+  };
+}
+
+// --- Required case 1: rebuilds into a dead box — create-session first, then
+// create-window, indices ascending ---
+test("planRestore rebuilds into a dead box — create-session first, then create-window, indices ascending", () => {
+  const { ops, skipped } = planRestore(SNAP, [], null);
+  assert.equal(skipped.length, 0);
+  assert.deepEqual(ops.map((o) => [o.tmuxSession, o.index]), [
+    ["alpha", 3], ["alpha", 4], ["alpha", 5], ["beta", 1],
+  ]);
+  assert.equal(ops[0].kind, "create-session");
+  assert.equal(ops[1].kind, "create-window");
+  assert.equal(ops[2].kind, "create-window");
+  // beta is also dead → its first window is a create-session too
+  assert.equal(ops[3].kind, "create-session");
+  // the create-session op carries the full payload the executor needs
+  assert.deepEqual(
+    { ...ops[0], kind: undefined },
+    {
+      tmuxSession: "alpha", mantaOwned: true, index: 3, name: "w3",
+      opencodeSessionId: "oc-3", cwd: "/home/dev/alpha",
+      worktreePath: "/home/dev/alpha/.worktrees/fix", kind: undefined,
+    },
+  );
+});
+
+// --- Required case 2: reproduces the EXACT index ---
+test("planRestore reproduces the exact snapshot index (5 stays 5)", () => {
+  const { ops } = planRestore(SNAP, [], null);
+  const op5 = ops.find((o) => o.tmuxSession === "alpha" && o.opencodeSessionId === "oc-5");
+  assert.equal(op5.index, 5);
+});
+
+// --- Required case 3: never emits a non-creation op ---
+test("planRestore never emits a non-creation op", () => {
+  const { ops } = planRestore(SNAP, [], null);
+  for (const op of ops) {
+    assert.ok(op.kind === "create-session" || op.kind === "create-window", op.kind);
+  }
+});
+
+// --- Required case 4: idempotent — a fully restored box plans nothing ---
+test("planRestore is idempotent — a fully restored box plans nothing", () => {
+  const live = [
+    liveWindow("alpha", 3, "oc-3"),
+    liveWindow("alpha", 4, "oc-4"),
+    liveWindow("alpha", 5, "oc-5"),
+    liveWindow("beta", 1, "oc-b"),
+  ];
+  const { ops } = planRestore(SNAP, live, null);
+  assert.equal(ops.length, 0);
+});
+
+// --- Required case 5: after a partial restore only the remainder is planned,
+// as create-window (session already exists) ---
+test("planRestore after a partial restore plans only the remainder, as create-window", () => {
+  const live = [liveWindow("alpha", 3, "oc-3"), liveWindow("alpha", 4, "oc-4")];
+  const { ops, skipped } = planRestore(SNAP, live, null);
+  assert.deepEqual(ops.map((o) => [o.tmuxSession, o.index, o.kind]), [
+    ["alpha", 5, "create-window"],
+    ["beta", 1, "create-session"],
+  ]);
+  // the two windows run 1 already rebuilt skip as already-restored (they are
+  // stamped live at their reproduced indices) — not the alarming
+  // "index-occupied"
+  assert.deepEqual(
+    skipped.map((s) => [s.tmuxSession, s.index, s.reason]),
+    [["alpha", 3, "already-restored"], ["alpha", 4, "already-restored"]],
+  );
+});
+
+// --- Required case 6: skips an id already stamped under a DIFFERENT session ---
+test("planRestore skips an id already stamped under a different session (already-restored)", () => {
+  const live = [liveWindow("gamma", 9, "oc-5")];
+  const { ops, skipped } = planRestore(SNAP, live, null);
+  const skip = skipped.find((s) => s.tmuxSession === "alpha" && s.index === 5);
+  assert.equal(skip.reason, "already-restored");
+  assert.ok(!ops.some((o) => o.opencodeSessionId === "oc-5"));
+  // the rest of alpha is still planned (its session is dead → create-session)
+  assert.equal(ops[0].kind, "create-session");
+  assert.deepEqual(ops.map((o) => o.index), [3, 4, 1]);
+});
+
+// --- Required case 7: skips an occupied index ---
+test("planRestore skips an occupied index (index-occupied)", () => {
+  // alpha IS live and index 5 is held by a TUI window (no opencode id) —
+  // the slot is taken, the conversation's id is stamped nowhere.
+  const live = [
+    { tmuxSession: "alpha", defaultCwd: "/home/dev/alpha", mantaOwned: true, windows: [{ index: 5, name: "shell", active: false, paneCurrentPath: "/home/dev/alpha", opencodeSessionId: null, worktreePath: null, owner: "user" }] },
+  ];
+  const { ops, skipped } = planRestore(SNAP, live, null);
+  const skip = skipped.find((s) => s.tmuxSession === "alpha" && s.index === 5);
+  assert.equal(skip.reason, "index-occupied");
+  // alpha exists live → every planned alpha op is a create-window
+  assert.deepEqual(ops.map((o) => [o.tmuxSession, o.kind]), [["alpha", "create-window"], ["alpha", "create-window"], ["beta", "create-session"]]);
+});
+
+// --- Required case 8: drops windows whose opencode session is gone ---
+test("planRestore drops windows whose opencode session is gone (knownSessionIds Set)", () => {
+  const { ops, skipped } = planRestore(SNAP, [], new Set(["oc-3", "oc-4"]));
+  assert.deepEqual(ops.map((o) => o.opencodeSessionId), ["oc-3", "oc-4"]);
+  assert.deepEqual(
+    skipped.map((s) => [s.tmuxSession, s.index, s.reason]),
+    [["alpha", 5, "opencode-session-gone"], ["beta", 1, "opencode-session-gone"]],
+  );
+});
+
+// --- Required case 9: knownSessionIds === null keeps everything ---
+test("planRestore with knownSessionIds === null keeps everything (unknown ≠ nothing survives)", () => {
+  const { ops, skipped } = planRestore(SNAP, [], null);
+  assert.equal(ops.length, 4);
+  assert.equal(skipped.length, 0);
+});
+
+test("planRestore tolerates null and {sessions: []} input", () => {
+  assert.deepEqual(planRestore(null, [], null), { ops: [], skipped: [] });
+  assert.deepEqual(planRestore({ version: TOPOLOGY_VERSION, capturedAt: 0, sessions: [] }, [], null), { ops: [], skipped: [] });
+});
+
+test("planRestore claims an id as it plans it — a duplicate id in one snapshot cannot be created twice", () => {
+  const snap = {
+    version: TOPOLOGY_VERSION,
+    capturedAt: 1,
+    sessions: [
+      {
+        tmuxSession: "alpha", defaultCwd: "/d", mantaOwned: false,
+        windows: [
+          { index: 2, name: "a", opencodeSessionId: "oc-dup", cwd: "/d", worktreePath: null, active: false },
+          { index: 7, name: "b", opencodeSessionId: "oc-dup", cwd: "/d", worktreePath: null, active: false },
+        ],
+      },
+    ],
+  };
+  const { ops, skipped } = planRestore(snap, [], null);
+  assert.deepEqual(ops.map((o) => o.index), [2]);
+  assert.equal(ops[0].kind, "create-session");
+  assert.deepEqual(skipped.map((s) => [s.index, s.reason]), [[7, "already-restored"]]);
+});
+
+// --- Required case 10: executeRestore continues past a failed create-window ---
+test("executeRestore continues past a failed create-window", async () => {
+  const { ops, skipped } = planRestore(SNAP, [], null);
+  const attempted = [];
+  const result = await executeRestore({ ops, skipped }, async (op) => {
+    attempted.push(`${op.tmuxSession}/${op.index}`);
+    if (op.tmuxSession === "alpha" && op.index === 4) throw new Error("tmux boom");
+  });
+  assert.deepEqual(attempted, ["alpha/3", "alpha/4", "alpha/5", "beta/1"]);
+  assert.equal(result.created, 3);
+  assert.equal(result.failed, 1);
+  assert.deepEqual(result.windows.map((w) => `${w.tmuxSession}/${w.index}`), ["alpha/3", "alpha/5", "beta/1"]);
+  assert.equal(result.failures.length, 1);
+  assert.equal(result.failures[0].index, 4);
+  assert.equal(result.failures[0].error, "tmux boom");
+});
+
+// --- Required case 11: executeRestore skips the rest of a session after a
+// failed create-session ---
+test("executeRestore skips the rest of a session after a failed create-session", async () => {
+  const { ops, skipped } = planRestore(SNAP, [], null);
+  const attempted = [];
+  const result = await executeRestore({ ops, skipped }, async (op) => {
+    attempted.push(`${op.tmuxSession}/${op.index}`);
+    if (op.kind === "create-session" && op.tmuxSession === "alpha") throw new Error("can't create session");
+  });
+  // alpha/3 attempted once; alpha/4 + alpha/5 failed WITHOUT an attempt;
+  // beta still restored.
+  assert.deepEqual(attempted, ["alpha/3", "beta/1"]);
+  assert.equal(result.created, 1);
+  assert.equal(result.failed, 3);
+  assert.deepEqual(result.failures.map((f) => [f.index, f.error]), [
+    [3, "can't create session"],
+    [4, "skipped — its tmux session could not be created"],
+    [5, "skipped — its tmux session could not be created"],
+  ]);
+  // created + failed always equals the planned window count
+  assert.equal(result.created + result.failed, ops.length);
+});
+
+// --- Required case 12: describeRestore covers created-only, created+failed,
+// and nothing-to-do ---
+test("describeRestore covers created-only, created+failed, and nothing-to-do", () => {
+  assert.equal(describeRestore({ created: 3, failed: 0 }), "Restored 3 windows.");
+  assert.equal(describeRestore({ created: 3, failed: 2 }), "Restored 3 windows · 2 failed.");
+  assert.equal(describeRestore({ created: 0, failed: 0 }), "Nothing to restore — every saved window is already open.");
+  assert.equal(describeRestore({ created: 1, failed: 0 }), "Restored 1 window.");
 });

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -163,6 +163,57 @@ export type SyncDelta =
   | SyncPayload
   | { resync: true };
 
+// BET-1453: one planned window-creation op from the topology restore plan.
+// ONLY creation ops are ever emitted — never a kill/rename/restamp/reorder —
+// so re-running a restore after a partial recovery is safe.
+export type TopologyRestoreOp = {
+  kind: "create-session" | "create-window";
+  tmuxSession: string;
+  mantaOwned: boolean;
+  index: number;
+  name: string;
+  opencodeSessionId: string;
+  cwd: string;
+  worktreePath: string | null;
+};
+
+// BET-1453: why planRestore did NOT plan a saved window. `already-restored`
+// covers both "stamped on a live window (any session)" and "claimed earlier
+// in the same plan" (a duplicate id in one snapshot).
+export type TopologyRestoreSkipped = {
+  tmuxSession: string;
+  index: number;
+  name: string;
+  opencodeSessionId: string;
+  reason: "index-occupied" | "already-restored" | "opencode-session-gone";
+};
+
+// BET-1453: `tmux:restore-preview` — READ-ONLY. `available:false` means no
+// usable snapshot (never captured, or unloadable); the restore button hides.
+export type TopologyRestorePreview = {
+  available: boolean;
+  capturedAt: number | null;
+  ops: TopologyRestoreOp[];
+  skipped: TopologyRestoreSkipped[];
+  restorable: number;
+};
+
+// BET-1453: `tmux:restore-topology` — apply the SAME plan the preview showed.
+// `created + failed` always equals the number of planned windows; a window
+// whose tmux session could not be created counts as failed too. `windows`
+// lists the created identities; `failures` carries one error per failed
+// window; `message` is the server's human summary (describeRestore).
+export type TopologyRestoreResult = {
+  ok: boolean;
+  error?: string;
+  created: number;
+  failed: number;
+  skipped?: TopologyRestoreSkipped[];
+  windows?: { tmuxSession: string; index: number; name: string; opencodeSessionId: string }[];
+  failures?: { tmuxSession: string; index: number; name: string; opencodeSessionId: string; error: string }[];
+  message?: string;
+};
+
 // Adaptive CTO state (§10.1/§10.6). The engine's `{kind:"ctoState"}` bus
 // event and `GET /api/cto/state` both carry this exact shape.
 export type CtoState = {
@@ -583,6 +634,15 @@ export interface Api {
   tmuxKillSession(sessionName: string): Promise<Project[]>;
   tmuxKillWindow(input: { sessionName: string; windowIndex: number }): Promise<Project[]>;
   tmuxSelectWindow(input: { sessionName: string; windowIndex: number }): Promise<void>;
+
+  // BET-1453: topology restore (S2a) — rebuild the saved chat-window layout
+  // at the ORIGINAL tmux indices after a tmux server death. Preview is
+  // READ-ONLY and mutates nothing; apply executes the SAME plan (preview can
+  // never disagree with apply) and never creates an opencode session — the
+  // ids in the snapshot are existing sessions being re-adopted. User-initiated
+  // only (Settings > General > Backup, S3) — restore is never automatic.
+  tmuxRestorePreview(): Promise<TopologyRestorePreview>;
+  tmuxRestoreTopology(): Promise<TopologyRestoreResult>;
 
   gitListWorktrees(cwd: string): Promise<WorktreeInfo[]>;
   // BET-246: create a sibling git worktree next to `cwd`'s repo root, named

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1221,6 +1221,12 @@ export const IPC = {
   // BET-678: sync cursor snapshot/delta RPC (the single bootstrap + resync).
   syncSnapshot: "sync:snapshot",
 
+  // BET-1453: topology restore (S2a) — read-only preview + apply of the saved
+  // chat-window layout (rebuild at the ORIGINAL tmux indices). The only
+  // affordance is S3's Settings > General > Backup section.
+  tmuxRestorePreview: "tmux:restore-preview",
+  tmuxRestoreTopology: "tmux:restore-topology",
+
   // Project metadata (local-only)
   projectMetaDelete: "project:meta:delete",
 


### PR DESCRIPTION
## BET-1453 — Topology S2a: rebuild windows at their exact index (RPC only, no UI)

Base: origin/main @ a8c9ecc9

### What

Server-side restore of the chat-window layout captured by BET-1452, as pure logic + RPC. No UI (S3 wires Settings > General > Backup).

- `src/server/topology.mjs` — `planRestore` / `executeRestore` / `describeRestore` (pure):
  - Only creation ops (`create-session` / `create-window`) — never a kill, rename, restamp or reorder, so re-running after a partial recovery completes only the remainder.
  - Idempotent: skips when (tmuxSession, index) is occupied (`index-occupied`) or the opencode session id is already stamped on any live window — including under a different session — or claimed earlier in the same plan (`already-restored`).
  - `knownSessionIds` Set → drops windows whose opencode session is gone (`opencode-session-gone`); `null` → filter off (an unreachable opencode means "do not filter", never "drop all").
  - Windows sorted ascending by index per session; the first op for a dead session is `create-session` (tmux new-session cannot pick its first window's index → create, then `move-window` into place — verified on tmux 3.4).
  - `executeRestore` continues past a failed window; a failed `create-session` fails the rest of that session with "skipped — its tmux session could not be created".
- `src/server/tmux.mjs` — one new primitive, `restoreChatWindow`: explicit-index rebuild (`new-window -t <sess>:<N>` works out of order), re-stamps the EXISTING opencode session id (never creates one), optional worktree stamp only when the snapshot recorded one, re-adds Manta ownership.
- `src/server/rpc.mjs` — `tmux:restore-preview` (READ-ONLY, same `planRestore` the apply channel runs) + `tmux:restore-topology` (apply + `syncState.refreshNow()`); `knownOpencodeSessionIds` helper treats an unreachable opencode as "do not filter".
- Wiring: `src/shared/types.ts` (2 channels), `src/shared/api.ts` (result types + 2 methods), `src/renderer/api/httpApi.ts` (no fail-fast timeout — a restore legitimately takes a while), `demoCoverage.test.ts` inventory.

### Verification results

**Files changed:** 8 files, +623. `demoCoverage.test.ts`, `httpApi.ts`, `rpc.mjs`, `tmux.mjs`, `topology.mjs`, `topology.test.mjs`, `api.ts`, `types.ts`

- PR branch (`multica/BET-1453-restore-windows` @ 724efbad):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e8fce…
  - test: exit 0, 3869 vitest pass / 0 fail / 7 skip; node:test 3694 pass / 0 fail (incl. 14 new restore tests). Failures: none. log sha256: 4ed52c6834b02656…
- Base (`main` @ a8c9ecc9, verified in an isolated git worktree — the shared checkout is contested by a concurrent BET-1454 run):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e8fce…
  - test: exit 0, 3869 vitest pass / 0 fail / 7 skip; node:test 3680 pass / 0 fail. Failures: none. log sha256: 2fead73fe1bd5827…
- **Conclusion:** 0 new failures, 0 pre-existing failures. The 14 new node:test cases cover all 12 issue-required restore behaviours (dead-box rebuild, exact index, creation-only ops, idempotency, partial-restore remainder, different-session stamp, occupied index, gone-session filter, null filter, continue-past-failure, session-failure skip, describeRestore) plus null/empty tolerance and duplicate-id claim.

### Notes

- Manual sanity check against a live box (issue acceptance item) could not be performed from this run: this box's tmux/opencode are the LIVE ones the server itself uses, and a concurrent BET-1454 run shares this checkout — killing the tmux server to test restore would wreck both runs. The pure engine is fully covered by tests; the tmux primitives used (`new-session -d`/`new-window -t`/`move-window`/`set-option`) are the same ones newSession/newWindow already exercise in production.
- Cross-cutting: `tmux:restore-preview`/`tmux:restore-topology` are new Api surface consumed by nobody yet (S3). The demo-coverage inventory was updated accordingly.
- Process incident (not a code concern): a concurrent BET-1454 run shares this git checkout and switched branches mid-run; the mixed commit was salvaged to `multica/BET-1454-wip-salvage` and both issues' work was separated cleanly. Details on BET-1454.
