### PR TITLE
fix(server): count unchanged-card suggestion regeneration as surfaced, not silent (BET-1477)

### DIFF
--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -308,7 +308,10 @@ export function createCtoCards(deps = {}) {
 
   // Upsert one blocker card by its stable id. Idempotent on re-detection: the
   // existing open card is updated in place (title/body/refs/age preserved),
-  // never duplicated. Returns `{ changed, isNew }`.
+  // never duplicated. Returns `{ ok, changed, isNew }` — `ok` is true when
+  // the write path ran without exception (including the byte-identical
+  // no-op, where the card is already current), false when nothing was
+  // written (invalid args).
   async function upsertBlocker({ sourceKind, sourceId, sessionID, title, body, refs, ts = now(), pendingSince = ts }) {
     const id = stableCardId(sourceKind, sourceId);
     const { payload, cards } = await openCards();
@@ -329,7 +332,7 @@ export function createCtoCards(deps = {}) {
     // save, no ledger row. This is what stops an unanswered ask from being
     // "re-created" every minute forever by promoteDue.
     if (existing && cardContentEqual(existing, { ...card, updatedAt: ts })) {
-      return { changed: false, isNew: false };
+      return { ok: true, changed: false, isNew: false };
     }
     if (existing) {
       const idx = cards.indexOf(existing);
@@ -347,7 +350,7 @@ export function createCtoCards(deps = {}) {
       sessionID,
       refs: card.refs,
     });
-    return { changed: true, isNew: !existing };
+    return { ok: true, changed: true, isNew: !existing };
   }
 
   // Shared close-path for resolve/dismiss: remove one open card by id, save,
@@ -564,7 +567,7 @@ export function createCtoCards(deps = {}) {
   // deliberately out of scope for the server — option execution is the
   // renderer's job (§9.1 "option buttons execute a bound action").
   async function upsertDecision({ id, title, why, options = [], refs = [], evidence = [], sourceKind, cls, score, capped = false, ts = now() } = {}) {
-    if (!id || typeof id !== "string") return { changed: false, isNew: false };
+    if (!id || typeof id !== "string") return { ok: false, changed: false, isNew: false };
     return upsertOpenCard({
       id,
       variant: "decision",
@@ -607,9 +610,11 @@ export function createCtoCards(deps = {}) {
     };
     // BET-1463 (defect 2): same no-op rule as upsertBlocker — a byte-identical
     // regeneration (e.g. a decision card re-derived unchanged, or an unarmed
-    // veto countdown) is not a change.
+    // veto countdown) is not a change. BET-1477: the no-op still reports
+    // ok:true — the card is already on the board and current, which is a
+    // successful outcome for a caller branching on "did the card path work".
     if (existing && cardContentEqual(existing, card)) {
-      return { changed: false, isNew: false };
+      return { ok: true, changed: false, isNew: false };
     }
     if (existing) {
       const idx = list.indexOf(existing);
@@ -627,7 +632,7 @@ export function createCtoCards(deps = {}) {
       refs: card.refs,
       ...ledger,
     });
-    return { changed: true, isNew: !existing };
+    return { ok: true, changed: true, isNew: !existing };
   }
 
   // needs-you surface: only open cards count (§10.3 — resolved/dismissed cards
@@ -648,7 +653,7 @@ export function createCtoCards(deps = {}) {
   // points at; the engine resolves the card when the window opens (fulfilled),
   // cancels it (veto verdict) or abandons it (missed, §11.6).
   async function upsertVeto({ id, title, body, dueMs, options = [], refs = [], ts = now() } = {}) {
-    if (!id || typeof id !== "string") return { changed: false, isNew: false };
+    if (!id || typeof id !== "string") return { ok: false, changed: false, isNew: false };
     return upsertOpenCard({
       id,
       variant: "veto",

--- a/src/server/ctoSuggest.mjs
+++ b/src/server/ctoSuggest.mjs
@@ -665,19 +665,28 @@ export function createCtoSuggest(deps = {}) {
       // §9.2 veto-window verb: a card with a countdown that executes unless
       // cancelled (the cancel is a verdict, §9.4). BET-1419 ships the veto
       // card writer; until it lands the verb degrades to the ask card.
+      // BET-1477: `ok !== false` is the "card path worked" test — a resolved
+      // call whose return is the BET-1463 byte-identical no-op (`ok: true,
+      // changed: false`) means the veto card is ALREADY on the board and
+      // current: count it as surfaced (variant veto) with no new ledger row
+      // and no re-push (`isNew` false), never a veto→decision downgrade.
+      // Only a missing writer, a thrown write, or an explicit `ok: false`
+      // (invalid args) degrades the verb.
       if (decision.verb === "veto-window") {
-        let wrote = false;
+        let res = null;
         if (cards && typeof cards.upsertVeto === "function") {
           try {
-            const res = await cards.upsertVeto({ ...baseCard, variant: "veto", ts: now() });
-            wrote = res?.changed === true;
-            cardIsNew = res?.isNew === true;
+            res = await cards.upsertVeto({ ...baseCard, variant: "veto", ts: now() });
           } catch {
-            wrote = false;
+            res = null;
           }
         }
+        const wrote = !!res && res.ok !== false;
+        cardIsNew = res?.isNew === true;
         if (wrote) {
-          await ledgerAppend({ kind: "suggest.presented", cardId: c.id, class: c.class, variant: "veto", score: p, sourceKind: finding.sourceKind });
+          if (res.changed === true) {
+            await ledgerAppend({ kind: "suggest.presented", cardId: c.id, class: c.class, variant: "veto", score: p, sourceKind: finding.sourceKind });
+          }
           surfaced += 1;
           surfacedKind = "veto";
         } else {
@@ -686,20 +695,27 @@ export function createCtoSuggest(deps = {}) {
       }
 
       // ask verb → write (or upsert) the decision card.
+      // BET-1477: same `ok !== false` contract as the veto branch — a
+      // byte-identical regeneration of an unchanged decision card is
+      // "already surfaced, still current" (surfaced, no new ledger row, no
+      // re-push), NOT a `suggest.silent` no-card-path hold. Only a missing
+      // writer, a thrown write, or an explicit `ok: false` is a hold.
       if (!surfacedKind) {
         const card = { ...baseCard, variant: "decision" };
-        let wrote = false;
+        let res = null;
         if (cards && typeof cards.upsertDecision === "function") {
           try {
-            const res = await cards.upsertDecision({ ...card, ts: now() });
-            wrote = res?.changed === true;
-            cardIsNew = res?.isNew === true;
+            res = await cards.upsertDecision({ ...card, ts: now() });
           } catch {
-            wrote = false;
+            res = null;
           }
         }
+        const wrote = !!res && res.ok !== false;
+        cardIsNew = res?.isNew === true;
         if (wrote) {
-          await ledgerAppend({ kind: "suggest.presented", cardId: c.id, class: c.class, variant: "decision", score: p, sourceKind: finding.sourceKind });
+          if (res.changed === true) {
+            await ledgerAppend({ kind: "suggest.presented", cardId: c.id, class: c.class, variant: "decision", score: p, sourceKind: finding.sourceKind });
+          }
           surfaced += 1;
         } else {
           // No card machinery (or it failed) → hold instead of acting.

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createCtoCards } from "./ctoCards.mjs";
 import {
   ACTION_TYPES,
   DEFAULT_CLASS_PRIORS,
@@ -947,4 +948,140 @@ test("a generator that legitimately returns zero candidates (valid empty JSON) I
   const sug = makeDedupeSug({ engineState, runSuggest: async () => ({ text: JSON.stringify({ candidates: [] }) }) });
   await sug.processFinding({ id: "rec:empty", sourceKind: "fact-anomaly", text: "x", refs: [] }, { coldStart: false, tier: "medium" });
   assert.ok((es.suggest?.usedKeys || []).includes("rec:empty"));
+});
+
+// ---------------------------------------------------------------------------
+// BET-1477 — a byte-identical regeneration of an unchanged candidate is
+// "already surfaced, still current" (surfaced), never a suggest.silent
+// no-card-path hold, and never a veto→decision verb downgrade.
+// ---------------------------------------------------------------------------
+
+// A REAL card manager (createCtoCards) over fake stores — pins the whole
+// chain: the BET-1463 byte-identical no-op return in ctoCards.mjs AND the
+// BET-1477 branch in ctoSuggest.mjs, not just a fake writer's return shape.
+function makeRegenHarness() {
+  const clock = { ms: 1_000_000 };
+  const ledgerRows = [];
+  let cardPayload = { v: 1, cards: [] };
+  let engineState = { v: 1, suggest: { thresholds: { p_ask: 0.2, p_act: 0.95 } } };
+  const cards = createCtoCards({
+    cardStore: {
+      load: async () => cardPayload,
+      save: async (p) => { cardPayload = p; },
+    },
+    ledger: { append: async (r) => ledgerRows.push(r), read: async () => ledgerRows },
+    engineState: { load: async () => engineState, save: async (p) => { engineState = p; } },
+    now: () => clock.ms,
+  });
+  const deps = {
+    now: () => clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => ledgerRows.push(r), read: async () => ledgerRows },
+    verdicts: { load: async () => ({ v: 1, entries: Array(VERDICT_MIN).fill({}) }), save: async () => {} },
+    engineState: { load: async () => engineState, save: async (p) => { engineState = p; } },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({ ctoTier: "medium" }),
+    cards,
+    runWorthiness: async () => ({ text: "0.6" }),
+    senderReliability: async () => 1.0,
+    fireNotify: async () => {},
+  };
+  return {
+    clock,
+    ledgerRows,
+    cards: () => cardPayload,
+    resetDedupe() { engineState = { v: 1, suggest: { thresholds: { p_ask: 0.2, p_act: 0.95 } } }; }, // simulates usedKeys-cap churn / engine-state reset
+    deps,
+  };
+}
+
+test("BET-1477: a byte-identical decision regeneration counts as surfaced, not silent (no-card-path)", async () => {
+  const h = makeRegenHarness();
+  const sug = createCtoSuggest({
+    ...h.deps,
+    runSuggest: async () => ({
+      text: JSON.stringify({ candidates: [{ class: "config-change", finding: { text: "Tighten the cache TTL", refs: ["c1"] }, options: [{ label: "Apply", action: { type: "config-change", payload: {} } }] }] }),
+    }),
+  });
+  const finding = { id: "rec:regen-d", sourceKind: "fact-anomaly", text: "Tighten the cache TTL", refs: ["c1"] };
+
+  const r1 = await sug.processFinding(finding, { coldStart: false, tier: "medium" });
+  assert.equal(r1.surfaced, 1);
+  assert.equal(r1.silent, 0);
+  const firstWriteAt = h.cards().cards[0].updatedAt;
+  const presentedRows = h.ledgerRows.filter((r) => r.kind === "suggest.presented").length;
+
+  // Next pass: the dedupe marker was evicted (cap churn / engine-state
+  // reset), the generator regenerates the SAME candidate — the card content
+  // is byte-identical, only the write timestamp differs (excluded from
+  // cardContentEqual). This must count as surfaced, not as a no-card-path
+  // hold.
+  h.clock.ms += 30 * 60_000;
+  h.resetDedupe();
+  const r2 = await sug.processFinding(finding, { coldStart: false, tier: "medium" });
+  assert.equal(r2.surfaced, 1, "unchanged card is already on the board and current → surfaced");
+  assert.equal(r2.silent, 0);
+  assert.ok(!h.ledgerRows.some((r) => r.kind === "suggest.silent" && r.reason === "no-card-path"), "no suggest.silent(no-card-path) miscount");
+  assert.equal(h.ledgerRows.filter((r) => r.kind === "suggest.presented").length, presentedRows, "no second presented row — no ledger noise");
+  assert.equal(h.cards().cards.filter((c) => c.state === "open").length, 1, "never duplicated");
+  assert.equal(h.cards().cards[0].updatedAt, firstWriteAt, "byte-identical no-op did not rewrite the card");
+});
+
+test("BET-1477: a byte-identical veto regeneration stays the veto card — surfaced, no downgrade", async () => {
+  const h = makeRegenHarness();
+  const sug = createCtoSuggest({
+    ...h.deps,
+    trustStore: { load: async () => ({ v: 1, tiers: { "record-decision": "veto-window" } }), save: async () => {} },
+    runSuggest: async () => ({
+      text: JSON.stringify({ candidates: [{ class: "record-decision", finding: { text: "Adopt a rollback policy", refs: ["c2"] }, options: [{ label: "Go", action: { type: "record-decision", payload: {} } }] }] }),
+    }),
+  });
+  const finding = { id: "rec:regen-v", sourceKind: "fact-anomaly", text: "Adopt a rollback policy", refs: ["c2"] };
+
+  const r1 = await sug.processFinding(finding, { coldStart: false, tier: "medium" });
+  assert.equal(r1.surfaced, 1);
+  assert.equal(h.cards().cards[0].variant, "veto");
+
+  h.clock.ms += 30 * 60_000;
+  h.resetDedupe();
+  const r2 = await sug.processFinding(finding, { coldStart: false, tier: "medium" });
+  assert.equal(r2.surfaced, 1, "unchanged veto card is already on the board and current → surfaced");
+  assert.equal(r2.silent, 0);
+  assert.ok(!h.ledgerRows.some((r) => r.kind === "suggest.silent" && r.reason === "no-card-path"), "no suggest.silent(no-card-path) miscount");
+  const open = h.cards().cards.filter((c) => c.state === "open");
+  assert.equal(open.length, 1, "never duplicated");
+  assert.equal(open[0].variant, "veto", "no veto→decision verb downgrade on the no-op path");
+  assert.equal(h.ledgerRows.filter((r) => r.kind === "suggest.presented" && r.variant === "decision").length, 0);
+  assert.equal(h.ledgerRows.filter((r) => r.kind === "suggest.presented" && r.variant === "veto").length, 1, "exactly one presented row total");
+});
+
+test("BET-1477: a thrown or explicitly-refused (ok:false) card write still holds as suggest.silent(no-card-path)", async () => {
+  for (const [label, writer] of [
+    ["throw", async () => { throw new Error("card store boom"); }],
+    ["ok:false", async () => ({ ok: false, changed: false, isNew: false })],
+  ]) {
+    const clock = { ms: 1_000_000 };
+    const ledgerRows = [];
+    const sug = createCtoSuggest({
+      now: () => clock.ms,
+      publish: () => {},
+      ledger: { append: async (r) => ledgerRows.push(r), read: async () => ledgerRows },
+      verdicts: { load: async () => ({ v: 1, entries: Array(VERDICT_MIN).fill({}) }), save: async () => {} },
+      engineState: { load: async () => ({ suggest: { thresholds: { p_ask: 0.2, p_act: 0.95 } } }), save: async () => {} },
+      digests: { list: async () => [], load: async () => null },
+      facts: { list: async () => [], load: async () => null },
+      configGet: async () => ({ ctoTier: "medium" }),
+      cards: { upsertDecision: writer },
+      runSuggest: async () => ({
+        text: JSON.stringify({ candidates: [{ class: "config-change", finding: { text: "x", refs: [] }, options: [{ label: "Apply", action: { type: "config-change", payload: {} } }] }] }),
+      }),
+      runWorthiness: async () => ({ text: "0.6" }),
+      senderReliability: async () => 1.0,
+    });
+    const r = await sug.processFinding({ id: `rec:fail-${label}`, sourceKind: "fact-anomaly", text: "x", refs: [] }, { coldStart: false, tier: "medium" });
+    assert.equal(r.surfaced, 0, `${label}: no surfaced count without a card`);
+    assert.equal(r.silent, 1, `${label}: held instead`);
+    assert.ok(ledgerRows.some((x) => x.kind === "suggest.silent" && x.reason === "no-card-path"), `${label}: the hold reason is preserved`);
+  }
 });

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -1056,10 +1056,11 @@ test("BET-1477: a byte-identical veto regeneration stays the veto card — surfa
   assert.equal(h.ledgerRows.filter((r) => r.kind === "suggest.presented" && r.variant === "veto").length, 1, "exactly one presented row total");
 });
 
-test("BET-1477: a thrown or explicitly-refused (ok:false) card write still holds as suggest.silent(no-card-path)", async () => {
-  for (const [label, writer] of [
-    ["throw", async () => { throw new Error("card store boom"); }],
-    ["ok:false", async () => ({ ok: false, changed: false, isNew: false })],
+test("BET-1477: a thrown, missing, or explicitly-refused (ok:false) decision-card write still holds as suggest.silent(no-card-path)", async () => {
+  for (const [label, cardsDep] of [
+    ["throw", { upsertDecision: async () => { throw new Error("card store boom"); } }],
+    ["missing-method", {}],
+    ["ok:false", { upsertDecision: async () => ({ ok: false, changed: false, isNew: false }) }],
   ]) {
     const clock = { ms: 1_000_000 };
     const ledgerRows = [];
@@ -1072,7 +1073,7 @@ test("BET-1477: a thrown or explicitly-refused (ok:false) card write still holds
       digests: { list: async () => [], load: async () => null },
       facts: { list: async () => [], load: async () => null },
       configGet: async () => ({ ctoTier: "medium" }),
-      cards: { upsertDecision: writer },
+      cards: cardsDep,
       runSuggest: async () => ({
         text: JSON.stringify({ candidates: [{ class: "config-change", finding: { text: "x", refs: [] }, options: [{ label: "Apply", action: { type: "config-change", payload: {} } }] }] }),
       }),


### PR DESCRIPTION
Opened automatically for `multica/BET-1477-cto-suggest-noop-card`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1477.