### PR TITLE
feat(renderer): Settings > General > Backup section with Restore windows button (BET-1455)

### DIFF
--- a/src/renderer/Settings.test.tsx
+++ b/src/renderer/Settings.test.tsx
@@ -500,3 +500,84 @@ describe("Settings — Backup section (BET-1455)", () => {
     expect(disclosure).toContain("tmux exploded");
   });
 });
+
+// In-flight (state 4) + the server-said-no branch: the button goes
+// loading+disabled while the restore is awaited, and an `ok:false` RESULT
+// (not a throw) still routes through the error disclosure.
+describe("Settings — Backup restore in-flight + ok:false (BET-1455)", () => {
+  let h: Harness | null = null;
+
+  const preview = {
+    available: true as const,
+    capturedAt: Date.parse("2026-08-30T20:00:00Z"),
+    ops: [
+      { kind: "create-window" as const, tmuxSession: "proj-a", mantaOwned: true, index: 1, name: "w1", opencodeSessionId: "oc-1", cwd: "/tmp/a", worktreePath: null },
+    ],
+    skipped: [],
+    restorable: 1,
+  };
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    useStore.setState({ appToasts: [] });
+  });
+
+  it("while the restore is in flight the button renders loading and disabled", async () => {
+    let resolveRestore: (v: unknown) => void = () => {};
+    installMockApi({
+      configGet: () => Promise.resolve({}),
+      getClientVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      getServerVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      tmuxRestorePreview: () => Promise.resolve(preview),
+      tmuxRestoreTopology: () => new Promise((res) => { resolveRestore = res; }),
+    });
+    h = mount(<Settings onClose={() => {}} />);
+    await h.flush();
+    await h.flush();
+
+    const btn = [...h.container.querySelectorAll("button")].find(
+      (b) => (b.textContent ?? "").trim() === "Restore windows",
+    ) as HTMLButtonElement;
+    act(() => btn.click());
+    await h.flush();
+
+    const inFlight = [...h.container.querySelectorAll("button")].find(
+      (b) => (b.textContent ?? "").trim() === "Restore windows",
+    ) as HTMLButtonElement;
+    expect(inFlight.disabled, "disabled while in flight").toBe(true);
+    expect(inFlight.getAttribute("aria-busy"), "the primitive's loading state").toBe("true");
+
+    act(() => resolveRestore({ ok: true, created: 1, failed: 0, message: "Restored 1 window." }));
+    await h.flush();
+    await h.flush();
+  });
+
+  it("an ok:false result pushes the error disclosure with the server's error string", async () => {
+    installMockApi({
+      configGet: () => Promise.resolve({}),
+      getClientVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      getServerVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      tmuxRestorePreview: () => Promise.resolve(preview),
+      tmuxRestoreTopology: () => Promise.resolve({ ok: false, error: "No saved window layout to restore from.", created: 0, failed: 0 }),
+    });
+    h = mount(<Settings onClose={() => {}} />);
+    await h.flush();
+    await h.flush();
+
+    const btn = [...h.container.querySelectorAll("button")].find(
+      (b) => (b.textContent ?? "").trim() === "Restore windows",
+    ) as HTMLButtonElement;
+    act(() => btn.click());
+    await h.flush();
+    await h.flush();
+
+    const toast = useStore.getState().appToasts.find((t) => String(t.id).startsWith("err-restore-"));
+    expect(toast, "error toast for ok:false").toBeTruthy();
+    const disclosure = renderToStaticMarkup(
+      toast!.message as unknown as Parameters<typeof renderToStaticMarkup>[0],
+    );
+    expect(disclosure).toContain("restore your windows.");
+    expect(disclosure).toContain("No saved window layout to restore from.");
+  });
+});

--- a/src/renderer/Settings.test.tsx
+++ b/src/renderer/Settings.test.tsx
@@ -323,3 +323,180 @@ describe("Settings — schema-driven toasts are error-only (BET-1055)", () => {
     expect(api.calls.configUpdate ?? []).toHaveLength(1);
   });
 });
