### PR TITLE
fix(renderer): CTO S3b renderer correctness (BET-1467)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -38,6 +38,7 @@ import {
   showPausedBanner,
   statDisplay,
   nowCostLabel,
+  blockerCards,
   decisionCards,
   vetoCards,
   connectCards,
@@ -164,13 +165,18 @@ export function CtoPanel({
   const [tonightLoading, setTonightLoading] = useState(false);
   const [tonightPinned, setTonightPinned] = useState(false);
   const [tonightWindowOpen, setTonightWindowOpen] = useState(false);
-  const blockerCards = useMemo(() => cards.filter((c) => c.variant !== "decision" && c.variant !== "veto"), [cards]);
+  const blockerCardList = useMemo(() => blockerCards(cards as unknown as ReadonlyArray<Record<string, unknown>>), [cards]);
   const suggestionCards = useMemo(() => decisionCards(cards), [cards]);
   const vetoList = useMemo(() => vetoCards(cards as unknown as ReadonlyArray<Record<string, unknown>>), [cards]);
   const connectList = useMemo(() => connectCards(cards as unknown as ReadonlyArray<Record<string, unknown>>), [cards]);
 
   const busy = digestBusy(state);
   const busyRef = useRef(busy);
+  // §10.2: after a generation settles with an otherwise-empty overview, scroll
+  // the resting line into view. Advanced from the single busyRef-bookkeeping
+  // effect below (BET-1467: two effects used to share this ref, so the second
+  // always read prev === busy and this never fired).
+  const [didSettle, setDidSettle] = useState(false);
 
   // §10.6-5: the kill switch being active drives the banner via the pure
   // state→banner selector (tested in ctoView.test.ts).
@@ -221,6 +227,7 @@ export function CtoPanel({
     if (generationSettled) {
       void window.api?.ctoDigestGet?.().then((r) => setDigest(r.digest)).catch(() => {});
       void window.api?.ctoFinishedGet?.().then((r) => setFinished(r.items)).catch(() => {});
+      setDidSettle(true);
     }
   }, [busy]);
 
@@ -552,15 +559,7 @@ export function CtoPanel({
     digestHasItems: (digest?.items?.length ?? 0) > 0,
   });
 
-  // §10.2: after a generation settles with an otherwise-empty overview, scroll
-  // the resting line into view. (useRef kept in the effect-scope-free form.)
   const restingRef = useRef<HTMLDivElement>(null);
-  const [didSettle, setDidSettle] = useState(false);
-  useEffect(() => {
-    const prev = busyRef.current;
-    busyRef.current = busy;
-    if (prev && !busy) setDidSettle(true);
-  }, [busy]);
   useEffect(() => {
     if (didSettle && isResting) {
       restingRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -654,7 +653,7 @@ export function CtoPanel({
           {/* Learning card (§10.6-4): cold-start backfill progress (BET-1387).
               Informational — never counts into the sidebar badge. */}
           <BackfillCard state={state} />
-          <BlockerSection cards={blockerCards} now={Date.now()} onAnswer={handleAnswer} />
+          <BlockerSection cards={blockerCardList} now={Date.now()} onAnswer={handleAnswer} />
           <VetoSection cards={vetoList} now={Date.now()} onCancel={handleVetoCancel} onEditPlan={handleVetoEditPlan} onRunNow={handleVetoRunNow} />
           <ConnectSection cards={connectList} onAnswer={handleConnectAnswer} />
           <SuggestionSection cards={suggestionCards} onAction={handleSuggestionAction} onDismiss={handleSuggestionDismiss} />
@@ -940,7 +939,7 @@ function SettingsView({
           <section className="rounded-lg border border-border-subtle p-4">
             <h3 className="text-sm font-semibold text-text">Behavior</h3>
             <p className="mt-1 text-sm text-text-faint">
-              One hard daily cap (<span className="font-mono">${config?.ctoAmbientCap ?? 2.5}</span>)
+              One hard daily cap (<span className="font-mono">${(config?.ctoAmbientCap ?? 2.5).toFixed(2)}</span>)
               bounds all autonomous work, independent of the effort dial.
             </p>
 
@@ -1143,7 +1142,7 @@ function SettingsView({
                   <li key={id} className="flex items-baseline justify-between gap-3 py-2">
                     <span className="text-sm text-text-muted">{stat.label}</span>
                     <span className={"text-right text-sm " + (d.ready ? "font-mono text-text" : "text-text-faint")}>
-                      {d.ready ? d.text : <><span>{stat.label}</span> · {d.text}</>}
+                      {d.text}
                     </span>
                   </li>
                 );
@@ -1716,7 +1715,9 @@ function ProfileView({
                           </div>
                           <div className="mt-1 flex min-w-0 flex-wrap items-center gap-1 text-[11px]">
                             {s.source === "stated" ? (
-                              <span className="text-text">stated: {s.statedValue}</span>
+                              <span className="text-text">
+                                stated: {typeof s.statedValue === "number" ? s.statedValue.toFixed(2) : s.statedValue}
+                              </span>
                             ) : s.topEvidence && s.topEvidence.length ? (
                               s.topEvidence.slice(0, 3).map((ref) => (
                                 <button
@@ -2506,7 +2507,7 @@ function ToolIntegrationsView({
           </span>
         ) : null}
         <span className="ml-auto text-[11px] text-text-faint">
-          {row.uses} uses · {row.weeksActive} wk active · ewma {row.ewmaPerWeek}/wk
+          {row.uses} uses · {row.weeksActive} wk active · ewma {Math.round(row.ewmaPerWeek * 100) / 100}/wk
         </span>
       </div>
       <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-text-faint">

--- a/src/renderer/ctoSections.tsx
+++ b/src/renderer/ctoSections.tsx
@@ -384,13 +384,13 @@ export const NowRail = memo(function NowRail({ cards }: { cards: NowCard[] }) {
             key={card.id}
             type="button"
             onClick={card.onClick}
-            className="flex flex-col gap-2 rounded-md border border-strong bg-fill p-3 text-left hover:bg-fill-hover"
+            className="min-w-0 flex flex-col gap-2 rounded-md border border-strong bg-fill p-3 text-left hover:bg-fill-hover"
           >
             <div className="flex items-center gap-2">
               <span
                 className={`h-2 w-2 shrink-0 rounded-full ${card.state === "blocked" ? "bg-danger" : "bg-accent"}`}
               />
-              <span className="truncate text-sm font-medium text-text">{card.name}</span>
+              <span className="min-w-0 flex-1 truncate text-sm font-medium text-text">{card.name}</span>
               <span className="ml-auto shrink-0 rounded-full bg-fill-active px-2 py-1 text-[11px] font-medium capitalize text-text-muted">
                 {card.state}
               </span>

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -382,6 +382,8 @@ describe("nowRailMeta (§10.4 project · cost · elapsed)", () => {
 // ---------------------------------------------------------------------------
 
 import {
+  blockerCards,
+  connectCards,
   decisionCards,
   executeSuggestionOption,
   runnableSuggestionOption,
@@ -520,6 +522,52 @@ it("vetoCards: selects veto-variant cards with the countdown fields", () => {
   expect(out[0].id).toBe("overnight:veto");
   expect(out[0].dueMs).toBe(5000);
   expect(out[0].options[0].action.type).toBe("veto-cancel");
+});
+
+// ---------------------------------------------------------------------------
+// BET-1467 — blocker/veto/connect selectors: positive selection + contentless
+// rows are dropped before they reach a component with live buttons.
+// ---------------------------------------------------------------------------
+
+it("blockerCards: selects blocker-variant cards only — a connect card is NOT selected", () => {
+  const cards = [
+    { id: "b1", variant: "blocker", title: "blk", body: "answer this" },
+    { id: "d1", variant: "decision", title: "dec" },
+    { id: "v1", variant: "veto", title: "vet" },
+    { id: "c1", variant: "connect", title: "con" },
+  ];
+  const out = blockerCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  expect(out.length).toBe(1);
+  expect(out[0].id).toBe("b1");
+});
+
+it("blockerCards: drops a row with neither title nor body", () => {
+  const cards = [
+    { id: "b1", variant: "blocker", title: "", body: "" },
+    { id: "b2", variant: "blocker", title: "", body: "has body" },
+    { id: "b3", variant: "blocker", title: "has title", body: "" },
+  ];
+  const out = blockerCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  expect(out.map((c) => c.id)).toEqual(["b2", "b3"]);
+});
+
+it("vetoCards: drops a row with neither title nor body", () => {
+  const cards = [
+    { id: "v1", variant: "veto", title: "", body: "", dueMs: 1000, options: [] },
+    { id: "v2", variant: "veto", title: "Overnight run planned", body: "", dueMs: 1000, options: [] },
+  ];
+  const out = vetoCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  expect(out.map((c) => c.id)).toEqual(["v2"]);
+});
+
+it("connectCards: selects connect-variant cards and drops a row with neither title nor body", () => {
+  const cards = [
+    { id: "b1", variant: "blocker", title: "blk" },
+    { id: "c1", variant: "connect", title: "", body: "", options: [] },
+    { id: "c2", variant: "connect", title: "GitHub", body: "used 6 times this week", options: [] },
+  ];
+  const out = connectCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  expect(out.map((c) => c.id)).toEqual(["c2"]);
 });
 
 it("countdownRemaining: ms left, null once due or without a dueMs", () => {

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -327,6 +327,28 @@ export type BlockerCard = {
   refs: string[];
 };
 
+// Selector: the open blocker cards among the wire cards (§10.3). Selected
+// POSITIVELY (`variant === "blocker"`) rather than by excluding the other
+// variants — a denylist that must be updated whenever a variant is added is
+// exactly the defect that let connect cards double-render as dead-end
+// blockers (BET-1467). Also drops a row with neither title nor body so an
+// empty card never reaches BlockerSection's live "Answer now" control.
+export function blockerCards(cards: ReadonlyArray<Record<string, unknown>>): BlockerCard[] {
+  return (cards ?? [])
+    .filter((c) => c?.variant === "blocker")
+    .map((c) => ({
+      id: String(c.id ?? ""),
+      title: String(c.title ?? ""),
+      body: String(c.body ?? ""),
+      sourceKind: String(c.sourceKind ?? ""),
+      sourceId: typeof c.sourceId === "string" ? c.sourceId : null,
+      sessionID: typeof c.sessionID === "string" ? c.sessionID : null,
+      pendingSince: Number.isFinite(c.pendingSince) ? (c.pendingSince as number) : 0,
+      refs: Array.isArray(c.refs) ? (c.refs as string[]) : [],
+    }))
+    .filter((c) => c.title || c.body);
+}
+
 // Readable relative time (age stamps, Just-finished relative time). Short
 // forms: "<1m", "<Nm", "<Nh", "Nd". Pure + deterministic for a given clock.
 export function relativeTime(ts: number, now: number): string {
@@ -513,13 +535,16 @@ export type VetoCardRow = {
 };
 
 export function vetoCards(cards: ReadonlyArray<Record<string, unknown>>): VetoCardRow[] {
-  return (cards ?? []).filter((c) => c?.variant === "veto").map((c) => ({
-    id: String(c.id ?? ""),
-    title: String(c.title ?? ""),
-    body: String(c.body ?? ""),
-    dueMs: Number.isFinite(c.dueMs) ? (c.dueMs as number) : null,
-    options: Array.isArray(c.options) ? (c.options as VetoCardRow["options"]) : [],
-  }));
+  return (cards ?? [])
+    .filter((c) => c?.variant === "veto")
+    .map((c) => ({
+      id: String(c.id ?? ""),
+      title: String(c.title ?? ""),
+      body: String(c.body ?? ""),
+      dueMs: Number.isFinite(c.dueMs) ? (c.dueMs as number) : null,
+      options: Array.isArray(c.options) ? (c.options as VetoCardRow["options"]) : [],
+    }))
+    .filter((c) => c.title || c.body);
 }
 
 // BET-1395: the open connect-ask cards (§10.3 connect variant) among the wire
@@ -550,7 +575,8 @@ export function connectCards(cards: ReadonlyArray<Record<string, unknown>>): Con
             }),
           )
         : [],
-    }));
+    }))
+    .filter((c) => c.title || c.body);
 }
 
 // Live countdown to a veto card's `dueMs`: the ms remaining (≥ 0), or null

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -248,8 +248,10 @@ export type CtoState = {
 };
 
 // An open needs-you card row (§10.3), as served by GET /api/cto/cards (a thin
-// read of the A8 card store). Only `blocker` variant rows are written today;
-// the decision/veto/connect variants are reserved for later writers (§13.1).
+// read of the A8 card store). All four variants are live writers today:
+// `blocker` (ctoCardStore), `decision` (BET-1392), `veto` (BET-1419), and
+// `connect` (ctoToolRegistry). Consumers must select positively on the
+// variant they want — see BET-1467.
 export type CtoCard = {
   id: string;
   variant: "blocker" | "decision" | "veto" | "connect";


### PR DESCRIPTION
Renderer-only fixes for BET-1467 (parent BET-1461, stage 3). No new component, no new utility module, no new CSS variable — every fix reuses an in-file precedent.

**Base:** `origin/main` @ `6c476f33`

## What changed

1. **Connect cards render twice, second time as a dead-end blocker** — `blockerCards` now selects `variant === "blocker"` positively instead of a denylist (`!== "decision" && !== "veto"`) that silently let `connect` through. Extracted the selector into `ctoView.ts` (mirroring `decisionCards`/`vetoCards`/`connectCards`) so it's unit-testable. Fixed the stale `src/shared/api.ts` comment that claimed only `blocker` was written.
2. **Now-rail cards overflow their column** — added `min-w-0` to the card `<button>` grid item and `min-w-0 flex-1` to the truncating title `<span>`, matching the existing `BlockerSection`/`JustFinishedRail` pattern.
3. **Contentless cards render as empty actionable boxes** — `blockerCards`/`vetoCards`/`connectCards` in `ctoView.ts` now drop a row with neither title nor body before it reaches a component with a live button (single filter at the mapper, not three per-component fallbacks).
4. **Dead scroll-into-view effect** — two `useEffect`s shared `busyRef` and ran in declaration order, so the second effect's `prev` always equaled the current `busy` and `didSettle` never flipped. Merged into one place that advances `busyRef` (the digest/finished reload effect); the scroll effect now reacts to `didSettle`.
5. **Duplicated Health row label** — the not-ready value column re-rendered `{stat.label}` alongside the already-rendered row label. Now renders only `{d.text}`.
6. **Raw floats** — `ewma {row.ewmaPerWeek}/wk` now matches the vitality ewma's `Math.round(x * 100) / 100`; the ambient-cap dollar figure and `stated: {s.statedValue}` now use `.toFixed(2)`, matching the `.toFixed(2)` used elsewhere in the same file.

## Tests

`ctoView.test.ts` (pure, no DOM):
- `blockerCards`: selects blocker-variant cards only (a connect/decision/veto card is not selected).
- `blockerCards` / `vetoCards` / `connectCards`: drop a row with neither title nor body.

Layout items (2, 5, 6) have no unit-test surface — verified by inspection against the precedent classes/formatting already used elsewhere in the same files, per the issue's own note.

## Verification results

- PR branch (`multica/BET-1467-cto-renderer-correctness` @ `988b06be`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`. vitest 3880 pass / 7 skip (3887); node:test 3713 pass / 0 fail. log sha256: `f11dc4064d806209c5ae63321987ffe14b7be86aeb2f5b60959267499b1a0eef`
- Base (`main` @ `6c476f33`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`. vitest 3876 pass / 7 skip (3883); node:test 3713 pass / 0 fail. log sha256: `17dec10d13668543d3a469d303600da652947e80f94fd9a724fe9f3096977316`
- **Conclusion:** 0 pre-existing failures, 0 new failures. The +4 vitest tests are the new `ctoView.test.ts` cases added by this PR; node:test (server) is untouched by this renderer-only change.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

## Scope note

Files touched match the issue's scope exactly (`CtoPanel.tsx`, `ctoSections.tsx`, `ctoView.ts`, `ctoView.test.ts`), plus the one-line `src/shared/api.ts` comment fix the issue explicitly called out. No loading-state, error-handling or dead-control changes — those are the stage-4 sibling issue's.
