### PR TITLE
BET-1462: fix CTO watchdog budget math + escalation latch

### DIFF
--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -212,37 +212,42 @@ export function overnightSpendUsd(rows, { now, modelCost = null } = {}) {
 // ---------------------------------------------------------------------------
 
 /**
- * The expected ambient $/hour, derived from the trailing 7-day ambient spend
- * (total / (7 × 24)). This is what the A2 watchdog compares the measured
- * per-hour burn against (>2× → auto-thrifty, >4× → auto-pause).
- *
- * Degenerate case: when the trailing 7-day history holds no spend (a fresh
- * box), we fall back to the cap-equivalent even pace (cap / 24) rather than 0 —
- * otherwise a box with no history would trip the watchdog instantly on its very
- * first ambient call.
+ * The expected ambient $/hour — the baseline the A2 watchdog compares the
+ * measured per-hour burn against (>2× → auto-thrifty, >4× → auto-pause).
+ * Derived from the trailing 7-day spend, divided by ACTIVE days only
+ * (day-buckets with non-zero spend, × 24) — a blanket 7×24 denominator crushed
+ * the baseline toward 0 on a box that spends on only a few days a week
+ * (BET-1462 defects 1–2). The result is floored at the cap-equivalent even
+ * pace (cap / 24): no history may push the baseline below what the box is
+ * configured to spend, or a tiny measured burn reads as a huge multiple and
+ * trips the watchdog (the 2026-08-31 auto-pause incident).
  */
 export function expectedHourlyBurnUsd(payload, { now, capUsd } = {}) {
   const t = typeof now === "number" && Number.isFinite(now) ? now : Date.now();
   const cap = dollar(capUsd);
   let total = 0;
+  let activeDays = 0;
   let sod = startOfDay(t);
   for (let i = 0; i < BURN_HISTORY_DAYS; i++) {
-    total += spendForDay(payload, String(sod));
+    const usd = spendForDay(payload, String(sod));
+    if (usd > 0) activeDays += 1;
+    total += usd;
     sod -= 24 * HOUR_MS;
   }
-  if (!(total > 0)) return cap / 24;
-  return dollar(total) / (BURN_HISTORY_DAYS * 24);
+  return Math.max(dollar(total) / (Math.max(1, activeDays) * 24), cap / 24);
 }
 
 /**
  * The measured ambient $/hour so far today — the watchdog's `getSpendPerHour`.
- * Returns 0 before the first hour of the day has elapsed.
+ * The divisor never drops below one hour: 30 seconds past local midnight a
+ * single $0.01 call measures $0.01/hr, not ~$1.20 (BET-1462 defect 3). At the
+ * exact midnight instant (0 hours elapsed) the reading is 0.
  */
 export function spendPerHourNow(payload, now) {
   const t = typeof now === "number" && Number.isFinite(now) ? now : Date.now();
   const h = hoursIntoLocalDay(t);
   if (h <= 0) return 0;
-  return todaySpend(payload, t) / h;
+  return todaySpend(payload, t) / Math.max(1, h);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -114,18 +114,42 @@ test("priceTokens prices via the model cost and a cache-heavy mix", () => {
 });
 
 test("expected hourly burn derives from trailing 7-day spend", () => {
-  // Spend $16.80 over 7 days → 16.80 / 168h = $0.10/h.
+  // Spend $16.80 over 7 days → 16.80 / 168h = $0.10/h — below the $2.50
+  // cap-equivalent pace, so the new floor wins (BET-1462 defect 1).
   let p = defaultBudgetPayload();
   for (let i = 0; i < 7; i++) {
     p = recordSpend(p, { now: MIDNIGHT + i * 86_400_000 + 1000, usd: 2.4 });
   }
   const burn = expectedHourlyBurnUsd(p, { now: MIDNIGHT + 6 * 86_400_000 + 2000, capUsd: 2.5 });
-  assert.ok(Math.abs(burn - 0.1) < 1e-9);
-  // Old spend ages out of the 7-day window: the day-7 bucket alone, /168h.
-  const onlyRecent = defaultBudgetPayload();
+  assert.ok(Math.abs(burn - 2.5 / 24) < 1e-9);
+  // Old spend ages out of the 7-day window: one active day → 1.68/24h = $0.07,
+  // again below the floor (BET-1462 defects 1+2).
   const p2 = recordSpend(defaultBudgetPayload(), { now: MIDNIGHT + 6 * 86_400_000 + 1000, usd: 1.68 });
   const burn2 = expectedHourlyBurnUsd(p2, { now: MIDNIGHT + 6 * 86_400_000 + 5000, capUsd: 2.5 });
-  assert.ok(Math.abs(burn2 - 1.68 / 168) < 1e-9);
+  assert.ok(Math.abs(burn2 - 2.5 / 24) < 1e-9);
+});
+
+test("BET-1462: expected burn floors at the cap-equivalent pace (incident numbers)", () => {
+  // 2026-08-31 incident: the box's 7-day ambient total was $0.00005173744. The
+  // old baseline ($0.00000031/hr, no floor) let today's $0.0000041/hr measured
+  // burn read as >4x and auto-pause the engine. With the floor, the same
+  // history yields the cap-equivalent pace.
+  const p = recordSpend(defaultBudgetPayload(), {
+    now: MIDNIGHT + 6 * 86_400_000 + 1000,
+    usd: 5.173744e-5,
+  });
+  const burn = expectedHourlyBurnUsd(p, { now: MIDNIGHT + 6 * 86_400_000 + 5000, capUsd: 2.5 });
+  assert.ok(Math.abs(burn - 2.5 / 24) < 1e-9);
+});
+
+test("BET-1462: a lone active day divides by 24h, not the blanket 168h", () => {
+  // A single $5 call inside an otherwise-empty trailing window: the active-day
+  // denominator (defect 2) measures $5/24 ≈ $0.2083 — above the $2.50 floor,
+  // so the division itself is observable (not 5/168 ≈ $0.0298).
+  const p = recordSpend(defaultBudgetPayload(), { now: MIDNIGHT + 6 * 86_400_000 + 1000, usd: 5 });
+  const burn = expectedHourlyBurnUsd(p, { now: MIDNIGHT + 6 * 86_400_000 + 5000, capUsd: 2.5 });
+  assert.ok(Math.abs(burn - 5 / 24) < 1e-9);
+  assert.ok(Math.abs(burn - 5 / 168) > 1e-9);
 });
 
 test("empty history falls back to the cap-equivalent pace (never 0)", () => {
@@ -137,6 +161,16 @@ test("spendPerHourNow measures today's burn vs hours elapsed", () => {
   const p = recordSpend(defaultBudgetPayload(), { now: NOON, usd: 1.2 }); // 12h into day
   assert.ok(Math.abs(spendPerHourNow(p, NOON) - 0.1) < 1e-9);
   assert.equal(spendPerHourNow(p, MIDNIGHT), 0); // 0 hours elapsed
+});
+
+test("BET-1462: spendPerHourNow never divides by a fraction of an hour", () => {
+  // 30 seconds past local midnight with $0.01 spent: the divisor is floored at
+  // 1 hour → $0.01/hr, not $0.01/0.0083h ≈ $1.20 (the 2026-08-31 trip shape).
+  const early = MIDNIGHT + 30_000;
+  const p = recordSpend(defaultBudgetPayload(), { now: early, usd: 0.01 });
+  const perHour = spendPerHourNow(p, early);
+  assert.ok(Math.abs(perHour - 0.01) < 1e-9);
+  assert.ok(Math.abs(perHour - 1.2) > 1e-9);
 });
 
 test("thrifty shed ladder: ordered shed vs the kept-to-last-token set", () => {
@@ -195,9 +229,9 @@ test("createCtoBudget records into an injected store and reports todayUsd/cap", 
   // A spend that crosses the cap is still recorded (it already happened);
   // the NEXT call gates. 
   // Expected burn + spend-per-hour derive from the same store. $2.50 today
-  // only (no older history) → $2.50 / 168h; the fresh-box fallback only fires
-  // when there is NO history at all.
-  assert.equal(await budget.expectedHourlyBurnUsd({ capUsd: 2.5 }), 2.5 / 168);
+  // only (one active day) → $2.50 / 24h, matching the cap-equivalent floor
+  // (BET-1462 defect 2 replaced the old blanket $2.50 / 168h).
+  assert.equal(await budget.expectedHourlyBurnUsd({ capUsd: 2.5 }), 2.5 / 24);
   assert.ok((await budget.spendPerHourUsd()) > 0);
 });
 

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -2530,21 +2530,42 @@ export function createWatchdog(deps = {}) {
     }
   }
 
+  // BET-1462 defect 4: read the engine's live gate state through its own state
+  // accessor before escalating — an escalation already in effect is never
+  // re-asserted (the cardOpen-latch shape from ctoProbes). A failed read
+  // escalates as before; a real overspend is never silently skipped.
+  async function escalationState() {
+    try {
+      const st = await engine.getState();
+      return {
+        paused: st?.pausedAt != null || st?.dot === DOT.PAUSED,
+        thrifty: st?.dot === DOT.THRIFTY,
+      };
+    } catch {
+      return { paused: false, thrifty: false };
+    }
+  }
+
   async function tick() {
     const burn = await getSpendPerHour();
     const expected = await expectedHourlyBurn();
-    if (burn > 4 * expected) {
-      await engine.hardPause({
-        reason: `ambient spend ${burn} > 4x expected ${expected}`,
-        source: "watchdog",
-      });
-      return;
-    }
     if (burn > 2 * expected) {
-      await engine.setThrifty(true, {
-        reason: `ambient spend ${burn} > 2x expected ${expected}`,
-        source: "watchdog",
-      });
+      const { paused, thrifty } = await escalationState();
+      if (burn > 4 * expected) {
+        if (!paused) {
+          await engine.hardPause({
+            reason: `ambient spend $${burn.toFixed(2)}/hr > 4x expected $${expected.toFixed(2)}/hr`,
+            source: "watchdog",
+          });
+        }
+        return;
+      }
+      if (!thrifty) {
+        await engine.setThrifty(true, {
+          reason: `ambient spend $${burn.toFixed(2)}/hr > 2x expected $${expected.toFixed(2)}/hr`,
+          source: "watchdog",
+        });
+      }
       return;
     }
     const age = now() - (typeof engine.lastHeartbeat === "function" ? engine.lastHeartbeat() : 0);

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -387,6 +387,81 @@ test("watchdog: stale engine heartbeat is flagged, state untouched", async () =>
   assert.ok(h.ledgerRows.find((r) => r.kind === "cto.watchdog_stale"));
 });
 
+test("watchdog: a second tick while already paused does not re-escalate (BET-1462)", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  const calls = { hardPause: 0, setThrifty: 0 };
+  // Spy over the engine's escalation verbs without disturbing anything else
+  // (prototype delegation, so the engine's lazy getters are never touched).
+  const spyEngine = Object.create(h.engine);
+  spyEngine.hardPause = async (arg) => {
+    calls.hardPause += 1;
+    return h.engine.hardPause(arg);
+  };
+  spyEngine.setThrifty = async (v, opts) => {
+    calls.setThrifty += 1;
+    return h.engine.setThrifty(v, opts);
+  };
+  const w = createWatchdog({
+    engine: spyEngine,
+    getSpendPerHour: async () => 5,
+    expectedHourlyBurn: async () => 1,
+    livenessMs: 120_000,
+    now: () => h.clock.ms,
+    ledger: { append: async (row) => h.ledgerRows.push(row) },
+  });
+  await w.tick(); // 5 > 4×1 → the one legitimate hard pause
+  assert.equal(calls.hardPause, 1);
+  assert.equal(h.killSwitchPaused, true);
+  assert.equal(h.pendingBlockers.length, 1);
+  await w.tick(); // still burning, but the pause is already in effect
+  assert.equal(calls.hardPause, 1);
+  assert.equal(h.pendingBlockers.length, 1);
+  assert.equal(h.ledgerRows.filter((r) => r.kind === "cto.hard_pause").length, 1);
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+});
+
+test("watchdog: already thrifty is never re-asserted (BET-1462)", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  const calls = { hardPause: 0, setThrifty: 0 };
+  const spyEngine = Object.create(h.engine);
+  spyEngine.hardPause = async (arg) => {
+    calls.hardPause += 1;
+    return h.engine.hardPause(arg);
+  };
+  spyEngine.setThrifty = async (v, opts) => {
+    calls.setThrifty += 1;
+    return h.engine.setThrifty(v, opts);
+  };
+  const w = createWatchdog({
+    engine: spyEngine,
+    getSpendPerHour: async () => 3,
+    expectedHourlyBurn: async () => 1,
+    livenessMs: 120_000,
+    now: () => h.clock.ms,
+    ledger: { append: async (row) => h.ledgerRows.push(row) },
+  });
+  await w.tick(); // 3 > 2×1 → the one legitimate thrifty flip
+  assert.equal(calls.setThrifty, 1);
+  assert.equal((await h.engine.getState()).dot, DOT.THRIFTY);
+  await w.tick(); // still >2×, but thrifty is already on → no re-assert
+  assert.equal(calls.setThrifty, 1);
+  assert.equal(h.ledgerRows.filter((r) => r.kind === "cto.thrifty_on").length, 1);
+});
+
+test("watchdog: the 2026-08-31 live values no longer pause the engine (BET-1462)", async () => {
+  // Incident: 7-day ambient total $5.173744e-05 against the live $2.50 cap.
+  // The fixed baseline floors at the cap-equivalent pace ($2.50/24), so the
+  // measured burn that tripped the old code ($4.1668e-06/hr) is far below
+  // even the 2× thrifty line.
+  const h = makeHarness({ ctoEnabled: true });
+  const w = makeWatchdog(h, { spend: 4.166828969341808e-6, expected: 2.5 / 24 });
+  await w.tick();
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  assert.equal(h.killSwitchPaused, false);
+  assert.ok(!h.ledgerRows.some((r) => r.kind === "cto.hard_pause"));
+  assert.ok(!h.ledgerRows.some((r) => r.kind.startsWith("cto.thrifty")));
+});
+
 test("rate tracker slides the hourly window", async () => {
   const clock = { ms: 5_000 };
   const now = () => clock.ms;


### PR DESCRIPTION
Closes BET-1462. Fixes the 2026-08-31 watchdog auto-pause: the engine paused itself over ~$0.0000041/hr of real spend because its baseline was computed from degenerate budget math, then re-escalated on every tick.

**Defects fixed (per the issue):**

1. **Baseline floor** — `expectedHourlyBurnUsd` now floors at the cap-equivalent even pace (`cap/24`) for all inputs, not only empty history. The `if (!(total > 0))` early return is folded into a single `Math.max(...)` expression.
2. **Active-day denominator** — the trailing 7-day total divides by `max(1, activeDays) × 24` (day-buckets with non-zero spend), not a blanket `7 × 24`, which crushed the baseline toward 0 on sparsely-spending boxes.
3. **Fractional-hour divisor** — `spendPerHourNow` divides by `Math.max(1, h)`: 30 seconds past midnight with $0.01 spent reads $0.01/hr, not ~$1.20/hr. The `h <= 0` guard is kept — it is still reachable at the exact midnight instant and pinned by the existing `spendPerHourNow(p, MIDNIGHT) === 0` case.
4. **Escalation latch** — `createWatchdog` reads the engine's live gate state (its existing `getState()` accessor, which flows through the gate context) before escalating and never re-asserts a pause or thrifty flip already in effect — the `cardOpen` latch shape from `ctoProbes.mjs`. A failed state read escalates as before. The watchdog adds no local flag and no new engine accessor.
5. **Formatting** — escalation reasons now render money as `$0.00/hr` via inline `.toFixed(2)` (no shared currency formatter exists in the server tree; none added).

**Tests** (all in the existing files): incident-number floor case, lone-active-day ÷24 case, 30-seconds-past-midnight case, second-tick-no-re-escalate (spy on the escalation verbs), already-thrifty no-re-assert, and a live-values watchdog case asserting no pause. Two existing pins updated per the issue's instruction ("same spends, same window, floors applied"): the `trailing 7-day spend` test's two cases now assert the floored values, and the `createCtoBudget records…` case asserted `2.5/168` — the same defect-2 behavior in a third test — so it now pins `2.5/24` (flagging this one explicitly since the issue listed only the first by name).

**Out of scope, untouched:** `index.mjs` wiring (no change needed — it already passes `capUsd` through), `hoursIntoLocalDay`, `todaySpend`.

**Verification:** `npm run typecheck` ✅, `npm test` ✅ (3713/3713, including the six new/updated cases). Note: running `node --test src/server/ctoEngine.test.mjs` bare fails one pre-existing sandboxed-fs test (`createKillSwitch`); it passes under `npm test`, which sets the state-dir sandbox env var.