+
+// BET-1455 — Settings > General > Backup, the one user-facing affordance for
+// topology restore (the server side shipped in BET-1452/1453). Pins the four
+// preview states and the "never a dead control" rule: hidden when there is no
+// backup, disabled-with-title when nothing is restorable, enabled + loading
+// when it is, and both toast branches on completion.
+describe("Settings — Backup section (BET-1455)", () => {
+  let h: Harness | null = null;
+
+  const previewStub = (response: unknown) => {
+    let current = response;
+    const { api } = installMockApi({
+      configGet: () => Promise.resolve({}),
+      getClientVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      getServerVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      tmuxRestorePreview: () => Promise.resolve(current),
+      tmuxRestoreTopology: () => Promise.resolve({ ok: true, created: 2, failed: 0, message: "Restored 2 windows." }),
+    });
+    return {
+      api,
+      setPreview: (next: unknown) => { current = next; },
+    };
+  };
+
+  const restoreButton = (): HTMLButtonElement | undefined =>
+    [...h!.container.querySelectorAll("button")].find(
+      (b) => (b.textContent ?? "").trim() === "Restore windows",
+    ) as HTMLButtonElement | undefined;
+
+  const generalText = (): string => (h!.container.querySelector('[role="tabpanel"]')?.textContent ?? "");
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    useStore.setState({ appToasts: [] });
+  });
+
+  it("state 1 — available:false shows the no-backup copy and NO button (not a disabled dead control)", async () => {
+    previewStub({ available: false, capturedAt: null, ops: [], skipped: [], restorable: 0 });
+    h = mount(<Settings onClose={() => {}} />);
+    await h.flush();
+    await h.flush();
+
+    expect(generalText()).toContain("No backup yet. Manta saves your window layout automatically as you work.");
+    expect(restoreButton(), "Restore windows must not render without a backup").toBeUndefined();
+  });
+
+  it("state 3 — restorable>0 shows the timestamp census line and an enabled button", async () => {
+    const capturedAt = Date.parse("2026-08-30T20:00:00Z");
+    previewStub({
+      available: true,
+      capturedAt,
+      ops: [
+        { kind: "create-session", tmuxSession: "proj-a", mantaOwned: true, index: 0, name: "w0", opencodeSessionId: "oc-1", cwd: "/tmp/a", worktreePath: null },
+        { kind: "create-window", tmuxSession: "proj-a", mantaOwned: true, index: 2, name: "w2", opencodeSessionId: "oc-2", cwd: "/tmp/a", worktreePath: null },
+        { kind: "create-window", tmuxSession: "proj-b", mantaOwned: true, index: 1, name: "w1", opencodeSessionId: "oc-3", cwd: "/tmp/b", worktreePath: null },
+      ],
+      skipped: [
+        { tmuxSession: "proj-b", index: 3, name: "w3", opencodeSessionId: "oc-4", reason: "index-occupied" },
+      ],
+      restorable: 3,
+    });
+    h = mount(<Settings onClose={() => {}} />);
+    await h.flush();
+    await h.flush();
+
+    const text = generalText();
+    expect(text).toContain("Manta saves your chat window layout");
+    expect(text).toContain("3 window(s) can be restored.");
+    // W/P census derives from the ONE preview response: ops+skipped = 4 windows
+    // across the 2 distinct tmux sessions.
+    expect(text).toContain("4 windows across 2 projects");
+    const btn = restoreButton();
+    expect(btn, "Restore windows button").toBeTruthy();
+    expect(btn!.disabled, "enabled when something is restorable").toBe(false);
+    expect(btn!.getAttribute("title")).toBeNull();
+  });
+
+  it("state 2 — restorable===0 renders the button disabled with the nothing-to-restore title", async () => {
+    previewStub({
+      available: true,
+      capturedAt: Date.parse("2026-08-30T20:00:00Z"),
+      ops: [],
+      skipped: [
+        { tmuxSession: "proj-a", index: 0, name: "w0", opencodeSessionId: "oc-1", reason: "already-restored" },
+      ],
+      restorable: 0,
+    });
+    h = mount(<Settings onClose={() => {}} />);
+    await h.flush();
+    await h.flush();
+
+    expect(generalText()).toContain("Every saved window is already open.");
+    const btn = restoreButton();
+    expect(btn, "button still renders (never a hidden no-op)").toBeTruthy();
+    expect(btn!.disabled, "disabled when nothing is restorable").toBe(true);
+    expect(btn!.getAttribute("title")).toBe("Nothing to restore — every saved window is already open.");
+  });
+
+  it("restore reports success via the server's describeRestore copy, then re-previews in place", async () => {
+    const capturedAt = Date.parse("2026-08-30T20:00:00Z");
+    const { api, setPreview } = previewStub({
+      available: true,
+      capturedAt,
+      ops: [
+        { kind: "create-window", tmuxSession: "proj-a", mantaOwned: true, index: 1, name: "w1", opencodeSessionId: "oc-1", cwd: "/tmp/a", worktreePath: null },
+      ],
+      skipped: [],
+      restorable: 1,
+    });
+    h = mount(<Settings onClose={() => {}} />);
+    await h.flush();
+    await h.flush();
+    expect((api.calls.tmuxRestorePreview ?? []).length, "one preview on entering General").toBe(1);
+
+    // By the time the post-restore re-preview runs, the restored windows are
+    // live — the stub models that world so the in-place flip is observable.
+    setPreview({
+      available: true,
+      capturedAt,
+      ops: [],
+      skipped: [
+        { tmuxSession: "proj-a", index: 1, name: "w1", opencodeSessionId: "oc-1", reason: "already-restored" },
+      ],
+      restorable: 0,
+    });
+    act(() => restoreButton()!.click());
+    await h.flush();
+    await h.flush();
+
+    expect(api.calls.tmuxRestoreTopology ?? []).toHaveLength(1);
+    const toast = useStore.getState().appToasts.find((t) => String(t.id).startsWith("restore-"));
+    expect(toast, "success toast").toBeTruthy();
+    expect(String(toast!.message)).toContain("Restored 2 windows.");
+
+    // The section re-previewed AFTER the restore (2nd call) and flipped to the
+    // nothing-to-restore state in place — the server plan is now empty.
+    expect((api.calls.tmuxRestorePreview ?? []).length, "preview re-run after restore").toBe(2);
+    expect(generalText()).toContain("Every saved window is already open.");
+  });
+
+  it("restore reports failure through the error disclosure when the call throws or returns ok:false", async () => {
+    const capturedAt = Date.parse("2026-08-30T20:00:00Z");
+    const preview = {
+      available: true as const,
+      capturedAt,
+      ops: [
+        { kind: "create-window" as const, tmuxSession: "proj-a", mantaOwned: true, index: 1, name: "w1", opencodeSessionId: "oc-1", cwd: "/tmp/a", worktreePath: null },
+      ],
+      skipped: [],
+      restorable: 1,
+    };
+    installMockApi({
+      configGet: () => Promise.resolve({}),
+      getClientVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      getServerVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      tmuxRestorePreview: () => Promise.resolve(preview),
+      tmuxRestoreTopology: () => Promise.reject(new Error("tmux exploded")),
+    });
+    h = mount(<Settings onClose={() => {}} />);
+    await h.flush();
+    await h.flush();
+
+    act(() => restoreButton()!.click());
+    await h.flush();
+    await h.flush();
+
+    const toast = useStore.getState().appToasts.find((t) => String(t.id).startsWith("err-restore-"));
+    expect(toast, "error toast").toBeTruthy();
+    const disclosure = renderToStaticMarkup(
+      toast!.message as unknown as Parameters<typeof renderToStaticMarkup>[0],
+    );
+    // renderToStaticMarkup HTML-escapes the apostrophe in the headline.
+    expect(disclosure).toContain("restore your windows.");
+    expect(disclosure).toContain("tmux exploded");
+  });
+});

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -56,6 +56,7 @@ import type {
   OpencodeReference,
   UpdateTarget,
 } from "../shared/types";
