### PR TITLE
fix(cto): health blocker card lifecycle + no-op-safe card writes + probe escalation latch (BET-1463)

### DIFF
--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -170,6 +170,26 @@ export function askQuestionText(evt) {
   return "";
 }
 
+// BET-1463 (defect 2): compare a freshly-built card against the existing open
+// card, ignoring `updatedAt` (which always moves — it is the "when did we
+// last check" stamp, not content). A content-identical rebuild is not a
+// change: no save, no CARD_CREATED ledger row. Arrays are compared by value.
+function cardContentEqual(a, b) {
+  if (!a || !b) return false;
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  keys.delete("updatedAt");
+  for (const key of keys) {
+    const av = a[key];
+    const bv = b[key];
+    if (Array.isArray(av) || Array.isArray(bv)) {
+      if (JSON.stringify(av ?? []) !== JSON.stringify(bv ?? [])) return false;
+    } else if (av !== bv) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // The card manager — injected store/ledger/clock.
 // ---------------------------------------------------------------------------
@@ -184,6 +204,19 @@ export function createCtoCards(deps = {}) {
     // and health cards keep the "no notification path" invariant.
     fireNotify = async () => {},
     now = () => Date.now(),
+    // BET-1463: the writer for consuming/dropping a `pendingBlockers` entry in
+    // engine-state.json once its health card has been upserted or its card
+    // has closed. This MUST route through the engine's own `patchEngineState`
+    // (ctoStores.mjs) so it shares the same process-wide mutex as every other
+    // engine-state writer (e.g. `recordBlocker`) — ctoCards.mjs deliberately
+    // does NOT import patchEngineState itself; the engine injects its own
+    // bound instance here, the same way it injects getSessionInfo /
+    // getDesktopPresence into sibling modules. `mutation` is the same
+    // shape patchEngineState accepts: a static patch object, or a
+    // `(fresh) => patch` function. Defaults to null (a no-op) so standalone/
+    // test usage that doesn't care about pendingBlockers lifecycle keeps
+    // working without wiring it.
+    patchEngineState: patchPendingBlockers = null,
   } = deps;
 
   // In-flight worker asks: sessionID -> { sourceKind, sourceId, sessionID,
@@ -284,6 +317,12 @@ export function createCtoCards(deps = {}) {
       pendingSince,
       created,
     });
+    // BET-1463 (defect 2): a byte-identical rebuild is not a change — no
+    // save, no ledger row. This is what stops an unanswered ask from being
+    // "re-created" every minute forever by promoteDue.
+    if (existing && cardContentEqual(existing, { ...card, updatedAt: ts })) {
+      return { changed: false, isNew: false };
+    }
     if (existing) {
       const idx = cards.indexOf(existing);
       cards[idx] = { ...existing, ...card, created, updatedAt: ts };
@@ -320,7 +359,55 @@ export function createCtoCards(deps = {}) {
       sessionID: card.sessionID,
       reason,
     });
+    // BET-1463 (defect 1): a closed health card's source entry must not
+    // survive in engine-state.json `pendingBlockers`, or the next card tick
+    // resurrects it (this is the "Resume doesn't work" bug). Covers
+    // resolveById AND dismissById since both call this helper.
+    if (card.sourceKind === HEALTH_SOURCE_KIND) {
+      await dropPendingBlocker(card.sourceId);
+    }
     return { changed: true, card };
+  }
+
+  // Remove one entry from `pendingBlockers` by its watchdog-assigned id (used
+  // when its health card closes — resolved or dismissed). Best-effort, and a
+  // pure no-op patch (no save) when the id is already gone.
+  async function dropPendingBlocker(id) {
+    if (id === undefined || id === null || typeof patchPendingBlockers !== "function") return;
+    try {
+      await patchPendingBlockers((fresh) => {
+        const pending = Array.isArray(fresh?.pendingBlockers) ? fresh.pendingBlockers : [];
+        const next = pending.filter((b) => b?.id !== id);
+        return next.length === pending.length ? {} : { pendingBlockers: next };
+      });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // Stamp every ingested `pendingBlockers` entry `resolved: true` in one
+  // batched patch (used right after ingestHealthEscalations processes them).
+  // Best-effort; a missed stamp just means the same entry (harmlessly)
+  // upserts the same card again next tick — the upsert itself is idempotent.
+  async function markPendingBlockersConsumed(ids) {
+    if (!ids.length || typeof patchPendingBlockers !== "function") return;
+    try {
+      await patchPendingBlockers((fresh) => {
+        const pending = Array.isArray(fresh?.pendingBlockers) ? fresh.pendingBlockers : [];
+        const idSet = new Set(ids);
+        let touched = false;
+        const next = pending.map((b) => {
+          if (b && idSet.has(b.id) && b.resolved !== true) {
+            touched = true;
+            return { ...b, resolved: true };
+          }
+          return b;
+        });
+        return touched ? { pendingBlockers: next } : {};
+      });
+    } catch {
+      /* best-effort */
+    }
   }
 
   // Resolve one open card by id → `resolved` state + a card.resolved ACTIVITY
@@ -392,6 +479,10 @@ export function createCtoCards(deps = {}) {
     }
     const pending = Array.isArray(payload?.pendingBlockers) ? payload.pendingBlockers : [];
     let changed = false;
+    // BET-1463 (defect 1): every entry ingested here gets stamped `resolved:
+    // true` below (once) so it is never reprocessed — this is what makes the
+    // `resolved !== true` filter below live instead of dead code.
+    const consumedIds = [];
     for (const b of pending) {
       if (b?.resolved === true) continue;
       const r = await upsertBlocker({
@@ -405,7 +496,9 @@ export function createCtoCards(deps = {}) {
         pendingSince: typeof b?.ts === "number" ? b.ts : ts,
       });
       changed = changed || r.changed;
+      if (b?.id !== undefined) consumedIds.push(b.id);
     }
+    await markPendingBlockersConsumed(consumedIds);
     return { changed };
   }
 
@@ -478,6 +571,12 @@ export function createCtoCards(deps = {}) {
       updatedAt: ts,
       state: "open",
     };
+    // BET-1463 (defect 2): same no-op rule as upsertBlocker — a byte-identical
+    // regeneration (e.g. a decision card re-derived unchanged, or an unarmed
+    // veto countdown) is not a change.
+    if (existing && cardContentEqual(existing, card)) {
+      return { changed: false, isNew: false };
+    }
     if (existing) {
       const idx = list.indexOf(existing);
       list[idx] = { ...existing, ...card, created, updatedAt: ts };
@@ -610,6 +709,7 @@ export function createCtoCards(deps = {}) {
     promoteDue,
     ingestHealthEscalations,
     onHealthRecovered,
+    upsertBlocker,
     resolveById,
     dismissById,
     upsertDecision,

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -170,6 +170,14 @@ export function askQuestionText(evt) {
   return "";
 }
 
+// BET-1463: the health-card grouping identity for one `pendingBlockers`
+// entry — every entry from the same underlying trip source (`recordBlocker`'s
+// `source` param, e.g. "watchdog" | "rate_limit") is the SAME ongoing
+// condition and folds into ONE card, never one card per entry.
+function healthGroupKey(b) {
+  return typeof b?.source === "string" && b.source ? b.source : "unknown";
+}
+
 // BET-1463 (defect 2): compare a freshly-built card against the existing open
 // card, ignoring `updatedAt` (which always moves — it is the "when did we
 // last check" stamp, not content). A content-identical rebuild is not a
@@ -359,25 +367,27 @@ export function createCtoCards(deps = {}) {
       sessionID: card.sessionID,
       reason,
     });
-    // BET-1463 (defect 1): a closed health card's source entry must not
-    // survive in engine-state.json `pendingBlockers`, or the next card tick
-    // resurrects it (this is the "Resume doesn't work" bug). Covers
-    // resolveById AND dismissById since both call this helper.
+    // BET-1463 (defect 1): every pendingBlockers entry that fed the closed
+    // health card must not survive in engine-state.json, or the next card
+    // tick resurrects it (this is the "Resume doesn't work" bug). Covers
+    // resolveById AND dismissById since both call this helper. `sourceId` for
+    // a health card is the trip's GROUP KEY (see `healthGroupKey` below), not
+    // one entry's id — multiple pendingBlockers entries fold into one card.
     if (card.sourceKind === HEALTH_SOURCE_KIND) {
-      await dropPendingBlocker(card.sourceId);
+      await dropPendingBlockersByGroup(card.sourceId);
     }
     return { changed: true, card };
   }
 
-  // Remove one entry from `pendingBlockers` by its watchdog-assigned id (used
+  // Remove every `pendingBlockers` entry belonging to one health group (used
   // when its health card closes — resolved or dismissed). Best-effort, and a
-  // pure no-op patch (no save) when the id is already gone.
-  async function dropPendingBlocker(id) {
-    if (id === undefined || id === null || typeof patchPendingBlockers !== "function") return;
+  // pure no-op patch (no save) when nothing in the group is left.
+  async function dropPendingBlockersByGroup(group) {
+    if (!group || typeof patchPendingBlockers !== "function") return;
     try {
       await patchPendingBlockers((fresh) => {
         const pending = Array.isArray(fresh?.pendingBlockers) ? fresh.pendingBlockers : [];
-        const next = pending.filter((b) => b?.id !== id);
+        const next = pending.filter((b) => healthGroupKey(b) !== group);
         return next.length === pending.length ? {} : { pendingBlockers: next };
       });
     } catch {
@@ -470,6 +480,15 @@ export function createCtoCards(deps = {}) {
   // Source (2): read the watchdog's blocker-card requests that A2 already
   // writes to engine-state.json `pendingBlockers` and turn the unresolved ones
   // into health blocker cards. `{changed}` for tests/diagnostics.
+  //
+  // BET-1463: one health CARD per underlying CONDITION (`healthGroupKey`),
+  // not one card per pendingBlockers ENTRY. This is the literal shape of the
+  // 2026-08-31 incident — a watchdog that (before BET-1462) re-tripped every
+  // tick wrote one new uniquely-id'd entry per trip, and keying the card by
+  // that per-entry id turned 82 trips into 82 "identical" cards. Repeat
+  // trips of the SAME condition upsert the one ongoing card in place
+  // (pendingSince = the EARLIEST trip still outstanding, body = the most
+  // recent reason) exactly like re-detecting the same worker ask never dups.
   async function ingestHealthEscalations({ ts = now() } = {}) {
     let payload;
     try {
@@ -478,26 +497,41 @@ export function createCtoCards(deps = {}) {
       return { changed: false };
     }
     const pending = Array.isArray(payload?.pendingBlockers) ? payload.pendingBlockers : [];
+    const unresolved = pending.filter((b) => b?.resolved !== true);
     let changed = false;
-    // BET-1463 (defect 1): every entry ingested here gets stamped `resolved:
-    // true` below (once) so it is never reprocessed — this is what makes the
-    // `resolved !== true` filter below live instead of dead code.
     const consumedIds = [];
-    for (const b of pending) {
-      if (b?.resolved === true) continue;
-      const r = await upsertBlocker({
-        sourceKind: HEALTH_SOURCE_KIND,
-        sourceId: b.id,
-        sessionID: undefined,
-        title: blockerTitle(HEALTH_SOURCE_KIND),
-        body: blockerBody(HEALTH_SOURCE_KIND, b?.reason),
-        refs: [],
-        ts,
-        pendingSince: typeof b?.ts === "number" ? b.ts : ts,
-      });
-      changed = changed || r.changed;
-      if (b?.id !== undefined) consumedIds.push(b.id);
+    if (unresolved.length) {
+      const groups = new Map();
+      for (const b of unresolved) {
+        const key = healthGroupKey(b);
+        const bts = typeof b?.ts === "number" ? b.ts : ts;
+        const group = groups.get(key) ?? { minTs: bts, latest: b, latestTs: bts, ids: [] };
+        if (bts < group.minTs) group.minTs = bts;
+        if (bts >= group.latestTs) {
+          group.latest = b;
+          group.latestTs = bts;
+        }
+        if (b?.id !== undefined) group.ids.push(b.id);
+        groups.set(key, group);
+      }
+      for (const [key, group] of groups) {
+        const r = await upsertBlocker({
+          sourceKind: HEALTH_SOURCE_KIND,
+          sourceId: key,
+          sessionID: undefined,
+          title: blockerTitle(HEALTH_SOURCE_KIND),
+          body: blockerBody(HEALTH_SOURCE_KIND, group.latest?.reason),
+          refs: [],
+          ts,
+          pendingSince: group.minTs,
+        });
+        changed = changed || r.changed;
+        consumedIds.push(...group.ids);
+      }
     }
+    // BET-1463 (defect 1): every entry ingested above gets stamped `resolved:
+    // true` here (once) so it is never reprocessed — this is what makes the
+    // `resolved !== true` filter above live instead of dead code.
     await markPendingBlockersConsumed(consumedIds);
     return { changed };
   }

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -345,6 +345,36 @@ test("createCtoCards exports upsertBlocker", () => {
   assert.equal(typeof cards.upsertBlocker, "function");
 });
 
+test("BET-1463: 82 pendingBlockers entries from the SAME watchdog trip source fold into ONE card, not 82", async () => {
+  // The literal shape of the 2026-08-31 incident: repeated watchdog trips
+  // each wrote a uniquely-id'd pendingBlockers entry with the same source.
+  const pendingBlockers = Array.from({ length: 82 }, (_, i) => ({
+    id: `trip-${i}`,
+    kind: "blocker",
+    source: "watchdog",
+    reason: `ambient spend ${i} > 4x expected`,
+    ts: 1_000_000 + i * 60_000,
+    resolved: false,
+  }));
+  const h = makeHarness({ pendingBlockers });
+
+  const r1 = await h.cards.ingestHealthEscalations();
+  assert.equal(r1.changed, true);
+  const open1 = h.store().cards.filter((c) => c.state === "open");
+  assert.equal(open1.length, 1, "at most one card after the first tick");
+  assert.equal(open1[0].pendingSince, 1_000_000, "pendingSince is the EARLIEST outstanding trip");
+  assert.ok(open1[0].body.includes("81"), "body carries the MOST RECENT reason");
+
+  const r2 = await h.cards.ingestHealthEscalations();
+  assert.equal(r2.changed, false, "second tick produces no new card / no new write");
+  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 1);
+  assert.equal(
+    h.engineStateSnapshot().pendingBlockers.filter((b) => b.resolved !== true).length,
+    0,
+    "every entry stamped consumed",
+  );
+});
+
 test("dismiss moves a card out of cards.json with a card.dismissed ledger row", async () => {
   const h = makeHarness();
   await h.cards.onAskStart({ sourceKind: "question", sourceId: "que_m", sessionID: "sM", body: "", ts: h.clock.ms });

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -15,13 +15,18 @@ import {
 } from "./ctoCards.mjs";
 
 // A fully-injected card harness: real in-memory card store, engine-state,
-// ledger and a clock we control. No real fs — pure behavior.
+// ledger and a clock we control. No real fs — pure behavior. The
+// `patchEngineState` seam mirrors the real ctoStores.mjs helper's contract
+// (a static patch object, or a `(fresh) => patch` function; a key set to
+// `undefined` deletes it) but without its mutex — fine for these
+// single-threaded, sequential-await tests.
 function makeHarness({ pendingBlockers = [], fireNotify = false } = {}) {
   const clock = { ms: 1_000_000 };
   let cardPayload = { v: 1, cards: [] };
   const ledgerRows = [];
   const notified = [];
   let engineState = { v: 1, pendingBlockers: [...pendingBlockers] };
+  const patchCalls = [];
 
   const cards = createCtoCards({
     cardStore: {
@@ -39,6 +44,18 @@ function makeHarness({ pendingBlockers = [], fireNotify = false } = {}) {
     ledger: { append: async (row) => ledgerRows.push(row) },
     ...(fireNotify ? { fireNotify: async (a) => notified.push(a) } : {}),
     now: () => clock.ms,
+    patchEngineState: async (mutation) => {
+      patchCalls.push(mutation);
+      const fresh = engineState;
+      const patch = typeof mutation === "function" ? await mutation(fresh) : mutation;
+      const next = { ...fresh };
+      for (const [k, v] of Object.entries(patch ?? {})) {
+        if (v === undefined) delete next[k];
+        else next[k] = v;
+      }
+      engineState = next;
+      return next;
+    },
   });
 
   return {
@@ -46,7 +63,9 @@ function makeHarness({ pendingBlockers = [], fireNotify = false } = {}) {
     clock,
     ledgerRows,
     notified,
+    patchCalls,
     store: () => cardPayload,
+    engineStateSnapshot: () => engineState,
     setCardPayload(p) {
       cardPayload = p;
     },
@@ -214,8 +233,11 @@ test("health escalation: watchdog pendingBlockers become health cards; recovery 
   assert.equal(open[0].variant, "blocker");
   assert.ok(open[0].body.includes("ambient spend"), "body carries the watchdog reason");
 
+  // BET-1463 (defect 1): ingesting the entry stamps it consumed on its own —
+  // no manual setPendingBlockers needed to simulate this any more.
+  assert.equal(h.engineStateSnapshot().pendingBlockers[0].resolved, true);
+
   // Resolved health cards are ignored (never re-created).
-  h.setPendingBlockers([{ id: "b1", resolved: true }]);
   await h.cards.ingestHealthEscalations();
   assert.equal(h.store().cards.filter((c) => c.state === "open").length, 1);
 
@@ -223,6 +245,104 @@ test("health escalation: watchdog pendingBlockers become health cards; recovery 
   await h.cards.onHealthRecovered();
   assert.equal(h.store().cards.filter((c) => c.state === "open").length, 0);
   assert.equal(h.ledgerRows.filter((r) => r.kind === CARD_RESOLVED).length, 1);
+});
+
+test("BET-1463 defect 1: ingesting a pending blocker stamps the entry consumed; a second ingest creates NO second card and appends NO second ledger row", async () => {
+  const h = makeHarness({
+    pendingBlockers: [{ id: "b1", source: "watchdog", reason: "r1", ts: 500, resolved: false }],
+  });
+
+  const r1 = await h.cards.ingestHealthEscalations();
+  assert.equal(r1.changed, true);
+  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 1);
+  const createdRows = h.ledgerRows.filter((r) => r.kind === CARD_CREATED);
+  assert.equal(createdRows.length, 1);
+
+  // Same entry, unresolved-by-hand-mutation would be the OLD bug; here the
+  // engine-state store itself was stamped by the first ingest.
+  const r2 = await h.cards.ingestHealthEscalations();
+  assert.equal(r2.changed, false, "the consumed entry is skipped, not re-upserted");
+  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 1, "still exactly one card");
+  assert.equal(h.ledgerRows.filter((r) => r.kind === CARD_CREATED).length, 1, "no second card.created row");
+});
+
+test("BET-1463 defect 1: resolving a health card removes its pendingBlockers entry, and a subsequent ingest does not recreate it (Resume regression)", async () => {
+  const h = makeHarness({
+    pendingBlockers: [{ id: "b1", source: "watchdog", reason: "ambient spend", ts: 500, resolved: false }],
+  });
+
+  await h.cards.ingestHealthEscalations();
+  const cardId = h.store().cards.find((c) => c.state === "open").id;
+  assert.equal(h.engineStateSnapshot().pendingBlockers.length, 1, "entry still present, just stamped consumed");
+
+  // User presses Resume -> onHealthRecovered resolves the open health card.
+  await h.cards.onHealthRecovered();
+  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 0);
+  // The regression this test guards: the entry itself must be GONE, not just
+  // marked resolved — otherwise the next card tick's ingest (via a NEW
+  // watchdog trip reusing state, or a stale resolved:false somehow) has
+  // nothing to resurrect from.
+  assert.equal(h.engineStateSnapshot().pendingBlockers.length, 0);
+
+  // A card tick after Resume must not bring the card back.
+  const r = await h.cards.ingestHealthEscalations();
+  assert.equal(r.changed, false);
+  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 0, "Resume actually works — no resurrection");
+  assert.equal(h.store().cards.find((c) => c.id === cardId), undefined);
+});
+
+test("BET-1463 defect 1: dismissing a health card also drops its pendingBlockers entry", async () => {
+  const h = makeHarness({
+    pendingBlockers: [{ id: "b1", source: "watchdog", reason: "ambient spend", ts: 500, resolved: false }],
+  });
+  await h.cards.ingestHealthEscalations();
+  const cardId = h.store().cards.find((c) => c.state === "open").id;
+
+  await h.cards.dismissById(cardId, { reason: "user dismissed" });
+  assert.equal(h.engineStateSnapshot().pendingBlockers.length, 0);
+
+  const r = await h.cards.ingestHealthEscalations();
+  assert.equal(r.changed, false);
+  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 0);
+});
+
+test("BET-1463 defect 2: a no-op re-upsert returns changed:false and appends no ledger row", async () => {
+  const h = makeHarness();
+  const args = {
+    sourceKind: "question",
+    sourceId: "que_noop",
+    sessionID: "sN",
+    title: "Question waiting",
+    body: "Pick one?",
+    refs: ["sN"],
+    ts: h.clock.ms,
+    pendingSince: h.clock.ms,
+  };
+
+  const first = await h.cards.upsertBlocker(args);
+  assert.equal(first.changed, true);
+  assert.equal(first.isNew, true);
+  assert.equal(h.ledgerRows.filter((r) => r.kind === CARD_CREATED).length, 1);
+
+  // Time moves on (as promoteDue's re-check would do), but nothing about the
+  // ask actually changed — re-upserting identical content must be a no-op.
+  h.advance(60_000);
+  const second = await h.cards.upsertBlocker({ ...args, ts: h.clock.ms });
+  assert.equal(second.changed, false);
+  assert.equal(second.isNew, false);
+  assert.equal(h.ledgerRows.filter((r) => r.kind === CARD_CREATED).length, 1, "no second ledger row");
+  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 1);
+
+  // A genuine content change still upserts.
+  h.advance(1000);
+  const third = await h.cards.upsertBlocker({ ...args, ts: h.clock.ms, body: "Pick one? (updated)" });
+  assert.equal(third.changed, true);
+  assert.equal(h.ledgerRows.filter((r) => r.kind === CARD_CREATED).length, 2);
+});
+
+test("createCtoCards exports upsertBlocker", () => {
+  const cards = createCtoCards();
+  assert.equal(typeof cards.upsertBlocker, "function");
 });
 
 test("dismiss moves a card out of cards.json with a card.dismissed ledger row", async () => {

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -309,7 +309,18 @@ export function createCtoEngine(deps = {}) {
     // (`cardFireNotify`) so an inbox `blocker` note (source 3) fires the one
     // notification on the live box.
     cardFireNotify = async () => {},
-    cards = createCtoCards({ fireNotify: cardFireNotify }),
+    // BET-1463: the cards module needs to consume/drop `pendingBlockers`
+    // entries in engine-state.json (mark ingested entries resolved; drop an
+    // entry when its health card closes) through the SAME sanctioned
+    // read-modify-write path `recordBlocker` uses below, so concurrent
+    // engine-state writers share one process-wide mutex. Inject a bound
+    // instance rather than letting ctoCards.mjs import patchEngineState
+    // itself — same seam pattern as getSessionInfo/getDesktopPresence.
+    cards = createCtoCards({
+      fireNotify: cardFireNotify,
+      engineState,
+      patchEngineState: (mutation) => patchEngineState(mutation, { engineState }),
+    }),
     // A5 evidence/presence seams (injected I/O — nothing here touches tmux /
     // push directly; index.mjs supplies the real resolvers).
     getSessionInfo = async () => ({ owner: "user", project: undefined }),

--- a/src/server/ctoProbes.mjs
+++ b/src/server/ctoProbes.mjs
@@ -1104,10 +1104,38 @@ export function createProbes(deps = {}) {
       }
     }
 
-    // Escalation / resolution (§10.6-7) — nextState already carries cardOpen.
+    // Escalation / resolution (§10.6-7). `nextState.cardOpen` is the pure
+    // state machine's INTENT ("this failure crossed the escalate threshold"),
+    // not a fact about the world — BET-1463 (defect 3): only latch `cardOpen`
+    // once the card write actually lands. A missing method (cards not wired)
+    // or a thrown write must NOT latch, or the escalation is marked "already
+    // surfaced" and silently never retried while the credential stays broken.
+    let cardOpen = nextState.cardOpen;
+    if (action === "escalate") {
+      cardOpen = false;
+      if (cards && typeof cards.upsertBlocker === "function") {
+        const copy = probeBlockerCopy(tool, key, spec.auth?.secret ?? null);
+        try {
+          const r = await cards.upsertBlocker({
+            sourceKind: PROBE_SOURCE_KIND,
+            sourceId: probeKey(tool, key),
+            title: copy.title,
+            body: copy.body,
+            refs: [tool],
+            ts,
+          });
+          cardOpen = r?.changed !== false;
+        } catch {
+          cardOpen = false;
+        }
+      }
+    } else if (action === "resolve" && cards && typeof cards.resolveById === "function") {
+      await cards.resolveById(stableCardId(PROBE_SOURCE_KIND, probeKey(tool, key)), { reason: "probe recovered", ts }).catch(() => {});
+    }
     const p = st.probes ?? {};
     p[key] = {
       ...nextState,
+      cardOpen,
       lastAt: ts,
       lastOk: ok,
       lastError: ok ? null : (error ?? "unknown"),
@@ -1115,21 +1143,6 @@ export function createProbes(deps = {}) {
       nextRunAt: ts + cadence,
     };
     st.probes = p;
-    if (action === "escalate" && cards && typeof cards.upsertBlocker === "function") {
-      const copy = probeBlockerCopy(tool, key, spec.auth?.secret ?? null);
-      await cards
-        .upsertBlocker({
-          sourceKind: PROBE_SOURCE_KIND,
-          sourceId: probeKey(tool, key),
-          title: copy.title,
-          body: copy.body,
-          refs: [tool],
-          ts,
-        })
-        .catch(() => {});
-    } else if (action === "resolve" && cards && typeof cards.resolveById === "function") {
-      await cards.resolveById(stableCardId(PROBE_SOURCE_KIND, probeKey(tool, key)), { reason: "probe recovered", ts }).catch(() => {});
-    }
     await saveToolState(tool, st);
     return row;
   }

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -31,7 +31,7 @@ import {
   validateProbeSpec,
   vitalityOf,
 } from "./ctoProbes.mjs";
-import { PROBE_SOURCE_KIND, probeBlockerCopy, stableCardId } from "./ctoCards.mjs";
+import { PROBE_SOURCE_KIND, createCtoCards, probeBlockerCopy, stableCardId } from "./ctoCards.mjs";
 
 // ---------------------------------------------------------------------------
 // Fakes
@@ -98,11 +98,20 @@ function fakeRegistry(rows = []) {
   };
 }
 
+// BET-1463 (defect 3): the real production bug was a fake `cards` double that
+// implemented a method (`upsertBlocker`) production's `createCtoCards()`
+// didn't actually export — the escalation guard's `typeof
+// cards.upsertBlocker === "function"` was true in every test and false on
+// the live box. Guard against that recurring: every method this fake defines
+// must be a real key of `createCtoCards()`'s return shape, or this throws at
+// module-load time instead of silently drifting from production again.
+const REAL_CARDS_KEYS = new Set(Object.keys(createCtoCards()));
+
 function fakeCards() {
   const upserts = [];
   const resolved = [];
   const open = [];
-  return {
+  const obj = {
     open,
     upserts,
     resolved,
@@ -122,6 +131,16 @@ function fakeCards() {
       return { changed: true };
     },
   };
+  for (const key of Object.keys(obj)) {
+    if (typeof obj[key] === "function" && !REAL_CARDS_KEYS.has(key)) {
+      throw new Error(
+        `fakeCards() defines "${key}" which createCtoCards() does not export — this is exactly the ` +
+          `BET-1463 defect 3 shape (a test double hiding a production gap). Fix createCtoCards()'s ` +
+          `return object, not this fake.`,
+      );
+    }
+  }
+  return obj;
 }
 
 function fakeLedger() {
@@ -606,6 +625,41 @@ test("a missing secret is auth-shaped (same rotated-key failure mode) and escala
   for (let i = 0; i < 3; i++) await eng.runDue({ forceTool: "github" });
   assert.equal(cards.upserts.length, 1);
   assert.match(cards.upserts[0].body, /GITHUB_TOKEN/);
+});
+
+test("BET-1463 defect 3: cardOpen is NOT latched when the card write is skipped (cards missing the method)", async () => {
+  // A `cards` double with no upsertBlocker at all — the exact shape of the
+  // pre-fix production bug (createCtoCards() didn't export it).
+  const skipCards = { async resolveById() { return { changed: false }; } };
+  const eng = build({ cards: skipCards, http: async () => ({ status: 401, bodyText: "" }) });
+  for (let i = 0; i < 3; i++) await eng.runDue({ forceTool: "github" });
+  const st = await eng.loadToolState("github");
+  assert.equal(st.probes.repo_events.cardOpen, false, "no write was attempted -> must not latch");
+});
+
+test("BET-1463 defect 3: cardOpen is NOT latched when the card write throws", async () => {
+  const throwCards = fakeCards();
+  throwCards.upsertBlocker = async () => {
+    throw new Error("store unavailable");
+  };
+  const eng = build({ cards: throwCards, http: async () => ({ status: 401, bodyText: "" }) });
+  for (let i = 0; i < 3; i++) await eng.runDue({ forceTool: "github" });
+  const st = await eng.loadToolState("github");
+  assert.equal(st.probes.repo_events.cardOpen, false, "a failed write must not latch cardOpen");
+});
+
+test("BET-1463 defect 3: a card write that failed before is retried on the next auth failure, not stuck forever", async () => {
+  const recoverCards = fakeCards();
+  // Seed state as if a prior run crossed the escalate threshold but the
+  // write failed (cardOpen correctly left false by the fix above).
+  const state = {
+    github: { probes: { repo_events: { fails: 3, authFails: 3, cardOpen: false, lastAt: 1, lastOk: false } } },
+  };
+  const eng = build({ cards: recoverCards, state, http: async () => ({ status: 401, bodyText: "" }) });
+  await eng.runDue({ forceTool: "github" });
+  assert.equal(recoverCards.upserts.length, 1, "escalation retries because it was never actually latched open");
+  const st = await eng.loadToolState("github");
+  assert.equal(st.probes.repo_events.cardOpen, true, "this time the write succeeded, so it latches");
 });
 
 test("non-auth failures (500s / timeouts) never escalate — health rows only", async () => {


### PR DESCRIPTION
## BET-1463: CTO S1b — health blockers must be dismissable; a no-op card write must do nothing

Base: origin/main @ 6c476f33

### Defect 1 — `pendingBlockers` lifecycle
- `ingestHealthEscalations` now stamps every ingested entry `resolved: true`
  via the engine's own `patchEngineState` (injected as a seam, not imported
  into `ctoCards.mjs`, so it shares the process-wide mutex with `recordBlocker`).
- Closing a health card (`resolveById`/`dismissById`, and `onHealthRecovered`
  which calls `resolveById`) drops every `pendingBlockers` entry belonging to
  that condition — this is the actual "Resume doesn't work" fix.
- Bonus (required by the acceptance criteria, not spelled out in the defect
  narrative but necessary for it): health cards are now keyed by the trip's
  `source` (e.g. `"watchdog"`), not the per-trip unique id — repeated trips of
  the SAME condition upsert ONE ongoing card in place instead of fanning out
  one card per `pendingBlockers` entry. Verified by replaying
  `/tmp/cto-backup-engine-state.json` (82 entries, all `source: "watchdog"`):
  one card tick -> 1 card, a second tick -> 0 new.

### Defect 2 — no-op writes now no-op
`upsertBlocker` and `upsertOpenCard` (used by `upsertDecision`/`upsertVeto`)
compare the freshly-built card against the existing open card (ignoring
`updatedAt`) and skip the save + `CARD_CREATED` ledger row when nothing
changed.

**Caller audit (per the issue's ask):** `ctoToolRegistry.mjs`'s
`upsertConnect` call sites ignore the return value — unaffected.
`ctoSuggest.mjs` DOES depend on the old always-`changed:true` semantics
(treats `changed:false` as "card machinery failed" and logs
`suggest.silent (no-card-path)`). That file is out of this issue's scope
(not in "Files in scope"), so I filed **BET-1477** (assigned `manta-pm`,
priority high) instead of patching it silently.

### Defect 3 — probe escalation could never actually latch a card
- `createCtoCards()` now exports `upsertBlocker` (it already existed,
  just wasn't in the returned object — the guard in `ctoProbes.mjs` was
  always false in production).
- `cardOpen` is only set `true` once the card write actually succeeds; a
  missing method or a thrown write leaves it `false` so the NEXT auth
  failure retries the escalation instead of being marked "already
  surfaced" forever.
- `ctoProbes.test.mjs`'s `fakeCards()` now throws at module load if it
  defines a method `createCtoCards()` doesn't actually export — the exact
  shape of the bug that let this ship green before.

### Files touched
`src/server/ctoCards.mjs`, `src/server/ctoEngine.mjs` (only the `cards =
createCtoCards({...})` wiring), `src/server/ctoProbes.mjs` (only the
escalation block), plus their `.test.mjs` files. `createWatchdog` and the
60s card-tick interval are untouched, as required.

### Verification results
- PR branch (`multica/BET-1463-cto-health-blocker-lifecycle` @ `$(git rev-parse --short HEAD)`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3722 pass / 0 fail / 0 skip. log sha256: `8db29d1574cd722ff75570fdfbb49abaab373739822e50560bf6c5cccd6c0997`
- Base (`main` @ `6c476f33`): unmodified — the pre-existing `createKillSwitch uses a real flag file` failure only reproduces when running `ctoEngine.test.mjs` in isolation outside the full `npm test` harness (confirmed identical on `main` via `git stash`); the full `npm test` run above (which is how CI runs it) is 3722/3722 green on this branch.
- **Conclusion:** 0 new failures, 0 pre-existing failures in the full-suite run.

Follow-up filed: BET-1477 (PM) — `ctoSuggest.mjs` caller drift from defect 2's semantics change.
