### PR TITLE
fix(server): tmux classifier regression, phantom-empty prune guard, stderr leak (BET-1454)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -3360,7 +3360,11 @@ const handleRequest = async (req, res) => {
       const projects = await tmux.listProjects();
       respondJson(res, 200, projects);
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      // BET-1454: never forward raw tmux stderr to a client-facing body —
+      // the desktop chat panel renders `error` verbatim in a banner. Log the
+      // fault server-side and return a safe, human message instead.
+      console.warn("[api/projects] tmux listing failed:", e?.message ?? e);
+      respondJson(res, 500, { error: "Couldn't reach tmux on the box." });
     }
     return;
   }

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -1434,10 +1434,11 @@ export function buildHandlers({
       const resolvedCwd = await resolveProjectCwd(sessionName, cwd);
       const windowIndex = await tmux.newWindowGetIndex(sessionName, windowName, resolvedCwd);
       await tmux.restampSessionId(sessionName, windowIndex, forked.id);
-      const projects = await tmux.listProjects();
-      // BET-675: refresh materialized state so the new window's delta publishes now.
+      // BET-1454: refreshNow() materializes the refreshed tree — read it from
+      // the snapshot instead of a second listProjects() shell-out whose
+      // transient tmux fault would throw and forward raw stderr to the client.
       await syncState.refreshNow();
-      return { newSessionId: forked.id, projects };
+      return { newSessionId: forked.id, projects: syncState.snapshot().projects };
     },
 
     // opencode:clear-session
@@ -1451,10 +1452,9 @@ export function buildHandlers({
       const directory = await resolveProjectCwd(sessionName, cwd);
       const sess = await oc.createSession({ directory, title });
       await tmux.restampSessionId(sessionName, windowIndex, sess.id);
-      const projects = await tmux.listProjects();
-      // BET-675: refresh materialized state so the change publishes now.
+      // BET-1454: snapshot, not a second shell-out (see fork-session above).
       await syncState.refreshNow();
-      return { newSessionId: sess.id, projects };
+      return { newSessionId: sess.id, projects: syncState.snapshot().projects };
     },
 
     // opencode:delete-session
@@ -1467,10 +1467,9 @@ export function buildHandlers({
     "opencode:delete-session": async ({ sessionId, sessionName, windowIndex }) => {
       await oc.deleteSessionRaw(sessionId);
       await tmux.killWindow({ sessionName, windowIndex }).catch(() => {});
-      const projects = await tmux.listProjects();
-      // BET-675: refresh materialized state so the removed window publishes now.
+      // BET-1454: snapshot, not a second shell-out (see fork-session above).
       await syncState.refreshNow();
-      return projects;
+      return syncState.snapshot().projects;
     },
 
     // BET-421: bare session lifecycle for the onboarding verifier. create

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -322,12 +322,14 @@ export function resolveOwner(raw) {
 // premise is false: a restarted/dead server produces `no server running on`
 // (tmux unlinks the stale socket and says so); ENOENT means the socket was
 // never there — you cannot have sessions on a box whose tmux socket does not
-// exist. The no-server-shaped stderr we deliberately REJECT as a fault:
-// `error connecting to <sock>: Connection refused` (a stale socket that a
-// modern tmux would have self-cleaned — treated as a restart race, must
-// surface as a fault, never as a phantom empty box), `spawn tmux ENOENT`
-// (the tmux BINARY itself is missing) and hard-fault wording like
-// `lost server`.
+// exist. Empirically measured on this box's tmux 3.4 (BET-1454 review): a
+// stale socket file with no listener (true ECONNREFUSED at connect time)
+// comes back as `no server running on <sock>` — tmux 3.4 self-cleans it — so
+// the `Connection refused` arm of the third clause is belt-and-braces for
+// tmux builds that DO emit it verbatim. Both `error connecting to …` rows are
+// classified no-server per the issue's pinned spec. The no-server-shaped
+// stderr we deliberately REJECT as a fault: `spawn tmux ENOENT` (the tmux
+// BINARY itself is missing) and hard-fault wording like `lost server`.
 //
 // Pure + exported for tests.
 export function isNoTmuxServerError(err) {
@@ -336,7 +338,7 @@ export function isNoTmuxServerError(err) {
   return (
     /no server running on/i.test(msg) ||
     /no sessions?$/im.test(msg) ||
-    /error connecting to .*no such file or directory/i.test(msg)
+    /error connecting to .*(no such file or directory|connection refused)/i.test(msg)
   );
 }
 

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -308,11 +308,26 @@ export function resolveOwner(raw) {
 // (or no session) to talk to — i.e. the box really does have zero sessions.
 // Anything else is a FAULT and must not be reported as "zero sessions".
 //
-// We deliberately match ONLY "no server running" and "no sessions". The
-// `error connecting to … (No such file or directory)` / `Connection refused`
-// variants are NOT genuine-empty: they indicate a restarted server or a
-// socket race, so they must surface as a fault (throw) rather than masquerade
-// as an empty box (BET-675).
+// Verified on tmux 3.4 (BET-1454). Do NOT re-tighten this a third time — this
+// is the second classifier regression already:
+//
+// | Box state                              | tmux stderr                                        | Truth       |
+// |----------------------------------------|----------------------------------------------------|-------------|
+// | socket never existed (fresh/dead box)  | `error connecting to <sock> (No such file or ...)` | no server   |
+// | socket left behind, server died        | `no server running on <sock>`                      | no server   |
+// | server alive, zero sessions            | (empty stdout, exit 0)                             | no sessions |
+//
+// Commit 688221fb matched the ENOENT row; commit 4b5a95db removed it on the
+// reasoning that ENOENT indicated "a restarted server or a socket race". That
+// premise is false: a restarted/dead server produces `no server running on`
+// (tmux unlinks the stale socket and says so); ENOENT means the socket was
+// never there — you cannot have sessions on a box whose tmux socket does not
+// exist. The no-server-shaped stderr we deliberately REJECT as a fault:
+// `error connecting to <sock>: Connection refused` (a stale socket that a
+// modern tmux would have self-cleaned — treated as a restart race, must
+// surface as a fault, never as a phantom empty box), `spawn tmux ENOENT`
+// (the tmux BINARY itself is missing) and hard-fault wording like
+// `lost server`.
 //
 // Pure + exported for tests.
 export function isNoTmuxServerError(err) {
@@ -320,7 +335,8 @@ export function isNoTmuxServerError(err) {
   if (!msg) return false;
   return (
     /no server running on/i.test(msg) ||
-    /no sessions?$/im.test(msg)
+    /no sessions?$/im.test(msg) ||
+    /error connecting to .*no such file or directory/i.test(msg)
   );
 }
 
@@ -333,12 +349,18 @@ export function isNoTmuxServerError(err) {
 // has no sessions, so the phone showed "No sessions yet. Tap + to create one."
 // with no error, and (worse) `reconcileOwnedSessions` pruned the ownership
 // sidecar against that phantom empty list. A fault must surface as a fault.
+//
+// Returns `{ stdout, swallowed }`. `swallowed: true` means the no-server
+// error was converted to an empty listing — i.e. this is NOT a genuine
+// listing of a live server, and consumers that prune state against the
+// result (see `listProjects` / `reconcileOwnedSessions`) must skip the
+// prune (BET-1454).
 async function tmuxListOutput(args) {
   try {
     const { stdout } = await run("tmux", args);
-    return stdout;
+    return { stdout, swallowed: false };
   } catch (e) {
-    if (isNoTmuxServerError(e)) return "";
+    if (isNoTmuxServerError(e)) return { stdout: "", swallowed: true };
     throw e;
   }
 }
@@ -346,16 +368,26 @@ async function tmuxListOutput(args) {
 export async function listProjects(installHome = INSTALL_HOME) {
   const sessFmt = `#{session_name}${FS}#{?session_attached,1,0}`;
   const winFmt = `#{session_name}${FS}#{window_index}${FS}#{window_name}${FS}#{?window_active,1,0}${FS}#{pane_current_path}${FS}#{@manta-session-id}${FS}#{@manta-worktree-path}${FS}#{@manta-owner}`;
-  const sess = { stdout: await tmuxListOutput(["list-sessions", "-F", sessFmt]) };
-  const wins = { stdout: await tmuxListOutput(["list-windows", "-a", "-F", winFmt]) };
+  const sess = await tmuxListOutput(["list-sessions", "-F", sessFmt]);
+  const wins = await tmuxListOutput(["list-windows", "-a", "-F", winFmt]);
   // BET-348: build the owned set from the cache (hydrated on first call),
   // reconcile it against the LIVE tmux session list — anything in the
   // sidecar that no longer exists gets pruned before we serve the listing,
   // so the renderer can't see a session that "remembers ownership" of a
   // session that was killed. Then stamp each session with mantaOwned.
+  //
+  // BET-1454: a swallowed listing (no tmux server — dead box, fresh boot) is
+  // NOT a genuine empty box. reconcileOwnedSessions prunes every sidecar
+  // entry not in the live list, so pruning against the phantom `[]` would
+  // wipe `~/.manta/tmux-sessions.json` on exactly the event the topology
+  // epic exists to survive. Skip the prune entirely and stamp `mantaOwned`
+  // from the unpruned cache instead; the next GENUINE listing reconciles
+  // as before.
   const parsedSess = parseSessions(sess.stdout, "");
   const liveNames = parsedSess.map((p) => p.tmuxSession);
-  const owned = await reconcileOwnedSessions(liveNames);
+  const owned = sess.swallowed
+    ? await getOwnedSessions(ownedSessionsCachePath)
+    : await reconcileOwnedSessions(liveNames);
   const projects = parseSessions(sess.stdout, wins.stdout, owned);
   // BET-995: the box runs its own session FROM its install dir, so that dir
   // surfaces as an "available project" in onboarding. Never offer the server's
@@ -688,7 +720,7 @@ export async function stampOwner(sessionName, windowIndex, owner) {
 export async function findWindowForCwd(cwd) {
   const dir = expandTilde(cwd ?? "");
   if (!dir) return null;
-  const stdout = await tmuxListOutput([
+  const { stdout } = await tmuxListOutput([
     "list-windows", "-a",
     "-F", `#{session_name}${FS}#{window_index}${FS}#{pane_current_path}`,
   ]);

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -370,6 +370,14 @@ test("resolveCwdOrThrow: '~/<existing dir>' resolves under os.homedir()", async 
 // that genuinely has no sessions, so the phone showed the inviting "No
 // sessions yet. Tap + to create one." for a box full of work, and the
 // ownership sidecar was reconciled to nothing against the phantom empty list.
+//
+// BET-1454 twist: the classifier now swallows the two GENUINE no-server
+// stderrs (`no server running on`, and the never-created-socket ENOENT) into
+// that same successful-empty shape — that is correct, a box with no tmux
+// server really has no sessions. But a swallowed listing is NOT a genuine
+// listing, so listProjects must skip the reconcile/prune in that case (the
+// phantom-empty shape returns again, and this time it must not wipe the
+// sidecar). Both behaviours are pinned below.
 // ---------------------------------------------------------------------------
 
 test("isNoTmuxServerError separates 'no tmux server' from a real fault", () => {
@@ -377,11 +385,20 @@ test("isNoTmuxServerError separates 'no tmux server' from a real fault", () => {
     isNoTmuxServerError(new Error("tmux exited 1: no server running on /tmp/tmux-1000/default")),
     true,
   );
-  // BET-675: "error connecting … (No such file or directory)" / "Connection
-  // refused" indicate a restarted server / socket race, NOT a genuinely empty
-  // box — so they are no longer treated as "no tmux server".
+  // BET-1454: "error connecting … (No such file or directory)" means the
+  // socket was NEVER there — a fresh or dead box genuinely has no tmux
+  // server. Commit 4b5a95db had removed it on the false premise that ENOENT
+  // indicated a restarted server / socket race; that state actually produces
+  // `no server running on` (tmux unlinks the stale socket and says so).
   assert.equal(
     isNoTmuxServerError(new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default (No such file or directory)")),
+    true,
+  );
+  // A stale socket that still answers with Connection refused IS a restart
+  // race (modern tmux self-cleans it into `no server running on`) — keep it
+  // a fault so a transient restart can never masquerade as an empty box.
+  assert.equal(
+    isNoTmuxServerError(new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default: Connection refused")),
     false,
   );
   assert.equal(isNoTmuxServerError(new Error("tmux exited 1: no sessions")), true);
@@ -404,6 +421,22 @@ test("listProjects returns [] when tmux genuinely has no server", async () => {
   }
 });
 
+// BET-1454: same swallow for the never-created socket — the (No such file
+// or directory) stderr means "no tmux server exists right now", which is a
+// true empty box, not a fault.
+test("listProjects returns [] when the tmux socket never existed (ENOENT swallow)", async () => {
+  _resetOwnedSessionsCache();
+  _setRun(async () => {
+    throw new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default (No such file or directory)");
+  });
+  try {
+    assert.deepEqual(await listProjects(), []);
+  } finally {
+    _setRun(null);
+    _resetOwnedSessionsCache();
+  }
+});
+
 test("listProjects THROWS on a tmux fault rather than reporting zero sessions", async () => {
   _resetOwnedSessionsCache();
   _setRun(async () => {
@@ -417,16 +450,17 @@ test("listProjects THROWS on a tmux fault rather than reporting zero sessions", 
   }
 });
 
-// BET-675: a socket race ("error connecting … (No such file or directory)")
-// is a FAULT, not an empty box — it must throw out of listProjects, never
-// quietly return an empty list.
+// BET-675: a socket race ("error connecting …: Connection refused") is a
+// FAULT, not an empty box — it must throw out of listProjects, never
+// quietly return an empty list. (The never-created-socket ENOENT variant IS
+// a genuine empty box now — see the ENOENT swallow test above.)
 test("listProjects THROWS on a tmux socket-race fault, not empty", async () => {
   _resetOwnedSessionsCache();
   _setRun(async () => {
-    throw new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default (No such file or directory)");
+    throw new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default: Connection refused");
   });
   try {
-    await assert.rejects(() => listProjects(), /No such file or directory/);
+    await assert.rejects(() => listProjects(), /Connection refused/);
   } finally {
     _setRun(null);
     _resetOwnedSessionsCache();
@@ -466,6 +500,41 @@ test("a tmux fault does not prune the owned-session sidecar", async () => {
     assert.deepEqual(await loadOwnedSessions(path), ["alpha"]);
   } finally {
     _resetOwnedSessionsCache();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// BET-1454: the ENOENT swallow makes a dead box return [] SUCCESSFULLY —
+// which is exactly the phantom-empty shape that used to wipe the sidecar
+// (BET-675's incident). A swallowed listing is NOT a genuine listing, so the
+// reconcile/prune must be skipped entirely: the sidecar survives verbatim
+// (including entries that may look stale) until the next GENUINE listing
+// reconciles it.
+test("a swallowed no-server listing does not prune the owned-session sidecar", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tmux-swallow-"));
+  const path = join(dir, "tmux-sessions.json");
+  try {
+    _resetOwnedSessionsCache();
+    _setOwnedSessionsPath(path);
+    await addOwnedSession("alpha", { path });
+    await addOwnedSession("ghost", { path });
+    _setRun(async () => {
+      throw new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default (No such file or directory)");
+    });
+    try {
+      // Swallowed → resolves (not throws) with the phantom-empty list.
+      assert.deepEqual(await listProjects(), []);
+    } finally {
+      _setRun(null);
+    }
+    assert.deepEqual(
+      await loadOwnedSessions(path),
+      ["alpha", "ghost"],
+      "a swallowed listing must never reconcile/prune the sidecar",
+    );
+  } finally {
+    _resetOwnedSessionsCache();
+    _setOwnedSessionsPath(null);
     await rm(dir, { recursive: true, force: true });
   }
 });

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -394,12 +394,14 @@ test("isNoTmuxServerError separates 'no tmux server' from a real fault", () => {
     isNoTmuxServerError(new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default (No such file or directory)")),
     true,
   );
-  // A stale socket that still answers with Connection refused IS a restart
-  // race (modern tmux self-cleans it into `no server running on`) — keep it
-  // a fault so a transient restart can never masquerade as an empty box.
+  // Connection refused: the issue's pinned spec classifies the whole
+  // `error connecting to …` family as no-server. Measured on this box's
+  // tmux 3.4 a stale socket (true ECONNREFUSED) is self-cleaned by tmux into
+  // `no server running on` — so this arm is belt-and-braces for builds that
+  // emit the literal stderr, and harmless to swallow either way.
   assert.equal(
     isNoTmuxServerError(new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default: Connection refused")),
-    false,
+    true,
   );
   assert.equal(isNoTmuxServerError(new Error("tmux exited 1: no sessions")), true);
   assert.equal(isNoTmuxServerError(new Error("spawn tmux ENOENT")), false);
@@ -450,17 +452,31 @@ test("listProjects THROWS on a tmux fault rather than reporting zero sessions", 
   }
 });
 
-// BET-675: a socket race ("error connecting …: Connection refused") is a
-// FAULT, not an empty box — it must throw out of listProjects, never
-// quietly return an empty list. (The never-created-socket ENOENT variant IS
-// a genuine empty box now — see the ENOENT swallow test above.)
-test("listProjects THROWS on a tmux socket-race fault, not empty", async () => {
+// BET-1454 review: `Connection refused` is part of the pinned no-server
+// family (the issue's Change-1 clause) — same swallow as ENOENT. Real tmux
+// 3.4 usually self-cleans a stale socket into `no server running on`, so
+// this arm rarely fires; either way it must not throw a phantom fault.
+test("listProjects returns [] on a Connection-refused stderr (no-server family)", async () => {
   _resetOwnedSessionsCache();
   _setRun(async () => {
     throw new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default: Connection refused");
   });
   try {
-    await assert.rejects(() => listProjects(), /Connection refused/);
+    assert.deepEqual(await listProjects(), []);
+  } finally {
+    _setRun(null);
+    _resetOwnedSessionsCache();
+  }
+});
+
+// A genuine fault must still throw, never masquerade as an empty box.
+test("listProjects THROWS on a tmux lost-server fault, not empty", async () => {
+  _resetOwnedSessionsCache();
+  _setRun(async () => {
+    throw new Error("tmux exited 1: lost server");
+  });
+  try {
+    await assert.rejects(() => listProjects(), /lost server/);
   } finally {
     _setRun(null);
     _resetOwnedSessionsCache();


### PR DESCRIPTION
## Summary

Three fixes on the tmux dead-server path (epic BET-1451, stage 2b; builds on BET-1452's persisted topology):

1. **Classifier regression (root cause).** `isNoTmuxServerError` lost the never-created-socket row in commit 4b5a95db (BET-675): "error connecting to `<sock>` (No such file or directory)" was reclassified as a fault on the false premise that ENOENT meant "a restarted server or a socket race". On tmux 3.4 a restarted/dead server produces `no server running on` (tmux unlinks the stale socket and says so); ENOENT means the socket was **never there** — a fresh or dead box genuinely has no tmux server. Restored per the issue's pinned Change-1 clause: BOTH `error connecting to …` rows (No-such-file **and** Connection refused) are genuinely-no-server; `spawn tmux ENOENT` and `lost server` stay faults. Comment table in the source records the verified stderr rows + the measured stale-socket self-clean so this doesn't get "re-tightened" a third time.
2. **Phantom-empty prune guard.** `tmuxListOutput` now returns `{ stdout, swallowed }` so a swallowed no-server listing is distinguishable from a genuine listing. `listProjects` skips `reconcileOwnedSessions` entirely in the swallowed case and stamps `mantaOwned` from the unpruned cache — pruning against the phantom `[]` would wipe `~/.manta/tmux-sessions.json` on exactly the dead-box event the topology snapshot (BET-1452) exists to survive. The next genuine listing reconciles as before.
3. **Stderr leak.** The `opencode:fork-session` / `clear-session` / `delete-session` handlers double-shelled `listProjects()` after `syncState.refreshNow()`; a transient tmux fault in the second call threw raw tmux stderr straight to the client (the desktop banner renders it verbatim). They now read the already-materialised `syncState.snapshot().projects`. Same for `GET /api/projects`: safe human error body (`Couldn't reach tmux on the box.`) + server-side `console.warn`, instead of `String(e.message)`.

## Duplicate-site list (anti-spaghetti)

- `tmuxListOutput` call sites: all 3 updated (2× `listProjects`, 1× `findWindowForCwd` — the latter just destructures `stdout`, no behavior change).
- Raw-stderr-to-client sites: `rpc.mjs` fork/clear/delete handlers + `index.mjs` `/api/projects` — all 4 fixed in this PR. The `tmux:list*` rpc channels intentionally still throw (rpc error envelope, not a rendered banner).
- Single source of truth for "is this genuinely no-server": `isNoTmuxServerError` (unchanged canonical home).

## Cross-cutting

- Touchpoints overlap with sibling stage-2a branch `multica/BET-1453-restore-windows` (rpc.mjs handlers region, tmux.mjs additions) — independent changes; merge in either order, second one rebases.
- **Incident note:** both stage-2 runs were dispatched concurrently into the same shared bare repo / worktree namespace; the BET-1453 run's commit briefly landed on this branch (mixed commit `c1678898`, since split). This branch contains only BET-1454 hunks; BET-1453's branch re-committed its own work cleanly. Follow-up filed: BET-1456 (platform branch-namespace collision, assigned manta-pm).
- Precondition verified: BET-1452's `shouldPersist` exists (`src/server/topology.mjs:103`) and is wired (`createTopologyPersister` in `src/server/index.mjs:307`, invoked on refreshNow success).

Base: origin/main @ a8c9ecc9

## Verification results

**Files changed:** 4 files, +163/−44: `src/server/tmux.mjs`, `src/server/rpc.mjs`, `src/server/index.mjs`, `src/server/tmux.test.mjs`

- PR branch (`multica/BET-1454-tmux-classifier` @ `7b155735`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 3683 pass / 0 fail / 0 skip. Failures: none.
- Base (`main` @ `a8c9ecc9`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 3680 pass / 0 fail / 0 skip. Failures: none.
- **Conclusion:** 0 new failures; 3 new passing tests added by this PR (ENOENT swallow + prune guard + Connection-refused swallow) and one new fault case (lost-server throw).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.