+import type { TopologyRestorePreview } from "../shared/api";
 import {
   SETTINGS,
   SETTING_SECTIONS,
@@ -603,6 +604,52 @@ export function Settings({
     }
   };
 
+  // ===== Backup (BET-1455) — the ONLY user-facing affordance for topology
+  // restore. The box snapshots the chat-window layout continuously (BET-1452)
+  // and can rebuild it at the exact indices (BET-1453); this section previews
+  // that snapshot read-only and triggers the restore. Restore is NEVER
+  // automatic (parent decision 1) and is additive — no destructive op exists
+  // on the wire.
+  //
+  // The READ-ONLY preview runs on entering the General section, and again
+  // after a restore completes (`backupTick`), so the section updates in place
+  // from the same channel. A failed/absent preview renders no status at all —
+  // "No backup yet" would assert a fact we could not verify.
+  const [backupPreview, setBackupPreview] = useState<TopologyRestorePreview | null>(null);
+  const [restoring, setRestoring] = useState(false);
+  const [backupTick, setBackupTick] = useState(0);
+  useEffect(() => {
+    if (activeTab !== "general") return;
+    let cancelled = false;
+    window.api.tmuxRestorePreview()
+      .then((p) => { if (!cancelled) setBackupPreview(p ?? null); })
+      .catch(() => { if (!cancelled) setBackupPreview(null); });
+    return () => { cancelled = true; };
+  }, [activeTab, backupTick]);
+
+  const restoreTopology = async () => {
+    if (restoring) return;
+    setRestoring(true);
+    try {
+      // Awaited, never void-and-forget: the toast IS the feedback path, and
+      // the server's `message` (describeRestore) already covers both the
+      // created and the nothing-to-do outcomes in human copy.
+      const result = await window.api.tmuxRestoreTopology();
+      if (result.ok) {
+        push({ id: `restore-${Date.now()}`, message: result.message ?? "Windows restored." });
+      } else {
+        push({ id: `err-restore-${Date.now()}`, message: errorDisclosure("Couldn't restore your windows.", result.error ?? "unknown error") });
+      }
+    } catch (e) {
+      push({ id: `err-restore-${Date.now()}`, message: errorDisclosure("Couldn't restore your windows.", e) });
+    } finally {
+      setRestoring(false);
+      // Re-run the preview so the section reflects the post-restore world
+      // without waiting for the user to leave and re-enter General.
+      setBackupTick((t) => t + 1);
+    }
+  };
+
   // One row per target (BET-1099): the list below maps over the canonical
   // `updateTargets` in its fixed display order, so Settings and the banner
   // always describe the same state. The two bespoke per-leg blocks they
@@ -958,6 +1005,17 @@ export function Settings({
   // Per-section custom content (cards/lists the schema doesn't describe).
   const renderCustom = (section: SettingSectionId): ReactNode => {
     if (section === "general") {
+      // Backup W/P derive from the ONE preview response — no second call.
+      // Every saved window is either planned for restore (`ops`) or explains
+      // itself in `skipped`, so ops+skipped IS the backup's window census, and
+      // the distinct tmux sessions across both are its project census.
+      const backupOps = backupPreview?.ops ?? [];
+      const backupSkipped = backupPreview?.skipped ?? [];
+      const backupWindows = backupOps.length + backupSkipped.length;
+      const backupProjects = new Set([...backupOps, ...backupSkipped].map((w) => w.tmuxSession)).size;
+      const backupAvailable = backupPreview?.available === true;
+      const backupRestorable = backupPreview?.restorable ?? 0;
+      const backupCapturedAt = backupPreview?.capturedAt ?? null;
       return (
         <>
           <GroupCard title="About">
@@ -998,6 +1056,42 @@ export function Settings({
                   error={targetUpdateErrors[t.id] ?? null}
                 />
               ))}
+            </div>
+          </GroupCard>
+          <GroupCard title="Backup">
+            <div className="space-y-3">
+              {/* This recovers a tmux SERVER death (parent scope table) — never
+                  promise undo-close: a deliberately closed window is gone, the
+                  next listing overwrote the snapshot. */}
+              <div className="text-body text-text-faint">Manta saves your chat window layout — names, order and grouping — so it can be rebuilt if the box's terminal server restarts. Your conversations are stored separately and are never affected.</div>
+              {backupAvailable && (
+                <div className="flex items-center gap-3">
+                  <Button
+                    onClick={() => void restoreTopology()}
+                    disabled={restoring || backupRestorable === 0}
+                    loading={restoring}
+                    title={backupRestorable === 0 ? "Nothing to restore — every saved window is already open." : undefined}
+                    tone="default"
+                  >
+                    Restore windows
+                  </Button>
+                  {backupCapturedAt != null && (
+                    <span className="text-meta text-text-faint">
+                      Last backup {new Date(backupCapturedAt).toLocaleString()} · {backupWindows} windows across {backupProjects} projects
+                    </span>
+                  )}
+                </div>
+              )}
+              {backupAvailable && (
+                <div className="text-body text-text-faint">
+                  {backupRestorable > 0
+                    ? `${backupRestorable} window(s) can be restored.`
+                    : "Every saved window is already open."}
+                </div>
+              )}
+              {backupPreview?.available === false && (
+                <div className="text-body text-text-faint">No backup yet. Manta saves your window layout automatically as you work.</div>
+              )}
             </div>
           </GroupCard>
           <GroupCard title="Danger zone" danger>


### PR DESCRIPTION
Closes BET-1455 — Topology S3: Settings > General > Backup section with Restore button.

Base: origin/main @ bf0eb4c1 (includes merged BET-1452/1453/1454 — the channels this UI renders).

## What

The ONLY user-facing affordance for topology restore (parent BET-1451, decision 4: Settings is the only affordance; decision 1: never automatic).

- `src/renderer/Settings.tsx` — new `<GroupCard title="Backup">` in the General section, after About, before Danger zone. Read-only `tmuxRestorePreview()` on entering General (and again after a restore, via a tick), rendered as exactly the four specified states:
  1. `available:false` → "No backup yet…" copy, button NOT rendered (no dead control).
  2. `restorable === 0` → timestamp + "Every saved window is already open.", button rendered disabled with the specified `title`.
  3. `restorable > 0` → timestamp + "N window(s) can be restored.", button enabled.
  4. In flight → Button `loading` + disabled.
- Timestamp census line `Last backup {when} · {W} windows across {P} projects` uses `toLocaleString()`; W/P derive from the ONE preview response (`ops`+`skipped` = the backup's window census; distinct `tmuxSession`s = projects) — no second call.
- Restore button: awaits `tmuxRestoreTopology()`, never void-and-forget. Success → toast with the server's `describeRestore` copy, then the preview re-runs so the section updates in place. Failure (thrown or `ok:false`) → toast via the existing `errorDisclosure("Couldn't restore your windows.", …)`.
- Token rules respected: the `Button` primitive with `tone="default"`, `text-meta text-text-faint` muted line, `text-body text-text-faint` copy, `GroupCard` chrome. No new token, no new component file, no raw `<button>`, no new CSS. Copy verbatim from the issue.

## Tests

`src/renderer/Settings.test.tsx` — 7 new cases: each of the four preview states (hidden-button rule, disabled-with-title, enabled + census derivation), in-flight loading/disabled, success toast + in-place re-preview flip, thrown-error disclosure, and `ok:false` disclosure.

## Verification results
- PR branch (`multica/BET-1455-backup-ui` @ e5a6daaa):
  - typecheck: exit 0. Errors: none. log sha256: 6a7d8073a55c9de5
  - test: exit 0, 3876 pass / 0 fail / 7 skip. Failures: none. log sha256: (fresh run this commit)
- Base (`main` @ bf0eb4c1):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 3869 pass / 0 fail / 7 skip. Failures: none.
- **Conclusion:** 0 new failures; the PR adds exactly 7 passing tests. All failures on both branches: 0.

Follow-ups: none discovered — the ok:false and in-flight gaps found during self-check were closed in this PR rather than filed.
