### PR TITLE
feat(server): CTO store patchStore discipline + start the retention sweeper (BET-1464)

### DIFF
--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -984,8 +984,11 @@ function validPrRef(ref) {
       // shape read the payload up front and saved it at the end, so a spend
       // row recorded by a concurrent model call was silently reverted by the
       // stale snapshot. The body is an async IIFE so its awaits hold the
-      // store mutex — the serialization IS the fix.
-      await patchBudget((payload) => {
+      // store mutex — the serialization IS the fix. The roll's working shape
+      // is normalizeRoi's (quota normalization + the roi/months/pending
+      // defaults), the same normalizer the old load path applied.
+      await patchStore(store, (raw) => {
+        const payload = normalizeRoi(raw);
         months = { ...payload.roi.months };
         pending = payload.roi.pending.map((j) => ({ ...j }));
         const countMerged = (row) => {

--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -794,6 +794,27 @@ export function createCtoBudget({
     const obs = hist[historyKey(provider, windowKind)] ?? [];
     const { series, historyDays, maxObserved } = buildSeries(obs, t);
 
+    // The windowed fold: one derivation shared by the store-mutex path and
+    // the degenerate fallback below (same inputs → same plan/quota shape).
+    const deriveWindowedQuota = (prevRow) => {
+      const activated = !!prevRow.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
+      const foldedNow = foldQuotaState(prevRow, { capHits: capHitsSince, earnedCleanDays, activated });
+      const planNow = planReserve({ state: foldedNow, series, remainingPct, forecast });
+      const quotaNow = {
+        ...foldedNow,
+        provider,
+        mode: planNow.mode,
+        reserve: planNow.reserve,
+        spendable: planNow.spendableFrac,
+        maxObserved: planNow.maxObserved,
+        historyDays: planNow.historyDays,
+        remainingFrac: planNow.remainingFrac,
+        mape14: mapeFn({ series, tailDays: 14 }),
+        updatedMs: t,
+      };
+      return { prev: prevRow, folded: foldedNow, plan: planNow, quota: quotaNow };
+    };
+
     // BET-1464 defect 3: the fold derives from the provider's PREVIOUS quota
     // row read FRESH inside the store mutex — the old load-then-save shape
     // suspended inside load(), letting a concurrent spend row land and then
@@ -804,22 +825,7 @@ export function createCtoBudget({
     let folded = null;
     try {
       await patchBudget((payload) => {
-        prev = payload.quota?.[provider] ?? defaultQuotaState(provider);
-        const activated = !!prev.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
-        folded = foldQuotaState(prev, { capHits: capHitsSince, earnedCleanDays, activated });
-        plan = planReserve({ state: folded, series, remainingPct, forecast });
-        quota = {
-          ...folded,
-          provider,
-          mode: plan.mode,
-          reserve: plan.reserve,
-          spendable: plan.spendableFrac,
-          maxObserved: plan.maxObserved,
-          historyDays: plan.historyDays,
-          remainingFrac: plan.remainingFrac,
-          mape14: mapeFn({ series, tailDays: 14 }),
-          updatedMs: t,
-        };
+        ({ prev, folded, plan, quota } = deriveWindowedQuota(payload.quota?.[provider] ?? defaultQuotaState(provider)));
         return { ...payload, quota: { ...payload.quota, [provider]: quota } };
       });
     } catch {
@@ -830,22 +836,7 @@ export function createCtoBudget({
       // from a plain read (no persistence attempt — same outcome as the old
       // caught save failure) so the caller still gets a plan.
       const payload = await load();
-      prev = payload.quota?.[provider] ?? defaultQuotaState(provider);
-      const activated = !!prev.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
-      folded = foldQuotaState(prev, { capHits: capHitsSince, earnedCleanDays, activated });
-      plan = planReserve({ state: folded, series, remainingPct, forecast });
-      quota = {
-        ...folded,
-        provider,
-        mode: plan.mode,
-        reserve: plan.reserve,
-        spendable: plan.spendableFrac,
-        maxObserved: plan.maxObserved,
-        historyDays: plan.historyDays,
-        remainingFrac: plan.remainingFrac,
-        mape14: mapeFn({ series, tailDays: 14 }),
-        updatedMs: t,
-      };
+      ({ prev, folded, plan, quota } = deriveWindowedQuota(payload.quota?.[provider] ?? defaultQuotaState(provider)));
     }
     // §14.5 ledger rows: a fractile notch and a spendable-reserve line.
     if (folded.fractile !== (prev.fractile ?? FRACTILE_INIT)) {

--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -57,7 +57,7 @@
 // `ctoNightCapUsd` (user-set in Behavior, default $5/night). The forecaster
 // still runs to feed the Health card, but produces no reserve.
 
-import { budgetStore } from "./ctoStores.mjs";
+import { budgetStore, patchStore } from "./ctoStores.mjs";
 import { startOfDay } from "./ctoRollups.mjs";
 import { blendedPrice } from "../shared/blendedPrice.mjs";
 import { effectsForVerdict } from "./ctoVerdicts.mjs";
@@ -666,8 +666,16 @@ export function createCtoBudget({
       return normalizeQuota(defaultBudgetPayload());
     }
   }
-  async function save(payload) {
-    await store.save(normalizeQuota(payload));
+  // BET-1464 defect 3: every budget.json write routes through patchStore —
+  // the read-fresh-merge-save runs under the budget store's mutex. The spend
+  // recorder fires per model call; the overnight roll (refreshRoi) holds the
+  // same mutex across its multi-second probe body, so a mid-roll spend row
+  // can no longer be reverted by the roll's stale-snapshot save. Mutators
+  // receive the RAW store payload and normalize it themselves; the patch is
+  // the full normalized payload (every key owned), so the merged state keeps
+  // the on-disk shape the accessors expect.
+  function patchBudget(mutate) {
+    return patchStore(store, (fresh) => mutate(normalizeQuota(fresh)));
   }
   async function ledgerAppend(row) {
     try {
@@ -680,9 +688,7 @@ export function createCtoBudget({
     const t = typeof nowMs === "number" && Number.isFinite(nowMs) ? nowMs : now();
     const usd = price({ model, tokens });
     try {
-      const payload = await load();
-      const next = recordSpend(payload, { now: t, usd, calls: 1 });
-      await save(next);
+      await patchBudget((payload) => recordSpend(payload, { now: t, usd, calls: 1 }));
       return { usd, dayKey: dayKey(t) };
     } catch {
       // Metering is best-effort: a store failure must never break the model
@@ -741,7 +747,6 @@ export function createCtoBudget({
       const obs = hist[historyKey(provider, windowKind)] ?? [];
       const { series, historyDays, maxObserved } = buildSeries(obs, t);
       const mape14 = mapeFn({ series, tailDays: 14 });
-      const payload = await load();
       const quota = {
         ...defaultQuotaState(provider),
         mode: "windowless",
@@ -753,9 +758,8 @@ export function createCtoBudget({
         mape14,
         updatedMs: t,
       };
-      const nextPayload = { ...payload, quota: { ...payload.quota, [provider]: quota } };
       try {
-        await save(nextPayload);
+        await patchBudget((payload) => ({ ...payload, quota: { ...payload.quota, [provider]: quota } }));
       } catch {
         /* quota persistence is best-effort */
       }
@@ -790,28 +794,58 @@ export function createCtoBudget({
     const obs = hist[historyKey(provider, windowKind)] ?? [];
     const { series, historyDays, maxObserved } = buildSeries(obs, t);
 
-    const payload = await load();
-    const prev = payload.quota?.[provider] ?? defaultQuotaState(provider);
-    const activated = !!prev.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
-    const folded = foldQuotaState(prev, { capHits: capHitsSince, earnedCleanDays, activated });
-    const plan = planReserve({ state: folded, series, remainingPct, forecast });
-    const quota = {
-      ...folded,
-      provider,
-      mode: plan.mode,
-      reserve: plan.reserve,
-      spendable: plan.spendableFrac,
-      maxObserved: plan.maxObserved,
-      historyDays: plan.historyDays,
-      remainingFrac: plan.remainingFrac,
-      mape14: mapeFn({ series, tailDays: 14 }),
-      updatedMs: t,
-    };
-    const nextPayload = { ...payload, quota: { ...payload.quota, [provider]: quota } };
+    // BET-1464 defect 3: the fold derives from the provider's PREVIOUS quota
+    // row read FRESH inside the store mutex — the old load-then-save shape
+    // suspended inside load(), letting a concurrent spend row land and then
+    // reverted it with the stale snapshot.
+    let plan = null;
+    let quota = null;
+    let prev = null;
+    let folded = null;
     try {
-      await save(nextPayload);
+      await patchBudget((payload) => {
+        prev = payload.quota?.[provider] ?? defaultQuotaState(provider);
+        const activated = !!prev.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
+        folded = foldQuotaState(prev, { capHits: capHitsSince, earnedCleanDays, activated });
+        plan = planReserve({ state: folded, series, remainingPct, forecast });
+        quota = {
+          ...folded,
+          provider,
+          mode: plan.mode,
+          reserve: plan.reserve,
+          spendable: plan.spendableFrac,
+          maxObserved: plan.maxObserved,
+          historyDays: plan.historyDays,
+          remainingFrac: plan.remainingFrac,
+          mape14: mapeFn({ series, tailDays: 14 }),
+          updatedMs: t,
+        };
+        return { ...payload, quota: { ...payload.quota, [provider]: quota } };
+      });
     } catch {
-      /* quota persistence is best-effort */
+      /* quota persistence is best-effort — the fold replays on the next refresh */
+    }
+    if (!plan) {
+      // Degenerate: the store path failed before deriving anything. Re-derive
+      // from a plain read (no persistence attempt — same outcome as the old
+      // caught save failure) so the caller still gets a plan.
+      const payload = await load();
+      prev = payload.quota?.[provider] ?? defaultQuotaState(provider);
+      const activated = !!prev.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
+      folded = foldQuotaState(prev, { capHits: capHitsSince, earnedCleanDays, activated });
+      plan = planReserve({ state: folded, series, remainingPct, forecast });
+      quota = {
+        ...folded,
+        provider,
+        mode: plan.mode,
+        reserve: plan.reserve,
+        spendable: plan.spendableFrac,
+        maxObserved: plan.maxObserved,
+        historyDays: plan.historyDays,
+        remainingFrac: plan.remainingFrac,
+        mape14: mapeFn({ series, tailDays: 14 }),
+        updatedMs: t,
+      };
     }
     // §14.5 ledger rows: a fractile notch and a spendable-reserve line.
     if (folded.fractile !== (prev.fractile ?? FRACTILE_INIT)) {
@@ -942,115 +976,121 @@ function validPrRef(ref) {
    */
   async function refreshRoi() {
     const t = typeof now === "function" ? now() : Date.now();
-    let payload;
+    let months = {};
+    let pending = [];
     try {
-      payload = normalizeRoi(await store.load());
-    } catch {
-      payload = normalizeRoi(defaultBudgetPayload());
-    }
-    const months = { ...payload.roi.months };
-    const pending = payload.roi.pending.map((j) => ({ ...j }));
-    const countMerged = (row) => {
-      const key = roiMonthKey(typeof row.finishedAt === "number" ? row.finishedAt : t);
-      const acc = monthAccumulator(months, key);
-      acc.merged += 1;
-      months[key] = acc;
-      row.counted = true;
-    };
-
-    // 1. Sample terminal CTO-actor jobs not yet snapshotted.
-    let jobs = [];
-    try {
-      jobs = (await jobsRead()) ?? [];
-    } catch {
-      jobs = [];
-    }
-    // Every pending id — counted or not — is a dedupe fingerprint: a job
-    // already snapshotted (and probed) must never re-sample.
-    const known = new Set(pending.map((j) => j.id));
-    for (const j of jobs) {
-      if (!j || j.actor !== "cto" || j.status !== "done") continue;
-      if (typeof j.branch !== "string" || !j.branch) continue;
-      if (typeof j.id !== "string" || !j.id || known.has(j.id)) continue;
-      pending.push({
-        id: j.id,
-        branch: j.branch,
-        cwd: typeof j.cwd === "string" ? j.cwd : "",
-        finishedAt: typeof j.finishedAt === "number" && Number.isFinite(j.finishedAt) ? j.finishedAt : null,
-        counted: false,
-      });
-    }
-
-    // 2. Probe pending branches (merged = branch deleted-on-merge, or present
-    //    and an ancestor of the project's HEAD, or its forge PR reports
-    //    merged — the squash-merge case, BET-1422). Probe failures leave the
-    //    row uncounted for a later refresh.
-    for (const row of pending) {
-      if (row.counted === true) continue;
-      let probe = { exists: false, isAncestor: false };
-      try {
-        probe = (await gitProbe({ cwd: row.cwd, branch: row.branch })) ?? probe;
-      } catch {
-        probe = { exists: false, isAncestor: false };
-      }
-      if (isJobMerged(probe)) {
-        countMerged(row);
-        continue;
-      }
-      // The local-git signals can never fire for a squash merge: resolve the
-      // job's PR on the forge (once — a resolved PR or a definitive no-PR is
-      // persisted on the row so neither is ever re-queried; an unconsultable
-      // forge leaves both markers unset so the next refresh retries), then
-      // probe its state.
-      const havePr = validPrRef(row.pr);
-      if (!havePr && row.prTried !== true && typeof discoverJobPr === "function") {
-        try {
-          const pr = await discoverJobPr({ cwd: row.cwd, branch: row.branch });
-          if (validPrRef(pr)) {
-            row.pr = { repoKey: pr.repoKey, number: pr.number };
-          } else {
-            row.prTried = true;
+      // BET-1464 defect 3: the roll holds the budget store's mutex across its
+      // whole multi-second body (sampling, probes, month recomputes). The old
+      // shape read the payload up front and saved it at the end, so a spend
+      // row recorded by a concurrent model call was silently reverted by the
+      // stale snapshot. The body is an async IIFE so its awaits hold the
+      // store mutex — the serialization IS the fix.
+      await patchBudget((payload) => {
+        months = { ...payload.roi.months };
+        pending = payload.roi.pending.map((j) => ({ ...j }));
+        const countMerged = (row) => {
+          const key = roiMonthKey(typeof row.finishedAt === "number" ? row.finishedAt : t);
+          const acc = monthAccumulator(months, key);
+          acc.merged += 1;
+          months[key] = acc;
+          row.counted = true;
+        };
+        return (async () => {
+          // 1. Sample terminal CTO-actor jobs not yet snapshotted.
+          let jobs = [];
+          try {
+            jobs = (await jobsRead()) ?? [];
+          } catch {
+            jobs = [];
           }
-        } catch {
-          /* transient — retried on a later refresh */
-        }
-      }
-      const pr = validPrRef(row.pr);
-      if (!pr) continue;
-      let prMerged = null;
-      try {
-        prMerged = await forgeProbe({ repoKey: pr.repoKey, number: pr.number, head: row.branch });
-      } catch {
-        prMerged = null;
-      }
-      if (isJobMerged({ ...probe, prMerged })) countMerged(row);
-    }
+          // Every pending id — counted or not — is a dedupe fingerprint: a job
+          // already snapshotted (and probed) must never re-sample.
+          const known = new Set(pending.map((j) => j.id));
+          for (const j of jobs) {
+            if (!j || j.actor !== "cto" || j.status !== "done") continue;
+            if (typeof j.branch !== "string" || !j.branch) continue;
+            if (typeof j.id !== "string" || !j.id || known.has(j.id)) continue;
+            pending.push({
+              id: j.id,
+              branch: j.branch,
+              cwd: typeof j.cwd === "string" ? j.cwd : "",
+              finishedAt: typeof j.finishedAt === "number" && Number.isFinite(j.finishedAt) ? j.finishedAt : null,
+              counted: false,
+            });
+          }
 
-    // 3. Recompute the store-derived counters: current month every refresh;
-    //    the previous month once after it closes, then frozen.
-    const currentKey = roiMonthKey(t);
-    const currentWindow = monthWindow(currentKey);
-    const prevKey = currentWindow ? roiMonthKey(currentWindow.startTs - 1) : null;
-    const toCompute = [currentKey];
-    if (prevKey && months[prevKey]?.frozen !== true) toCompute.push(prevKey);
-    for (const key of toCompute) {
-      const acc = monthAccumulator(months, key);
-      const isCurrent = key === currentKey;
-      const computed = await computeMonth({ ...acc, frozen: !isCurrent }, t);
-      if (computed) months[key] = computed;
-    }
+          // 2. Probe pending branches (merged = branch deleted-on-merge, or
+          //    present and an ancestor of the project's HEAD, or its forge PR
+          //    reports merged — the squash-merge case, BET-1422). Probe
+          //    failures leave the row uncounted for a later refresh.
+          for (const row of pending) {
+            if (row.counted === true) continue;
+            let probe = { exists: false, isAncestor: false };
+            try {
+              probe = (await gitProbe({ cwd: row.cwd, branch: row.branch })) ?? probe;
+            } catch {
+              probe = { exists: false, isAncestor: false };
+            }
+            if (isJobMerged(probe)) {
+              countMerged(row);
+              continue;
+            }
+            // The local-git signals can never fire for a squash merge: resolve
+            // the job's PR on the forge (once — a resolved PR or a definitive
+            // no-PR is persisted on the row so neither is ever re-queried; an
+            // unconsultable forge leaves both markers unset so the next
+            // refresh retries), then probe its state.
+            const havePr = validPrRef(row.pr);
+            if (!havePr && row.prTried !== true && typeof discoverJobPr === "function") {
+              try {
+                const pr = await discoverJobPr({ cwd: row.cwd, branch: row.branch });
+                if (validPrRef(pr)) {
+                  row.pr = { repoKey: pr.repoKey, number: pr.number };
+                } else {
+                  row.prTried = true;
+                }
+              } catch {
+                /* transient — retried on a later refresh */
+              }
+            }
+            const pr = validPrRef(row.pr);
+            if (!pr) continue;
+            let prMerged = null;
+            try {
+              prMerged = await forgeProbe({ repoKey: pr.repoKey, number: pr.number, head: row.branch });
+            } catch {
+              prMerged = null;
+            }
+            if (isJobMerged({ ...probe, prMerged })) countMerged(row);
+          }
 
-    // 4. Hygiene: drop stale pending rows.
-    const cutoff = t - ROI_PENDING_RETENTION_MS;
-    const kept = pending.filter((j) => j.counted === true ? (typeof j.finishedAt === "number" ? j.finishedAt >= cutoff : true) : true);
-    const trimmed = kept.slice(-200);
+          // 3. Recompute the store-derived counters: current month every
+          //    refresh; the previous month once after it closes, then frozen.
+          const currentKey = roiMonthKey(t);
+          const currentWindow = monthWindow(currentKey);
+          const prevKey = currentWindow ? roiMonthKey(currentWindow.startTs - 1) : null;
+          const toCompute = [currentKey];
+          if (prevKey && months[prevKey]?.frozen !== true) toCompute.push(prevKey);
+          for (const key of toCompute) {
+            const acc = monthAccumulator(months, key);
+            const isCurrent = key === currentKey;
+            const computed = await computeMonth({ ...acc, frozen: !isCurrent }, t);
+            if (computed) months[key] = computed;
+          }
 
-    try {
-      await save({ ...payload, roi: { months, pending: trimmed } });
+          // 4. Hygiene: drop stale pending rows.
+          const cutoff = t - ROI_PENDING_RETENTION_MS;
+          const kept = pending.filter((j) => j.counted === true ? (typeof j.finishedAt === "number" ? j.finishedAt >= cutoff : true) : true);
+          const trimmed = kept.slice(-200);
+          pending = trimmed;
+
+          return { ...payload, roi: { months, pending: trimmed } };
+        })();
+      });
     } catch {
-      /* ROI persistence is best-effort */
+      /* ROI persistence is best-effort — a store failure degrades the report */
     }
-    return { months, pending: trimmed };
+    return { months, pending };
   }
 
   /** The render model for the Health ROI row (§12.4): the most recent CLOSED

--- a/src/server/ctoBudgetWiring.test.mjs
+++ b/src/server/ctoBudgetWiring.test.mjs
@@ -20,7 +20,11 @@ const indexSource = readFileSync(join(here, "index.mjs"), "utf8");
 
 // Walks the deps object literal that opens at `openMarker` (the first `{`
 // after the marker's call site) and returns its source, balancing braces
-// with quote awareness. Returns "" when the marker is absent.
+// with quote AND comment awareness. Returns "" when the marker is absent.
+// The comment awareness matters: an apostrophe inside a deps comment (e.g.
+// "the poller's pct observation") used to open a phantom quote and derail
+// the brace walk across the rest of the file — any unrelated edit after the
+// block could flip this gate (BET-1464).
 function depsBlock(source, openMarker) {
   const call = source.indexOf(openMarker);
   if (call === -1) return "";
@@ -30,8 +34,21 @@ function depsBlock(source, openMarker) {
   for (let i = open; i < source.length; i += 1) {
     const ch = source[i];
     const prev = i > 0 ? source[i - 1] : "";
+    const next = i + 1 < source.length ? source[i + 1] : "";
     if (quote) {
       if (ch === quote && prev !== "\\") quote = null;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      // line comment — skip to the newline (apostrophes inside are text)
+      i = source.indexOf("\n", i);
+      if (i === -1) break;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      const close = source.indexOf("*/", i + 2);
+      if (close === -1) break;
+      i = close + 1;
       continue;
     }
     if (ch === '"' || ch === "'" || ch === "`") {

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -40,6 +40,7 @@ import {
   cardsStore,
   engineStateStore,
   ledgerStore,
+  patchStore,
 } from "./ctoStores.mjs";
 
 export const ACTOR = "cto";
@@ -310,64 +311,85 @@ export function createCtoCards(deps = {}) {
   // existing open card is updated in place (title/body/refs/age preserved),
   // never duplicated. Returns `{ ok, changed, isNew }` — `ok` is true when
   // the write path ran without exception (including the byte-identical
-  // no-op, where the card is already current), false when nothing was
-  // written (invalid args).
+  // no-op, where the card is already current — BET-1477's "card path
+  // worked" test), false when nothing was written (invalid args).
+  //
+  // BET-1464 defect 3: the read-fresh-merge-save runs under the cards store's
+  // patchStore mutex, so a writer derived from a stale snapshot can no longer
+  // erase a concurrent writer's card (reached from fire-and-forget call
+  // sites — promoteDue timers, bus handlers — which used to race).
   async function upsertBlocker({ sourceKind, sourceId, sessionID, title, body, refs, ts = now(), pendingSince = ts }) {
     const id = stableCardId(sourceKind, sourceId);
-    const { payload, cards } = await openCards();
-    const existing = cards.find((c) => c?.id === id && c?.state === "open");
-    const created = existing?.created ?? ts;
-    const card = buildBlockerCard({
-      id,
-      sourceKind,
-      sourceId,
-      sessionID,
-      title,
-      body,
-      refs,
-      pendingSince,
-      created,
+    let changed = false;
+    let isNew = false;
+    let cardRefs = [];
+    await patchStore(cardStore, (fresh) => {
+      const cards = Array.isArray(fresh?.cards) ? fresh.cards : [];
+      const existing = cards.find((c) => c?.id === id && c?.state === "open");
+      const created = existing?.created ?? ts;
+      const card = buildBlockerCard({
+        id,
+        sourceKind,
+        sourceId,
+        sessionID,
+        title,
+        body,
+        refs,
+        pendingSince,
+        created,
+      });
+      cardRefs = card.refs;
+      // BET-1463 (defect 2): a byte-identical rebuild is not a change — an
+      // empty patch is a pure no-op (no save, no ledger row). This is what
+      // stops an unanswered ask from being "re-created" every minute forever
+      // by promoteDue.
+      if (existing && cardContentEqual(existing, { ...card, updatedAt: ts })) return {};
+      changed = true;
+      isNew = !existing;
+      const nextCards = existing
+        ? cards.map((c) => (c === existing ? { ...existing, ...card, created, updatedAt: ts } : c))
+        : [...cards, card];
+      return { cards: nextCards };
     });
-    // BET-1463 (defect 2): a byte-identical rebuild is not a change — no
-    // save, no ledger row. This is what stops an unanswered ask from being
-    // "re-created" every minute forever by promoteDue.
-    if (existing && cardContentEqual(existing, { ...card, updatedAt: ts })) {
-      return { ok: true, changed: false, isNew: false };
+    if (changed) {
+      await ledgerAppend({
+        kind: CARD_CREATED,
+        cardId: id,
+        variant: "blocker",
+        sourceKind,
+        sourceId,
+        sessionID,
+        refs: cardRefs,
+      });
     }
-    if (existing) {
-      const idx = cards.indexOf(existing);
-      cards[idx] = { ...existing, ...card, created, updatedAt: ts };
-    } else {
-      cards.push(card);
-    }
-    await cardStore.save({ ...payload, cards });
-    await ledgerAppend({
-      kind: CARD_CREATED,
-      cardId: id,
-      variant: "blocker",
-      sourceKind,
-      sourceId,
-      sessionID,
-      refs: card.refs,
-    });
-    return { ok: true, changed: true, isNew: !existing };
+    // BET-1477: the no-op still reports ok:true — the card is already on the
+    // board and current, which is a successful outcome for a caller branching
+    // on "did the card path work" (`res.ok !== false` in ctoSuggest).
+    return { ok: true, changed, isNew };
   }
 
-  // Shared close-path for resolve/dismiss: remove one open card by id, save,
-  // and write the ledger row with the close kind (resolved vs dismissed).
+  // Shared close-path for resolve/dismiss: remove one open card by id (under
+  // the cards patchStore mutex — BET-1464 defect 3), save, and write the
+  // ledger row with the close kind (resolved vs dismissed). Two concurrent
+  // closes of the same id now compose: the second re-reads fresh, finds the
+  // card gone, and returns `{ changed: false }` instead of double-ledgering.
   async function closeOpenCard(id, kind, reason, ts = now()) {
-    const { payload, cards } = await openCards();
-    const idx = cards.findIndex((c) => c?.id === id && c?.state === "open");
-    if (idx < 0) return { changed: false };
-    const [card] = cards.splice(idx, 1);
-    await cardStore.save({ ...payload, cards });
+    let closed = null;
+    await patchStore(cardStore, (fresh) => {
+      const cards = Array.isArray(fresh?.cards) ? fresh.cards : [];
+      const idx = cards.findIndex((c) => c?.id === id && c?.state === "open");
+      if (idx < 0) return {};
+      closed = cards[idx];
+      return { cards: cards.filter((_, i) => i !== idx) };
+    });
+    if (!closed) return { changed: false };
     await ledgerAppend({
       kind,
       cardId: id,
-      variant: card.variant,
-      sourceKind: card.sourceKind,
-      refs: card.refs,
-      sessionID: card.sessionID,
+      variant: closed.variant,
+      sourceKind: closed.sourceKind,
+      refs: closed.refs,
+      sessionID: closed.sessionID,
       reason,
     });
     // BET-1463 (defect 1): every pendingBlockers entry that fed the closed
@@ -376,10 +398,10 @@ export function createCtoCards(deps = {}) {
     // resolveById AND dismissById since both call this helper. `sourceId` for
     // a health card is the trip's GROUP KEY (see `healthGroupKey` below), not
     // one entry's id — multiple pendingBlockers entries fold into one card.
-    if (card.sourceKind === HEALTH_SOURCE_KIND) {
-      await dropPendingBlockersByGroup(card.sourceId);
+    if (closed.sourceKind === HEALTH_SOURCE_KIND) {
+      await dropPendingBlockersByGroup(closed.sourceId);
     }
-    return { changed: true, card };
+    return { changed: true, card: closed };
   }
 
   // Remove every `pendingBlockers` entry belonging to one health group (used
@@ -589,50 +611,61 @@ export function createCtoCards(deps = {}) {
     });
   }
 
-  // Shared card-writer core: ONE load/find/merge-or-push/save/ledger path
-  // for every variant writer (decision/veto/connect). `build` returns the
+  // Shared card-writer core: ONE read-fresh-merge-save path for every
+  // variant writer (decision/veto/connect), under the cards store's
+  // patchStore mutex (BET-1464 defect 3 — a stale-derived writer can no
+  // longer erase a concurrent writer's card). `build` returns the
   // variant-specific fields given { existing, created, ts }; the helper adds
   // the identity/lifecycle envelope, upserts by stable id (regeneration
   // updates in place, never dups), saves, and writes the CARD_CREATED row.
+  // Returns `{ ok, changed, isNew }` per the BET-1477 contract: ok:true on
+  // the byte-identical no-op too, ok:false only from the variant wrappers'
+  // invalid-args guards.
   async function upsertOpenCard({ id, variant, sourceKind = null, sourceId = null, ts = now(), ledger = {}, build }) {
-    const { payload, cards: list } = await openCards();
-    const existing = list.find((c) => c?.id === id && c?.state === "open");
-    const created = existing?.created ?? ts;
-    const card = {
-      ...build({ existing, created, ts }),
-      id,
-      variant,
-      sourceKind,
-      sourceId,
-      created,
-      updatedAt: ts,
-      state: "open",
-    };
-    // BET-1463 (defect 2): same no-op rule as upsertBlocker — a byte-identical
-    // regeneration (e.g. a decision card re-derived unchanged, or an unarmed
-    // veto countdown) is not a change. BET-1477: the no-op still reports
-    // ok:true — the card is already on the board and current, which is a
-    // successful outcome for a caller branching on "did the card path work".
-    if (existing && cardContentEqual(existing, card)) {
-      return { ok: true, changed: false, isNew: false };
-    }
-    if (existing) {
-      const idx = list.indexOf(existing);
-      list[idx] = { ...existing, ...card, created, updatedAt: ts };
-    } else {
-      list.push(card);
-    }
-    await cardStore.save({ ...payload, cards: list });
-    await ledgerAppend({
-      kind: CARD_CREATED,
-      cardId: id,
-      variant,
-      sourceKind,
-      sourceId,
-      refs: card.refs,
-      ...ledger,
+    let changed = false;
+    let isNew = false;
+    let cardRefs = [];
+    await patchStore(cardStore, (fresh) => {
+      const list = Array.isArray(fresh?.cards) ? fresh.cards : [];
+      const existing = list.find((c) => c?.id === id && c?.state === "open");
+      const created = existing?.created ?? ts;
+      const card = {
+        ...build({ existing, created, ts }),
+        id,
+        variant,
+        sourceKind,
+        sourceId,
+        created,
+        updatedAt: ts,
+        state: "open",
+      };
+      cardRefs = card.refs;
+      // BET-1463 (defect 2): same no-op rule as upsertBlocker — a byte-identical
+      // regeneration (e.g. a decision card re-derived unchanged, or an unarmed
+      // veto countdown) is an empty patch: no save, no ledger row. BET-1477:
+      // the no-op still reports ok:true — the card is already on the board and
+      // current, which is a successful outcome for a caller branching on "did
+      // the card path work".
+      if (existing && cardContentEqual(existing, card)) return {};
+      changed = true;
+      isNew = !existing;
+      const nextList = existing
+        ? list.map((c) => (c === existing ? { ...existing, ...card, created, updatedAt: ts } : c))
+        : [...list, card];
+      return { cards: nextList };
     });
-    return { ok: true, changed: true, isNew: !existing };
+    if (changed) {
+      await ledgerAppend({
+        kind: CARD_CREATED,
+        cardId: id,
+        variant,
+        sourceKind,
+        sourceId,
+        refs: cardRefs,
+        ...ledger,
+      });
+    }
+    return { ok: true, changed, isNew };
   }
 
   // needs-you surface: only open cards count (§10.3 — resolved/dismissed cards
@@ -711,16 +744,22 @@ export function createCtoCards(deps = {}) {
 
   // Resolve every open connect-ask card for one tool (the registry's
   // three-way answer is the resolution predicate's only false-path). Returns
-  // `{changed}` for tests/diagnostics.
+  // `{changed}` for tests/diagnostics. Under the cards patchStore mutex
+  // (BET-1464 defect 3) the matched set derives from the FRESH list, so a
+  // concurrent card writer's card can never be reverted by this close.
   async function resolveConnectCards(toolId, reason, ts = now()) {
-    const { payload, cards: list } = await openCards();
-    const open = list.filter(
-      (c) => c?.state === "open" && c?.variant === "connect" && (c?.sourceId === toolId || c?.refs?.includes(toolId)),
-    );
-    let changed = false;
-    for (const card of open) {
-      const idx = list.indexOf(card);
-      list.splice(idx, 1);
+    const closed = [];
+    await patchStore(cardStore, (fresh) => {
+      const list = Array.isArray(fresh?.cards) ? fresh.cards : [];
+      const open = list.filter(
+        (c) => c?.state === "open" && c?.variant === "connect" && (c?.sourceId === toolId || c?.refs?.includes(toolId)),
+      );
+      if (open.length === 0) return {};
+      closed.push(...open);
+      const openSet = new Set(open);
+      return { cards: list.filter((c) => !openSet.has(c)) };
+    });
+    for (const card of closed) {
       await ledgerAppend({
         kind: CARD_RESOLVED,
         cardId: card.id,
@@ -730,10 +769,8 @@ export function createCtoCards(deps = {}) {
         refs: card.refs,
         reason,
       });
-      changed = true;
     }
-    if (changed) await cardStore.save({ ...payload, cards: list });
-    return { changed };
+    return { changed: closed.length > 0 };
   }
 
   async function listOpen() {

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -159,50 +159,90 @@ export const engineStateStore = createCtoJsonStore("engine-state", ctoPath("engi
 export const trustStore = createCtoJsonStore("trust", ctoPath("trust.json"));
 
 // ---------------------------------------------------------------------------
-// BET-1425 engine-state write hygiene — per-key read-modify-write.
+// BET-1425 engine-state write hygiene, generalized in BET-1464 (defect 3) —
+// per-key read-modify-write for EVERY single-file CTO store.
 //
-// `engineStateStore.save(data)` writes the WHOLE file, so a writer that spreads
-// a load-time snapshot (`{ ...es, myKey }`) silently reverts every other key
-// another writer changed between its load and its save (the resurrect/clobber
-// demonstrated in the BET-1403 review). The durability invariant: a key's
-// value must survive any concurrent writer that does not own that key.
+// `store.save(data)` writes the WHOLE file, so a writer that spreads a
+// load-time snapshot (`{ ...snapshot, myKey }`) silently reverts every other
+// key another writer changed between its load and its save (the
+// resurrect/clobber demonstrated in the BET-1403 review). The durability
+// invariant: a key's value must survive any concurrent writer that does not
+// own that key.
 //
-// `patchEngineState` is the one sanctioned save path for engine-state writers:
-// under a process-wide mutex it loads FRESH, applies only the patch keys the
-// writer owns, and atomically saves. The mutex serializes the whole
-// load→merge→save sequence (the path mutex inside writeJsonAtomic only covers
-// the rename, not the read — a different mutex, so no nesting deadlock), so
-// two concurrent patches each re-derive from the other's committed state.
+// `patchStore(store, mutation)` is the one sanctioned save path for the CTO
+// stores: under ONE mutex PER STORE PATH it loads FRESH, applies only the
+// patch keys the writer owns, and atomically saves. The mutex serializes the
+// whole load→merge→save sequence (the path mutex inside writeJsonAtomic only
+// covers the rename, not the read — a different mutex, so no nesting
+// deadlock), so two concurrent patches each re-derive from the other's
+// committed state. Writers whose body awaits (a long scan, a network probe)
+// may pass an async mutator — the store mutex is held across the whole
+// body, exactly the serialization the old per-engine write chains gave, now
+// shared by every writer of the file.
 //
 // `mutation` is either a static patch object (keys owned by the writer) or a
 // `(fresh) => patch` function for writers whose value derives from state
 // (array pushes, sub-key merges like `watchers.lastAutoDay` vs the
-// `watchers` migration marker). Setting a patch key to `undefined` deletes it.
+// `watchers` migration marker). Setting a patch key to `undefined` deletes
+// it. An EMPTY patch (or a mutator resolving to one) is a pure no-op: no
+// save, no rewrite — the BET-1463 card writers rely on that to keep a
+// byte-identical regeneration from touching the file at all.
 // ---------------------------------------------------------------------------
 
-const engineStateWriteLock = createMutex();
+// One mutex per store path (BET-1464 defect 3): the five CTO writer files
+// (cards/watchers/trust/budget/tool-registry) each serialize on their own
+// key. Keyed by the real path so two wrapper instances around the same file
+// still serialize; injected test stores without a path fall back to the
+// object identity (over-serialization is always safe, under-serialization
+// is not).
+const storeWriteLocks = new Map();
 
-export async function patchEngineState(mutation, { engineState = engineStateStore } = {}) {
+function lockForStore(store) {
+  const key =
+    typeof store?.path === "string" && store.path
+      ? store.path
+      : typeof store?.name === "string" && store.name
+        ? `name:${store.name}`
+        : (store ?? ":anon:");
+  let lock = storeWriteLocks.get(key);
+  if (!lock) {
+    lock = createMutex();
+    storeWriteLocks.set(key, lock);
+  }
+  return lock;
+}
+
+export async function patchStore(store, mutation) {
+  if (!store || typeof store.load !== "function" || typeof store.save !== "function") {
+    throw new Error("patchStore requires a store with load and save");
+  }
   if (
     typeof mutation !== "function" &&
     (mutation === null || typeof mutation !== "object" || Array.isArray(mutation))
   ) {
-    throw new Error("engine-state patch must be a plain object or a (fresh) => patch function");
+    throw new Error("store patch must be a plain object or a (fresh) => patch function");
   }
-  return engineStateWriteLock.runExclusive(async () => {
-    const fresh = (await engineState.load()) ?? {};
+  return lockForStore(store).runExclusive(async () => {
+    const fresh = (await store.load()) ?? {};
     const patch = typeof mutation === "function" ? await mutation(fresh) : mutation;
     if (patch === null || typeof patch !== "object" || Array.isArray(patch)) {
-      throw new Error("engine-state patch must resolve to a plain object");
+      throw new Error("store patch must resolve to a plain object");
     }
     const next = { ...fresh };
     for (const [key, value] of Object.entries(patch)) {
       if (value === undefined) delete next[key];
       else next[key] = value;
     }
-    await engineState.save(next);
+    if (Object.keys(patch).length === 0) return fresh; // pure no-op: no save
+    await store.save(next);
     return next;
   });
+}
+
+// Engine-state's thin re-expression over the store-agnostic patchStore — the
+// original BET-1425 seam, unchanged for its callers.
+export async function patchEngineState(mutation, { engineState = engineStateStore } = {}) {
+  return patchStore(engineState, mutation);
 }
 
 // ---------------------------------------------------------------------------
@@ -312,13 +352,23 @@ function assertRollupLevel(level) {
 // ---------------------------------------------------------------------------
 
 export function createLedgerStore({ path = ctoPath("ledger.jsonl"), now = () => Date.now() } = {}) {
+  // BET-1464 defect 2: ONE write lock shared by the appender and the retention
+  // rewrite. Before this, append was a bare appendFile and the sweep's
+  // rewrite a bare writeFile — an append landing between the sweep's read and
+  // its rewrite was silently lost (appends are constant; the ledger is fed by
+  // the event firehose), and a crash mid-write truncated the whole 180-day
+  // audit ledger.
+  const writeLock = createMutex();
+
   async function append(entry) {
     if (entry === null || typeof entry !== "object") {
       throw new Error("ledger entries must be objects");
     }
     const row = { ...entry, ts: entry.ts != null ? entry.ts : now() };
-    await mkdir(dirname(path), { recursive: true });
-    await appendFile(path, JSON.stringify(row) + "\n", { mode: MODE });
+    return writeLock.runExclusive(async () => {
+      await mkdir(dirname(path), { recursive: true });
+      await appendFile(path, JSON.stringify(row) + "\n", { mode: MODE });
+    });
   }
 
   async function read({ from, to, timeField = "ts" } = {}) {
@@ -347,14 +397,40 @@ export function createLedgerStore({ path = ctoPath("ledger.jsonl"), now = () => 
     return rows;
   }
 
-  // Rewrites the whole file (used by the retention sweep to drop expired rows).
-  async function rewrite(rows) {
+  // Rewrites the whole file atomically (temp file + rename via the SHARED
+  // writeJsonAtomic — the same single atomic-write implementation every other
+  // store in this module uses; the jsonl text is already-serialized bytes, so
+  // no second implementation was needed and the bare writeFile is gone). The
+  // ledger write lock serializes it against concurrent appends; the jsonStore
+  // path mutex underneath covers the rename itself.
+  async function rewriteLocked(rows) {
     const text = rows.map((r) => JSON.stringify(r)).join("\n") + (rows.length ? "\n" : "");
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, text, { mode: MODE });
+    await writeJsonAtomic(path, text, { mode: MODE });
   }
 
-  return { name: "ledger", path, append, read, rewrite };
+  async function rewrite(rows) {
+    if (!Array.isArray(rows)) throw new Error("ledger rewrite rows must be an array");
+    return writeLock.runExclusive(() => rewriteLocked(rows));
+  }
+
+  // The retention sweep primitive (BET-1464 defect 2): read-filter-rewrite as
+  // ONE atomic section under the ledger write lock, so an append concurrent
+  // with a sweep is never lost — it either lands before the section (the
+  // fresh read sees it; fresh rows are never expired) or after the rewrite
+  // (the file already carries the rewritten content), never between. Returns
+  // `{ dropped, wrote }`.
+  async function sweepExpired({ nowMs, retentionMs, timeField = "ts" } = {}) {
+    return writeLock.runExclusive(async () => {
+      const rows = await read();
+      if (rows.length === 0) return { dropped: 0, wrote: false };
+      const { keep, dropped } = expireRows(rows, { nowMs, retentionMs, timeField });
+      if (keep.length === rows.length) return { dropped: 0, wrote: false };
+      await rewriteLocked(keep);
+      return { dropped: dropped.length, wrote: true };
+    });
+  }
+
+  return { name: "ledger", path, append, read, rewrite, sweepExpired };
 }
 
 export const ledgerStore = createLedgerStore();
@@ -519,6 +595,7 @@ export async function sweepInbox(nowMs = Date.now()) {
 // ---------------------------------------------------------------------------
 
 const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+export const CTO_STORE_SWEEP_INTERVAL_MS = SWEEP_INTERVAL_MS;
 
 async function listJsonFiles(dir) {
   let entries;
@@ -538,10 +615,10 @@ async function fileTimestamp(filePath) {
 }
 
 async function sweepLedger(nowMs) {
-  const rows = await ledgerStore.read();
-  if (rows.length === 0) return;
-  const { keep } = expireRows(rows, { nowMs, retentionMs: RETENTION_MS.ledger });
-  if (keep.length !== rows.length) await ledgerStore.rewrite(keep);
+  // BET-1464 defect 2: the sweep is the ledger's own atomic
+  // read-filter-rewrite primitive — no append can be lost between the read
+  // and the rewrite (both hold the ledger's write lock).
+  await ledgerStore.sweepExpired({ nowMs, retentionMs: RETENTION_MS.ledger });
 }
 
 async function sweepVerdicts(nowMs) {

--- a/src/server/ctoStores.test.mjs
+++ b/src/server/ctoStores.test.mjs
@@ -468,7 +468,7 @@ test("patchStore: parallel patches compose — every key lands on the injected s
   assert.equal(after.b, 2, "both increments landed on each other's committed state");
 });
 
-test("patchStore: a patch preserves keys it does not own — a stale-derived patch cannot erase a concurrent writer's key", async () => {
+test("patchStore: a patch preserves keys it does not own — a stale-derived patch cannot erase a concurrent writer's key (scalars AND whole-array replacements)", async () => {
   const store = memoryStore({ X: "old" });
   await patchStore(store, { X: "new" }); // A commits X=new
   // B's patch was derived from a stale snapshot still carrying old X — the
@@ -478,6 +478,21 @@ test("patchStore: a patch preserves keys it does not own — a stale-derived pat
   const after = await store.load();
   assert.equal(after.X, "new", "X survived B's save");
   assert.equal(after.Y, 42, "Y landed");
+
+  // The card/watcher/trust-pending shape: a patch that REPLACES a whole
+  // array. A commits a one-element array; B's stale-derived patch replaces a
+  // different key; then C's mutator (derived FRESH under the mutex) appends
+  // to the array it actually owns. A's rows survive all of it.
+  await patchStore(store, { cards: [{ id: "c1" }] });
+  await patchStore(store, { unrelated: true }); // a stale-derived whole-save would have reverted `cards`
+  const afterArray = await patchStore(store, (fresh) => ({
+    cards: [...(fresh.cards ?? []), { id: "c2" }],
+  }));
+  assert.deepEqual(
+    afterArray.cards.map((c) => c.id),
+    ["c1", "c2"],
+    "the array replacement composed with the unrelated writer's key",
+  );
 });
 
 test("patchStore: an async mutator holds the store mutex across its whole body", async () => {

--- a/src/server/ctoStores.test.mjs
+++ b/src/server/ctoStores.test.mjs
@@ -32,6 +32,9 @@ import {
   purgeExpiredInbox,
   engineStateStore,
   patchEngineState,
+  patchStore,
+  createLedgerStore,
+  startCtoStoreSweeper,
 } from "./ctoStores.mjs";
 import { createStandingQueryEngine, WATCHER_MIGRATION_KEY } from "./ctoWatchers.mjs";
 
@@ -443,4 +446,178 @@ test("durability: an engine-state writer that does not own tonightQueue cannot r
   assert.deepEqual(after.tonightQueue, [], "the removal landed");
   assert.deepEqual(after.pendingBlockers, [{ id: "b1" }], "the blocker survived both saves");
   assert.equal(after.segmentGMinutes, 7, "the late writer's key landed");
+});
+
+// ---------------------------------------------------------------------------
+// BET-1464 defect 3 — patchStore: the store-agnostic generalization of
+// patchEngineState. ONE mutex PER STORE PATH, shared by every writer of the
+// file; async mutators hold it across their whole body (the serialization the
+// per-engine write chains used to give); an empty patch is a pure no-op (no
+// save). All tests below use INJECTED stores — no shared singleton state.
+// ---------------------------------------------------------------------------
+
+test("patchStore: parallel patches compose — every key lands on the injected store", async () => {
+  const store = memoryStore({});
+  await Promise.all([
+    patchStore(store, { a: 1 }),
+    patchStore(store, (fresh) => ({ b: (fresh.b ?? 0) + 1 })),
+    patchStore(store, (fresh) => ({ b: (fresh.b ?? 0) + 1 })),
+  ]);
+  const after = await store.load();
+  assert.equal(after.a, 1);
+  assert.equal(after.b, 2, "both increments landed on each other's committed state");
+});
+
+test("patchStore: a patch preserves keys it does not own — a stale-derived patch cannot erase a concurrent writer's key", async () => {
+  const store = memoryStore({ X: "old" });
+  await patchStore(store, { X: "new" }); // A commits X=new
+  // B's patch was derived from a stale snapshot still carrying old X — the
+  // old whole-payload save shape would resurrect old X (or drop X entirely
+  // when the writer's shape no longer carries it). The per-key merge cannot.
+  await patchStore(store, { Y: 42 });
+  const after = await store.load();
+  assert.equal(after.X, "new", "X survived B's save");
+  assert.equal(after.Y, 42, "Y landed");
+});
+
+test("patchStore: an async mutator holds the store mutex across its whole body", async () => {
+  const store = memoryStore({ n: 0 });
+  let releaseA;
+  const gateA = new Promise((r) => {
+    releaseA = r;
+  });
+  let bRan = false;
+  const a = patchStore(store, async () => {
+    await gateA; // A holds the mutex while suspended mid-body
+    return { n: 1 };
+  });
+  const b = patchStore(store, async () => {
+    bRan = true;
+    return { n: 2 };
+  });
+  // Flush microtasks AND give the timer wheel real turns: B must still not
+  // have started while A's gate is held.
+  await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 5));
+  assert.equal(bRan, false, "B's mutator must wait for A's whole body");
+  releaseA();
+  const afterB = await b;
+  await a;
+  assert.equal(afterB.n, 2, "B re-derived from A's committed state");
+  assert.equal((await store.load()).n, 2);
+});
+
+test("patchStore: an empty patch is a pure no-op — no save fires", async () => {
+  let saves = 0;
+  const store = {
+    load: async () => ({ v: 1, n: 7 }),
+    save: async () => {
+      saves += 1;
+    },
+  };
+  const out = await patchStore(store, {});
+  assert.equal(saves, 0, "a static empty patch saves nothing");
+  assert.equal(out.n, 7, "the fresh state is returned unchanged");
+  await patchStore(store, () => ({})); // the BET-1463 card-writer no-op shape
+  assert.equal(saves, 0, "a mutator resolving to an empty patch saves nothing");
+});
+
+test("patchStore: rejects a store without load/save and a non-object patch", async () => {
+  await assert.rejects(() => patchStore({}, { a: 1 }), /load and save/);
+  await assert.rejects(() => patchStore(memoryStore({}), null), /plain object/);
+  await assert.rejects(() => patchStore(memoryStore({}), () => [1, 2]), /plain object/);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1464 defect 2 — the activity ledger's atomic rewrite. ONE write lock
+// shared by the appender and the retention sweep; the rewrite goes through
+// writeJsonAtomic (temp + rename). The invariant under test: an append
+// concurrent with a sweep is never lost, and a rewrite never truncates the
+// surviving ledger.
+// ---------------------------------------------------------------------------
+
+test("the ledger rewrite is atomic: an append concurrent with a sweep is not lost", async () => {
+  const { rm } = await import("node:fs/promises");
+  const path = ctoPath("ledger-1464-atomicity.jsonl");
+  const store = createLedgerStore({ path, now: () => NOW_MS });
+  const retentionMs = RETENTION_MS.ledger;
+  const cutoff = NOW_MS - retentionMs;
+  try {
+    for (let i = 0; i < 12; i += 1) {
+      await rm(path, { force: true });
+      await store.append({ kind: "old", ts: cutoff - 1 });
+      // Both ops fired in the same tick: the append either lands before the
+      // sweep's locked read (the fresh row is kept — fresh rows are never
+      // expired) or after its rewrite (the file already carries the rewritten
+      // content). It can never land "between" — that window IS the lock.
+      const freshKind = `fresh-${i}`;
+      const sweepP = store.sweepExpired({ nowMs: NOW_MS, retentionMs });
+      const appendP = store.append({ kind: freshKind, ts: NOW_MS });
+      await Promise.all([sweepP, appendP]);
+      const rows = await store.read();
+      assert.ok(
+        rows.some((r) => r.kind === freshKind),
+        `the concurrent append (iter ${i}) must survive the sweep`,
+      );
+      assert.ok(!rows.some((r) => r.kind === "old"), "the expired row is dropped");
+    }
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
+test("the ledger rewrite never truncates a mid-sweep append (the lock is held across the whole sweep section)", async () => {
+  const { rm } = await import("node:fs/promises");
+  const path = ctoPath("ledger-1464-midflight.jsonl");
+  const store = createLedgerStore({ path, now: () => NOW_MS });
+  const retentionMs = RETENTION_MS.ledger;
+  const cutoff = NOW_MS - retentionMs;
+  try {
+    // Seed the expired row plus enough fresh rows that the sweep's
+    // read-filter-rewrite spans real time.
+    await store.append({ kind: "old", ts: cutoff - 1 });
+    for (let i = 0; i < 800; i += 1) {
+      await store.append({ kind: `bulk-${i}`, ts: NOW_MS });
+    }
+    const sweepP = store.sweepExpired({ nowMs: NOW_MS, retentionMs });
+    // Land while the sweep is provably in its locked section.
+    await new Promise((r) => setTimeout(r, 2));
+    await store.append({ kind: "mid-sweep", ts: NOW_MS });
+    await sweepP;
+    const rows = await store.read();
+    assert.ok(rows.some((r) => r.kind === "mid-sweep"), "the mid-sweep append must not be lost");
+    assert.ok(!rows.some((r) => r.kind === "old"), "the expired row is dropped");
+    assert.equal(rows.filter((r) => r.kind?.startsWith("bulk-")).length, 800, "the kept set is intact (no truncation)");
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BET-1464 defect 1 — the retention sweeper actually starts. The poller is
+// real (immediate first tick + the given interval); the assertion is that its
+// sweep removes an expired ledger row from the sandboxed store.
+// ---------------------------------------------------------------------------
+
+test("startCtoStoreSweeper starts a poller that sweeps the stores on its interval", async () => {
+  const { rm } = await import("node:fs/promises");
+  const cutoff = Date.now() - RETENTION_MS.ledger;
+  await ledgerStore.append({ kind: "sweeper-canary", ts: cutoff - 1 });
+  const sweeper = startCtoStoreSweeper({ intervalMs: 15 });
+  try {
+    const deadline = Date.now() + 5000;
+    let gone = false;
+    while (Date.now() < deadline) {
+      const rows = await ledgerStore.read();
+      if (!rows.some((r) => r.kind === "sweeper-canary")) {
+        gone = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    assert.equal(gone, true, "the sweeper's first tick removed the expired ledger row");
+  } finally {
+    sweeper.stop();
+    await rm(ctoPath("ledger-1464-atomicity.jsonl"), { force: true });
+  }
 });

--- a/src/server/ctoSweeperWiring.test.mjs
+++ b/src/server/ctoSweeperWiring.test.mjs
@@ -1,0 +1,39 @@
+// ctoSweeperWiring.test.mjs — BET-1464 defect 1 wiring gate. index.mjs cannot
+// be imported (it boots the server on import), so the sweeper's startup
+// wiring is asserted by a source scan: the poller must be imported from
+// ctoStores.mjs, started alongside the other CTO pollers (after the watchdog
+// poller, in the CTO poller family block), and bound to a stop handle — the
+// exact pattern every other CTO poller follows.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const indexSource = readFileSync(join(here, "index.mjs"), "utf8");
+
+test("wiring: index.mjs starts the CTO store retention sweeper (BET-1464 defect 1)", () => {
+  assert.ok(
+    /import \{[^}]*startCtoStoreSweeper[^}]*\} from "\.\/ctoStores\.mjs"/.test(indexSource),
+    "startCtoStoreSweeper must be imported from ./ctoStores.mjs",
+  );
+  assert.ok(
+    /const stopCtoStoreSweeper = startCtoStoreSweeper\(\{/.test(indexSource),
+    "the sweeper must be started and its stop handle bound, like every other CTO poller",
+  );
+  assert.ok(
+    indexSource.includes("CTO_STORE_SWEEP_INTERVAL_MS"),
+    "the sweep interval must come from the shared constant",
+  );
+  // Same poller family as the engine/digest/suggest/watchdog pollers: the
+  // sweeper's start sits inside the CTO startup block, after the watchdog.
+  const watchdogStart = indexSource.indexOf("startPoller(adaptiveCtoWatchdog.tick");
+  const sweeperStart = indexSource.indexOf("startCtoStoreSweeper({");
+  assert.ok(watchdogStart !== -1, "the watchdog poller block must exist (family anchor)");
+  assert.ok(
+    sweeperStart > watchdogStart,
+    "the sweeper must start within the CTO poller family (after the watchdog poller)",
+  );
+});

--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -20,7 +20,7 @@
 //
 // All I/O is injected; pure helpers are exported for tests.
 
-import { toolRegistryStore, toolUsageStore, ledgerStore } from "./ctoStores.mjs";
+import { toolRegistryStore, toolUsageStore, ledgerStore, patchStore } from "./ctoStores.mjs";
 import { displayName as catalogDisplayName } from "./ctoToolCatalog.mjs";
 import {
   CHANNEL_TRANSCRIPT,
@@ -390,7 +390,7 @@ export function createToolRegistry(deps = {}) {
   // and normalize via payloadFrom; returning an empty patch means "no
   // change, no save" (the early-exit error paths rely on that).
   function patchRegistry(mutate) {
-    return patchStore(registryStore, async (fresh) => mutate(payloadFrom(fresh)));
+    return patchStore(registryStore, async (fresh) => (await mutate(payloadFrom(fresh))) ?? {});
   }
 
   async function loadPayload() {

--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -35,6 +35,31 @@ import { vitalityOf, CADENCE_WEEKLY_MS } from "./ctoProbes.mjs";
 import { betaLowerBound } from "./ctoVerdicts.mjs";
 
 export const TOOL_REGISTRY_VERSION = 1;
+
+// The raw store payload → the working registry shape (the writers' shared
+// normalization, BET-1440's single source): rows persisted before the
+// deep-read/decay fields existed are back-filled so every consumer sees the
+// fields at their §7.2-schema defaults (spread order: stored row wins). Pure.
+function payloadFrom(raw) {
+  const p = raw && typeof raw === "object" ? raw : {};
+  return {
+    v: TOOL_REGISTRY_VERSION,
+    tools: (Array.isArray(p?.tools) ? p.tools : []).map((t) => ({
+      deepAskRound: 0,
+      deepAskAtUses: 0,
+      deepReArmAt: null,
+      deepAskBarMet: false,
+      lastDeepAskDay: null,
+      asSourceDecayed: false,
+      decayedAtUses: 0,
+      ...(t ?? {}),
+    })),
+    lastScanTs: Number.isFinite(p?.lastScanTs) ? p.lastScanTs : null,
+    lastFusedTs: Number.isFinite(p?.lastFusedTs) ? p.lastFusedTs : null,
+    lastAskDay: typeof p?.lastAskDay === "string" ? p.lastAskDay : null,
+    lastDeepAskDay: typeof p?.lastDeepAskDay === "string" ? p.lastDeepAskDay : null,
+  };
+}
 export const ACTOR = "cto";
 
 // Evidence-log cap (all channels) — the usage log is a bounded FIFO.
@@ -352,68 +377,28 @@ export function createToolRegistry(deps = {}) {
     scaffoldProbes = null,
   } = deps;
 
+  // BET-1464 defect 3: every tool-registry.json write routes through
+  // patchStore — the read-fresh-merge-save runs under the registry store's
+  // own mutex, keyed by the store path. This replaces the old per-instance
+  // write chain (`serialized`) with the ONE shared discipline every CTO
+  // store writer uses: a writer whose body awaits (the scan's db batch, the
+  // LLM classification, the consent-time probe scaffold) holds the mutex
+  // across the whole body, so a connect answer landing mid-scan can no
+  // longer be silently overwritten by the scan's stale save — the user's
+  // explicit "never" reverting (the same snapshot-spreading-writer class
+  // BET-1425 fixed for engine-state). Mutators receive the RAW store payload
+  // and normalize via payloadFrom; returning an empty patch means "no
+  // change, no save" (the early-exit error paths rely on that).
+  function patchRegistry(mutate) {
+    return patchStore(registryStore, async (fresh) => mutate(payloadFrom(fresh)));
+  }
+
   async function loadPayload() {
     try {
-      const p = await registryStore.load();
-      return {
-        v: TOOL_REGISTRY_VERSION,
-        // Rows persisted before the deep-read/decay fields existed are
-        // back-filled here so every consumer sees the fields at their
-        // §7.2-schema defaults (spread order: stored row wins).
-        tools: (Array.isArray(p?.tools) ? p.tools : []).map((t) => ({
-          deepAskRound: 0,
-          deepAskAtUses: 0,
-          deepReArmAt: null,
-          deepAskBarMet: false,
-          lastDeepAskDay: null,
-          asSourceDecayed: false,
-          decayedAtUses: 0,
-          ...(t ?? {}),
-        })),
-        lastScanTs: Number.isFinite(p?.lastScanTs) ? p.lastScanTs : null,
-        lastFusedTs: Number.isFinite(p?.lastFusedTs) ? p.lastFusedTs : null,
-        lastAskDay: typeof p?.lastAskDay === "string" ? p.lastAskDay : null,
-        lastDeepAskDay: typeof p?.lastDeepAskDay === "string" ? p.lastDeepAskDay : null,
-      };
+      return payloadFrom(await registryStore.load());
     } catch {
       return { v: TOOL_REGISTRY_VERSION, tools: [], lastScanTs: null, lastFusedTs: null, lastAskDay: null, lastDeepAskDay: null };
     }
-  }
-
-  async function savePayload(payload) {
-    await registryStore.save(payload);
-  }
-
-  // Shared preamble for the tool-scoped writers: normalize the toolId, load
-  // the whole-payload store, find the row. Returns `{ ok: false, error }` on
-  // failure or `{ ok: true, id, payload, t }` on success. Single source for
-  // the block the duplication gate flagged file↔file (BET-1440).
-  async function resolveToolRow(toolId) {
-    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
-    if (!id) return { ok: false, error: "missing tool" };
-    const payload = await loadPayload();
-    const t = payload.tools.find((x) => x?.tool === id);
-    if (!t) return { ok: false, error: `unknown tool "${id}"` };
-    return { ok: true, id, payload, t };
-  }
-
-  // Serializes the registry's mutating writers (dailyScan / resolveConnect /
-  // unNever) — all load→mutate→save the same whole-payload store, and the
-  // scan holds its snapshot across seconds-long awaits (db batch, LLM
-  // classification). Without the guard, a connect answer landing mid-scan is
-  // silently overwritten by the scan's stale save — the user's explicit
-  // "never" reverting (lost update; the same snapshot-spreading-writer class
-  // BET-1425 fixed for engine-state). Writers queue behind the in-flight one
-  // (the established in-flight-guard pattern); each mutation is short except
-  // the scan, whose internal failures never leave the queue stuck.
-  let writeChain = Promise.resolve();
-  function serialized(fn) {
-    const run = writeChain.then(fn, fn);
-    writeChain = run.then(
-      () => {},
-      () => {},
-    );
-    return run;
   }
 
   async function ledgerLog(entry) {
@@ -425,12 +410,16 @@ export function createToolRegistry(deps = {}) {
   }
 
   // Append evidence rows to the bounded usage log (all channels funnel here —
-  // the §7.1 log). Returns the number of rows appended.
+  // the §7.1 log). Returns the number of rows appended. The usage log is its
+  // own file, so its patch mutex is the usage store's own (BET-1464 defect 3
+  // — two concurrent channels could previously drop each other's rows).
   async function appendUsage(rows) {
     if (!rows.length) return 0;
-    const payload = (await usageStore.load().catch(() => ({}))) ?? {};
-    const prev = Array.isArray(payload.rows) ? payload.rows : [];
-    await usageStore.save({ ...payload, rows: [...prev, ...rows].slice(-USAGE_ROWS_CAP) });
+    await patchStore(usageStore, (fresh) => {
+      const payload = fresh && typeof fresh === "object" ? fresh : {};
+      const prev = Array.isArray(payload.rows) ? payload.rows : [];
+      return { rows: [...prev, ...rows].slice(-USAGE_ROWS_CAP) };
+    });
     return rows.length;
   }
 
@@ -685,35 +674,42 @@ export function createToolRegistry(deps = {}) {
 
   // The daily batch (§7.1-2/3 + §7.3). First scan after install runs over the
   // cold-start backfill range; later scans run since the previous watermark.
-  // Returns `{ok, scanned, asked}`.
+  // The whole body runs under the registry store's mutex (BET-1464 defect 3):
+  // the scan holds its snapshot across seconds-long awaits, so without the
+  // mutex a connect answer landing mid-scan would be reverted by the scan's
+  // save. Returns `{ok, scanned, asked}`.
   async function dailyScan() {
     const nowMs = now();
     const untilTs = nowMs;
-    const payload = await loadPayload();
-    const sinceTs =
-      payload.lastScanTs ??
-      (Number.isFinite(backfillStartInstant) ? backfillStartInstant : nowMs - 30 * DAY_MS);
-
     const rows = [];
-    try {
-      if (typeof collectDb === "function") {
-        const dbRows = await collectDb({ sinceTs, untilTs, cap: SCAN_ROW_CAP });
-        rows.push(...extractFromDbRows(dbRows));
+    let asked = null;
+    let scanLedger = false;
+    await patchRegistry(async (payload) => {
+      const sinceTs =
+        payload.lastScanTs ??
+        (Number.isFinite(backfillStartInstant) ? backfillStartInstant : nowMs - 30 * DAY_MS);
+      try {
+        if (typeof collectDb === "function") {
+          const dbRows = await collectDb({ sinceTs, untilTs, cap: SCAN_ROW_CAP });
+          rows.push(...extractFromDbRows(dbRows));
+        }
+        if (typeof collectSurfaces === "function") {
+          const surfaces = (await collectSurfaces()) ?? {};
+          rows.push(...collectConfigEvidence(surfaces, { ts: nowMs }));
+        }
+      } catch {
+        /* channel failures never take the scan down */
       }
-      if (typeof collectSurfaces === "function") {
-        const surfaces = (await collectSurfaces()) ?? {};
-        rows.push(...collectConfigEvidence(surfaces, { ts: nowMs }));
-      }
-    } catch {
-      /* channel failures never take the scan down */
-    }
-    await appendUsage(rows);
-    await fusePending(payload);
-    await classifyOneRaw(payload);
-    const { changed, asked } = await lifecycleStep(payload);
-    payload.lastScanTs = untilTs;
-    await savePayload(payload);
-    if (changed || asked) {
+      await appendUsage(rows);
+      await fusePending(payload);
+      await classifyOneRaw(payload);
+      const { changed, asked: askTool } = await lifecycleStep(payload);
+      payload.lastScanTs = untilTs;
+      asked = askTool;
+      scanLedger = changed || askTool != null;
+      return payload;
+    });
+    if (scanLedger) {
       await ledgerLog({ kind: "cto.tool.scan", asked: asked ?? null });
     }
     return { ok: true, scanned: rows.length, asked: asked ?? null };
@@ -736,51 +732,62 @@ export function createToolRegistry(deps = {}) {
     if (ring !== "metadata" && ring !== "deep_read") {
       return { ok: false, error: `invalid ring "${ring}"` };
     }
-    const payload = await loadPayload();
-    const t = payload.tools.find((x) => x?.tool === id);
-    if (!t) return { ok: false, error: `unknown tool "${id}"` };
     const nowMs = now();
-    t.consent = t.consent ?? emptyConsent();
-    if (answer === "connect") {
-      if (ring === "deep_read") {
-        if (t.consent.metadata !== "yes") return { ok: false, error: `tool "${id}" has no metadata consent` };
-        t.consent.deep_read = "yes";
-        t.deepReArmAt = null;
-        await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "deep_read", value: "yes" });
-      } else {
-        // The metadata ring is granted. Status stays `candidate` until the
-        // first §7.5 probe actually runs (applyProbeResult flips it).
-        t.consent.metadata = "yes";
-        t.reArmAt = null;
-        await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "yes" });
-        // §7.5 BET-1396: the ENGINE authors the tool's probe-spec template at
-        // consent time, filled with the evidenced credential key (if any). The
-        // file is engine-written; its content is completed through the runner's
-        // validated writeSpec path. Best-effort — consent never depends on it.
-        if (typeof scaffoldProbes === "function") {
-          const secretRow = (t.evidence ?? []).find((e) => e?.channel === "secret" && typeof e?.detail === "string" && e.detail.startsWith("secret:"));
-          await scaffoldProbes(id, { secret: secretRow ? secretRow.detail.slice("secret:".length) : null }).catch(() => {});
+    // The consent write runs under the registry store's mutex (BET-1464
+    // defect 3). An early-exit error path returns an empty patch: no save.
+    let err = null;
+    await patchRegistry(async (payload) => {
+      const t = payload.tools.find((x) => x?.tool === id);
+      if (!t) {
+        err = { ok: false, error: `unknown tool "${id}"` };
+        return null;
+      }
+      t.consent = t.consent ?? emptyConsent();
+      if (answer === "connect") {
+        if (ring === "deep_read") {
+          if (t.consent.metadata !== "yes") {
+            err = { ok: false, error: `tool "${id}" has no metadata consent` };
+            return null;
+          }
+          t.consent.deep_read = "yes";
+          t.deepReArmAt = null;
+          await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "deep_read", value: "yes" });
+        } else {
+          // The metadata ring is granted. Status stays `candidate` until the
+          // first §7.5 probe actually runs (applyProbeResult flips it).
+          t.consent.metadata = "yes";
+          t.reArmAt = null;
+          await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "yes" });
+          // §7.5 BET-1396: the ENGINE authors the tool's probe-spec template at
+          // consent time, filled with the evidenced credential key (if any). The
+          // file is engine-written; its content is completed through the runner's
+          // validated writeSpec path. Best-effort — consent never depends on it.
+          if (typeof scaffoldProbes === "function") {
+            const secretRow = (t.evidence ?? []).find((e) => e?.channel === "secret" && typeof e?.detail === "string" && e.detail.startsWith("secret:"));
+            await scaffoldProbes(id, { secret: secretRow ? secretRow.detail.slice("secret:".length) : null }).catch(() => {});
+          }
         }
-      }
-    } else if (answer === "not-now") {
-      if (ring === "deep_read") {
-        t.consent.deep_read = "no";
-        t.deepReArmAt = nowMs + NOT_NOW_REARM_MS;
-        t.deepAskAtUses = t.uses ?? 0;
-        await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "deep_read", value: "no" });
+      } else if (answer === "not-now") {
+        if (ring === "deep_read") {
+          t.consent.deep_read = "no";
+          t.deepReArmAt = nowMs + NOT_NOW_REARM_MS;
+          t.deepAskAtUses = t.uses ?? 0;
+          await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "deep_read", value: "no" });
+        } else {
+          t.consent.metadata = "no";
+          t.reArmAt = nowMs + NOT_NOW_REARM_MS;
+          t.askAtUses = t.uses ?? 0;
+          await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "no" });
+        }
       } else {
-        t.consent.metadata = "no";
-        t.reArmAt = nowMs + NOT_NOW_REARM_MS;
-        t.askAtUses = t.uses ?? 0;
-        await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "no" });
+        // Never: kills ALL rings and suppresses future asks (revocable only in
+        // the §10.5 tool drill-down).
+        t.consent = { metadata: "never", deep_read: "never", write: "never" };
+        await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "never" });
       }
-    } else {
-      // Never: kills ALL rings and suppresses future asks (revocable only in
-      // the §10.5 tool drill-down).
-      t.consent = { metadata: "never", deep_read: "never", write: "never" };
-      await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "metadata", value: "never" });
-    }
-    await savePayload(payload);
+      return payload;
+    });
+    if (err) return err;
 
     // §9.5: every UI control that expresses a judgment writes exactly one
     // verdict. Connect → accept; Not now → dismiss; Never → never. The class
@@ -821,16 +828,29 @@ export function createToolRegistry(deps = {}) {
   // exists to prevent). The server rule ships here; the drill-down UI/route
   // is B11's.
   async function unNever(toolId) {
-    const r = await resolveToolRow(toolId);
-    if (!r.ok) return r;
-    const { id, payload, t } = r;
-    if (t.consent?.metadata !== "never") return { ok: false, error: `tool "${id}" is not never'd` };
-    t.consent = emptyConsent();
-    t.status = "observed";
-    t.unneverAtUses = t.uses ?? 0;
-    t.reArmAt = null;
-    await savePayload(payload);
-    await ledgerLog({ kind: "cto.tool.unnever", tool: id, uses: t.uses });
+    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
+    if (!id) return { ok: false, error: "missing tool" };
+    let err = null;
+    let uses = 0;
+    await patchRegistry(async (payload) => {
+      const t = payload.tools.find((x) => x?.tool === id);
+      if (!t) {
+        err = { ok: false, error: `unknown tool "${id}"` };
+        return null;
+      }
+      if (t.consent?.metadata !== "never") {
+        err = { ok: false, error: `tool "${id}" is not never'd` };
+        return null;
+      }
+      t.consent = emptyConsent();
+      t.status = "observed";
+      t.unneverAtUses = t.uses ?? 0;
+      t.reArmAt = null;
+      uses = t.uses ?? 0;
+      return payload;
+    });
+    if (err) return err;
+    await ledgerLog({ kind: "cto.tool.unnever", tool: id, uses });
     return { ok: true, tool: id };
   }
 
@@ -846,13 +866,22 @@ export function createToolRegistry(deps = {}) {
     if (ring !== "metadata" && ring !== "deep_read" && ring !== "write") {
       return { ok: false, error: `ring must be one of metadata, deep_read, write` };
     }
-    const payload = await loadPayload();
-    const t = payload.tools.find((x) => x?.tool === id);
-    if (!t) return { ok: false, error: `unknown tool "${id}"` };
-    const cur = { ...emptyConsent(), ...(t.consent ?? {}) };
-    if (cur[ring] !== "yes") return { ok: false, error: `ring "${ring}" is not granted for "${id}"` };
-    t.consent = { ...cur, [ring]: "no" };
-    await savePayload(payload);
+    let err = null;
+    await patchRegistry(async (payload) => {
+      const t = payload.tools.find((x) => x?.tool === id);
+      if (!t) {
+        err = { ok: false, error: `unknown tool "${id}"` };
+        return null;
+      }
+      const cur = { ...emptyConsent(), ...(t.consent ?? {}) };
+      if (cur[ring] !== "yes") {
+        err = { ok: false, error: `ring "${ring}" is not granted for "${id}"` };
+        return null;
+      }
+      t.consent = { ...cur, [ring]: "no" };
+      return payload;
+    });
+    if (err) return err;
     await ledgerLog({ kind: "cto.tool.consent", tool: id, ring, value: "no" });
     return { ok: true, tool: id, ring, value: "no" };
   }
@@ -869,8 +898,9 @@ export function createToolRegistry(deps = {}) {
 
   // ---------------------------------------------------------------------------
   // BET-1396 — §7.3 vitality / §7.6 relevance / §7.4 lifecycle. All mutating
-  // writers go through `serialized` (the whole-payload store's lost-update
-  // guard, same as the scan/connect writers).
+  // writers are patchStore writers (BET-1464 defect 3) — the whole-payload
+  // store's lost-update guard is the store mutex, shared with the scan and
+  // connect writers.
   // ---------------------------------------------------------------------------
 
   // The full row for one tool (probe runner reads evidence hosts + vitality;
@@ -900,36 +930,47 @@ export function createToolRegistry(deps = {}) {
   // The rate is EWMA-smoothed (τ = 7d, the engagement axis's constant) into
   // `vitality.ewma` — the runner reads it for the daily↔weekly adaptation.
   // First success also flips §7.4 candidate → integrated (probes ran).
-  // NOTE: the body does NOT self-serialize — the exported wrapper already
-  // routes through `serialized` (nesting would deadlock the write chain).
+  // NOTE: the body itself runs under the registry store's mutex — no
+  // wrapper serialization exists any more (BET-1464 defect 3); nesting a
+  // second patchStore on the same store would deadlock the promise tail.
   async function applyProbeResult(toolId, { fields, probedAt, cadenceMs } = {}) {
-    const r = await resolveToolRow(toolId);
-    if (!r.ok) return r;
-    const { id, payload, t } = r;
+    const id = typeof toolId === "string" ? toolId.trim().toLowerCase() : "";
+    if (!id) return { ok: false, error: "missing tool" };
     const vit = vitalityOf(fields);
-    t.vitality = t.vitality ?? { last_event: null, inflow_rate: null, ewma: null, last_probed: null };
-    const v = t.vitality;
-    const ts = typeof probedAt === "number" ? probedAt : now();
-    if (vit.last_event !== undefined) v.last_event = vit.last_event;
-    if (vit.inflow_rate !== undefined) {
-      const cad = Number.isFinite(cadenceMs) && cadenceMs > 0 ? cadenceMs : WEEK_MS;
-      const elapsed = Number.isFinite(v.last_probed) ? Math.max(ts - v.last_probed, 1) : cad;
-      const ratePerWeek = (vit.inflow_rate * WEEK_MS) / elapsed;
-      const decay = Math.exp(-(elapsed / DAY_MS) / EWMA_TAU_DAYS);
-      v.ewma = v.ewma == null ? ratePerWeek : v.ewma * decay + ratePerWeek * (1 - decay);
-      v.inflow_rate = vit.inflow_rate;
-    }
-    v.last_probed = ts;
+    let err = null;
     let flipped = false;
-    if (t.status === "candidate") {
-      t.status = "integrated";
-      flipped = true;
-    }
-    await savePayload(payload);
+    let vitality = null;
+    await patchRegistry(async (payload) => {
+      const t = payload.tools.find((x) => x?.tool === id);
+      if (!t) {
+        err = { ok: false, error: `unknown tool "${id}"` };
+        return null;
+      }
+      t.vitality = t.vitality ?? { last_event: null, inflow_rate: null, ewma: null, last_probed: null };
+      const v = t.vitality;
+      const ts = typeof probedAt === "number" ? probedAt : now();
+      if (vit.last_event !== undefined) v.last_event = vit.last_event;
+      if (vit.inflow_rate !== undefined) {
+        const cad = Number.isFinite(cadenceMs) && cadenceMs > 0 ? cadenceMs : WEEK_MS;
+        const elapsed = Number.isFinite(v.last_probed) ? Math.max(ts - v.last_probed, 1) : cad;
+        const ratePerWeek = (vit.inflow_rate * WEEK_MS) / elapsed;
+        const decay = Math.exp(-(elapsed / DAY_MS) / EWMA_TAU_DAYS);
+        v.ewma = v.ewma == null ? ratePerWeek : v.ewma * decay + ratePerWeek * (1 - decay);
+        v.inflow_rate = vit.inflow_rate;
+      }
+      v.last_probed = ts;
+      if (t.status === "candidate") {
+        t.status = "integrated";
+        flipped = true;
+      }
+      vitality = { ...v };
+      return payload;
+    });
+    if (err) return err;
     if (flipped) {
       await ledgerLog({ kind: "cto.tool.integrated", tool: id });
     }
-    return { ok: true, vitality: { ...v }, flipped };
+    return { ok: true, vitality, flipped };
   }
 
   // §7.6 relevance: persist the weekly nano-score for one (tool, project)
@@ -939,11 +980,17 @@ export function createToolRegistry(deps = {}) {
     if (!id || typeof project !== "string" || !project) return { ok: false, error: "missing tool/project" };
     const s = Number(score);
     if (!Number.isFinite(s)) return { ok: false, error: "invalid score" };
-    const payload = await loadPayload();
-    const t = payload.tools.find((x) => x?.tool === id);
-    if (!t) return { ok: false, error: `unknown tool "${id}"` };
-    t.relevance = { ...(t.relevance ?? {}), [project]: Math.max(0, Math.min(1, s)) };
-    await savePayload(payload);
+    let err = null;
+    await patchRegistry(async (payload) => {
+      const t = payload.tools.find((x) => x?.tool === id);
+      if (!t) {
+        err = { ok: false, error: `unknown tool "${id}"` };
+        return null;
+      }
+      t.relevance = { ...(t.relevance ?? {}), [project]: Math.max(0, Math.min(1, s)) };
+      return payload;
+    });
+    if (err) return err;
     return { ok: true };
   }
 
@@ -963,29 +1010,37 @@ export function createToolRegistry(deps = {}) {
     const e = effects && typeof effects === "object" ? effects : {};
     const isReport = e.success === true || e.rejection === true;
     if (!isReport) return { ok: true, changed: false };
-    const r = await resolveToolRow(id);
-    if (!r.ok) return r;
-    const { payload, t } = r;
-    t.as_source = t.as_source ?? { reports: 0, accepted: 0 };
-    if (e.success === true) t.as_source.accepted = (t.as_source.accepted ?? 0) + 1;
-    t.as_source.reports = (t.as_source.reports ?? 0) + 1;
-    const reports = t.as_source.reports;
-    const rejected = reports - (t.as_source.accepted ?? 0);
-    const tripped =
-      reports >= AS_SOURCE_MIN_REPORTS &&
-      betaLowerBound(t.as_source.accepted ?? 0, rejected) < AS_SOURCE_DECAY_LOWER_BOUND;
-    if (tripped && t.asSourceDecayed !== true) {
-      t.asSourceDecayed = true;
-      t.decayedAtUses = t.uses ?? 0;
-      await ledgerLog({
-        kind: "cto.tool.as_source_decayed",
-        tool: id,
-        reports,
-        accepted: t.as_source.accepted ?? 0,
-      });
-    }
-    await savePayload(payload);
-    return { ok: true, changed: true, as_source: { ...t.as_source }, decayed: t.asSourceDecayed === true };
+    let err = null;
+    let out = null;
+    await patchRegistry(async (payload) => {
+      const t = payload.tools.find((x) => x?.tool === id);
+      if (!t) {
+        err = { ok: false, error: `unknown tool "${id}"` };
+        return null;
+      }
+      t.as_source = t.as_source ?? { reports: 0, accepted: 0 };
+      if (e.success === true) t.as_source.accepted = (t.as_source.accepted ?? 0) + 1;
+      t.as_source.reports = (t.as_source.reports ?? 0) + 1;
+      const reports = t.as_source.reports;
+      const rejected = reports - (t.as_source.accepted ?? 0);
+      const tripped =
+        reports >= AS_SOURCE_MIN_REPORTS &&
+        betaLowerBound(t.as_source.accepted ?? 0, rejected) < AS_SOURCE_DECAY_LOWER_BOUND;
+      if (tripped && t.asSourceDecayed !== true) {
+        t.asSourceDecayed = true;
+        t.decayedAtUses = t.uses ?? 0;
+        await ledgerLog({
+          kind: "cto.tool.as_source_decayed",
+          tool: id,
+          reports,
+          accepted: t.as_source.accepted ?? 0,
+        });
+      }
+      out = { ok: true, changed: true, as_source: { ...t.as_source }, decayed: t.asSourceDecayed === true };
+      return payload;
+    });
+    if (err) return err;
+    return out;
   }
 
   // One evidence row on the tool's trail (probe failures; §7.2 evidence
@@ -995,16 +1050,24 @@ export function createToolRegistry(deps = {}) {
     if (!id || !entry || typeof entry.channel !== "string" || typeof entry.detail !== "string") {
       return { ok: false, error: "missing tool/evidence" };
     }
-    const payload = await loadPayload();
-    const t = payload.tools.find((x) => x?.tool === id);
-    if (!t) return { ok: false, error: `unknown tool "${id}"` };
-    const row = { channel: entry.channel, detail: entry.detail, ts: Number.isFinite(entry.ts) ? entry.ts : now() };
-    const exists = (t.evidence ?? []).some((e) => e?.channel === row.channel && e?.detail === row.detail);
-    if (exists) return { ok: true, changed: false };
-    t.evidence = [...(t.evidence ?? []), row];
-    if (t.evidence.length > EVIDENCE_CAP) t.evidence.splice(0, t.evidence.length - EVIDENCE_CAP);
-    await savePayload(payload);
-    return { ok: true, changed: true };
+    let err = null;
+    let changed = false;
+    await patchRegistry(async (payload) => {
+      const t = payload.tools.find((x) => x?.tool === id);
+      if (!t) {
+        err = { ok: false, error: `unknown tool "${id}"` };
+        return null;
+      }
+      const row = { channel: entry.channel, detail: entry.detail, ts: Number.isFinite(entry.ts) ? entry.ts : now() };
+      const exists = (t.evidence ?? []).some((e) => e?.channel === row.channel && e?.detail === row.detail);
+      if (exists) return null; // dedupe — an empty patch, no save
+      t.evidence = [...(t.evidence ?? []), row];
+      if (t.evidence.length > EVIDENCE_CAP) t.evidence.splice(0, t.evidence.length - EVIDENCE_CAP);
+      changed = true;
+      return payload;
+    });
+    if (err) return err;
+    return { ok: true, changed };
   }
 
   // Registry view for the §10.5 tool surfaces (read-only, stable shape).
@@ -1043,24 +1106,24 @@ export function createToolRegistry(deps = {}) {
   }
 
   return {
-    dailyScan: () => serialized(dailyScan),
-    resolveConnect: (input) => serialized(() => resolveConnect(input)),
-    unNever: (toolId) => serialized(() => unNever(toolId)),
-    revokeConsent: (toolId, ring) => serialized(() => revokeConsent(toolId, ring)),
+    dailyScan,
+    resolveConnect,
+    unNever,
+    revokeConsent,
     consentFor,
     listTools,
     appendUsage,
     // BET-1396: §7.5 probe-runner surface (read the row, fold vitality /
-    // relevance, append failure evidence). toolRow is a pure read — no
-    // serialization (it must never queue behind an in-flight scan).
+    // relevance, append failure evidence). toolRow is a pure read — it never
+    // touches the write mutex (must never queue behind an in-flight scan).
     toolRow,
-    applyProbeResult: (toolId, input) => serialized(() => applyProbeResult(toolId, input)),
-    applyRelevance: (toolId, project, score) => serialized(() => applyRelevance(toolId, project, score)),
-    appendEvidence: (toolId, entry) => serialized(() => appendEvidence(toolId, entry)),
-    // §9.5 as_source sink target (BET-1404) — serialized like the other
-    // whole-payload writers; the verdict sink is fire-and-forget, so the
-    // guard keeps concurrent folds from clobbering each other.
-    applyAsSource: (toolId, effects) => serialized(() => applyAsSource(toolId, effects)),
+    applyProbeResult,
+    applyRelevance,
+    appendEvidence,
+    // §9.5 as_source sink target (BET-1404) — a patchStore writer like the
+    // others; the verdict sink is fire-and-forget, so the mutex keeps
+    // concurrent folds from clobbering each other.
+    applyAsSource,
     // §7.6 decay chain: the runner asks instead of deriving chain state.
     probeCadenceCapMs,
   };

--- a/src/server/ctoTrust.mjs
+++ b/src/server/ctoTrust.mjs
@@ -26,7 +26,7 @@
 // Pure over injected stores + a now() clock — testable without a live box.
 
 import { betaTailAbove } from "./ctoVerdicts.mjs";
-import { appendLedgerBestEffort, engineStateStore, ledgerStore, trustStore, verdictsStore } from "./ctoStores.mjs";
+import { appendLedgerBestEffort, engineStateStore, ledgerStore, patchStore, trustStore, verdictsStore } from "./ctoStores.mjs";
 
 // The §3.5 ladder rungs, lowest → highest. `ask` covers the ask verbs
 // (silent-log / inbox card / notify — ctoSuggest picks within the rung);
@@ -147,20 +147,19 @@ export function createCtoTrust(deps = {}) {
     return appendLedgerBestEffort(ledger, now(), entry);
   }
 
-  async function loadState() {
-    let st = null;
-    try {
-      st = (await store.load()) ?? null;
-    } catch {
-      st = null;
-    }
+  // Derive the working state from a raw store payload, applying the one-time
+  // legacy `es.trust` adoption when the dedicated store is still fresh
+  // (shared by the read path and, under the store mutex, the writers).
+  async function stFromRaw(raw) {
+    let st = raw && typeof raw === "object" ? raw : null;
+    let adopted = false;
     // One-time migration (review cycle 4): trust used to live under the
     // shared engine-state file's `trust` key. If the dedicated store is
     // still fresh and a legacy payload exists, adopt it — after the first
     // write the dedicated store is authoritative and `es.trust` becomes a
     // harmless fossil no reader consults. Idempotent: the store being
     // non-empty short-circuits the legacy read entirely.
-    if (!st || typeof st !== "object" || (!st.v && !st.tiers && !st.stats && !st.pending)) {
+    if (!st || (!st.v && !st.tiers && !st.stats && !st.pending)) {
       let es = {};
       try {
         es = (await legacy?.load?.()) ?? {};
@@ -169,10 +168,25 @@ export function createCtoTrust(deps = {}) {
       }
       if (es.trust && typeof es.trust === "object" && (es.trust.tiers || es.trust.stats || es.trust.pending)) {
         st = es.trust;
-        await store.save(st).catch(() => {});
+        adopted = true;
       } else {
         st = {};
       }
+    }
+    return { st, adopted };
+  }
+
+  async function loadState() {
+    let st = null;
+    try {
+      st = (await store.load()) ?? null;
+    } catch {
+      st = null;
+    }
+    const derived = await stFromRaw(st);
+    st = derived.st;
+    if (derived.adopted) {
+      await store.save(st).catch(() => {});
     }
     return {
       st,
@@ -182,18 +196,29 @@ export function createCtoTrust(deps = {}) {
     };
   }
 
-  async function saveState(_snapshot, st) {
-    // Trust persists to its OWN file — the durability invariant (review
-    // cycle 4): no engine-state writer shape (snapshot-spread or otherwise)
-    // can revert tiers/counters/pending, because no engine-state writer
-    // touches this file. Callers pass a legacy snapshot for compatibility;
-    // it is never spread. `v` stamps the payload so a later load treats the
-    // store as authoritative even when it only holds the pending queue.
-    try {
-      await store.save({ ...(st ?? {}), v: st?.v ?? 1 });
-    } catch {
-      /* best-effort */
-    }
+  // BET-1464 defect 3: the trust writers' shared read-fresh-merge-save path —
+  // patchStore re-derives the working state from the FRESH payload inside the
+  // trust store's mutex (including the one-time legacy adoption, which the
+  // resulting patch persists — no separate unlocked save), runs the mutator,
+  // and persists the tiers/stats/pending keys. An empty patch is a pure
+  // no-op (no save). The old shape — loadState, mutate, saveState of a whole
+  // snapshot — could revert a concurrent writer's counters or queue rows.
+  async function patchState(mutate) {
+    return patchStore(store, async (fresh) => {
+      const { st } = await stFromRaw(fresh);
+      const patch = await mutate({
+        st,
+        tiers: (st.tiers && typeof st.tiers === "object") ? st.tiers : {},
+        stats: (st.stats && typeof st.stats === "object") ? st.stats : {},
+        pending: Array.isArray(st.pending) ? st.pending : [],
+      });
+      if (!patch) return {};
+      return {
+        tiers: patch.tiers ?? {},
+        stats: patch.stats ?? {},
+        pending: Array.isArray(patch.pending) ? patch.pending : [],
+      };
+    });
   }
 
   async function countVerdicts() {
@@ -226,48 +251,51 @@ export function createCtoTrust(deps = {}) {
   // non-counter outcome (e.g. a veto cancel when already at act) in the
   // rolling window without touching either Beta.
   async function applyOutcome(cls, { field = null, ok }) {
-    const { st, tiers, stats, pending } = await loadState();
-    const tier0 = TIERS.includes(tiers[cls]) ? tiers[cls] : TIER_ASK;
-    const s = stats[cls] && typeof stats[cls] === "object" ? { ...blankStats(), ...stats[cls] } : blankStats();
-    if (field) s[field] = (s[field] || 0) + 1;
-    s.recent = [...(Array.isArray(s.recent) ? s.recent : []), { ok: ok === true, ts: now() }].slice(-REJECT_WINDOW);
+    let result = { tier: TIER_ASK, changed: false };
+    await patchState(async ({ tiers, stats, pending }) => {
+      const tier0 = TIERS.includes(tiers[cls]) ? tiers[cls] : TIER_ASK;
+      const s = stats[cls] && typeof stats[cls] === "object" ? { ...blankStats(), ...stats[cls] } : blankStats();
+      if (field) s[field] = (s[field] || 0) + 1;
+      s.recent = [...(Array.isArray(s.recent) ? s.recent : []), { ok: ok === true, ts: now() }].slice(-REJECT_WINDOW);
 
-    const eligible = eligibilityOf(cls) === "eligible";
-    const coldStart = (await countVerdicts()) < VERDICT_MIN;
-    const ev = evaluateTier({
-      tier: tier0,
-      eligible,
-      coldStart,
-      ask: { a: s.a, b: s.b },
-      veto: { va: s.va, vb: s.vb },
-      recent: s.recent,
+      const eligible = eligibilityOf(cls) === "eligible";
+      const coldStart = (await countVerdicts()) < VERDICT_MIN;
+      const ev = evaluateTier({
+        tier: tier0,
+        eligible,
+        coldStart,
+        ask: { a: s.a, b: s.b },
+        veto: { va: s.va, vb: s.vb },
+        recent: s.recent,
+      });
+
+      let nextPending = pending.slice();
+      if (ev.changed) {
+        tiers[cls] = ev.tier;
+        s.recent = []; // the rolling window is consumed by the transition
+        // Ladder direction by RUNG order (never lexical — "act" < "veto-window"
+        // as strings), so an act promotion is never mislabeled a demotion.
+        const promoted = TIERS.indexOf(ev.tier) > TIERS.indexOf(tier0);
+        nextPending.push({
+          id: `trust-${now()}-${Math.random().toString(36).slice(2, 8)}`,
+          ts: now(),
+          kind: promoted ? "promoted" : "demoted",
+          text: announcementText(cls, tier0, ev.tier, ev.reason),
+          refs: [],
+        });
+        await ledgerAppend({
+          kind: promoted ? "trust.promoted" : "trust.demoted",
+          cls,
+          from: tier0,
+          to: ev.tier,
+          reason: ev.reason,
+        });
+      }
+      stats[cls] = s;
+      result = { tier: ev.tier, changed: ev.changed === true };
+      return { tiers, stats, pending: nextPending.slice(-PENDING_CAP) };
     });
-
-    let nextPending = pending.slice();
-    if (ev.changed) {
-      tiers[cls] = ev.tier;
-      s.recent = []; // the rolling window is consumed by the transition
-      // Ladder direction by RUNG order (never lexical — "act" < "veto-window"
-      // as strings), so an act promotion is never mislabeled a demotion.
-      const promoted = TIERS.indexOf(ev.tier) > TIERS.indexOf(tier0);
-      nextPending.push({
-        id: `trust-${now()}-${Math.random().toString(36).slice(2, 8)}`,
-        ts: now(),
-        kind: promoted ? "promoted" : "demoted",
-        text: announcementText(cls, tier0, ev.tier, ev.reason),
-        refs: [],
-      });
-      await ledgerAppend({
-        kind: promoted ? "trust.promoted" : "trust.demoted",
-        cls,
-        from: tier0,
-        to: ev.tier,
-        reason: ev.reason,
-      });
-    }
-    stats[cls] = s;
-    await saveState(null, { ...st, tiers, stats, pending: nextPending.slice(-PENDING_CAP) });
-    return { tier: ev.tier, changed: ev.changed === true };
+    return result;
   }
 
   // The B3 verdict-sink target (§9.5). Only suggestion verdicts attributed
@@ -301,7 +329,6 @@ export function createCtoTrust(deps = {}) {
   // act-tier execution is the top rung, not an acceptance input.
   async function recordAct({ cls, text, refs = [], action = null } = {}) {
     if (!cls || typeof cls !== "string") return { ok: false };
-    const { st, pending } = await loadState();
     const t = now();
     const row = {
       id: `act-${t}-${Math.random().toString(36).slice(2, 8)}`,
@@ -313,7 +340,7 @@ export function createCtoTrust(deps = {}) {
       actionType: action?.type ?? null,
     };
     await ledgerAppend({ kind: "trust.act", cls, text: row.text, refs: row.refs, actionType: row.actionType });
-    await saveState(null, { ...st, pending: [...pending, row].slice(-PENDING_CAP) });
+    await patchState(({ pending }) => ({ pending: [...pending, row].slice(-PENDING_CAP) }));
     return { ok: true, id: row.id };
   }
 
@@ -326,10 +353,13 @@ export function createCtoTrust(deps = {}) {
 
   async function markAnnounced(ids = []) {
     if (!Array.isArray(ids) || ids.length === 0) return { removed: 0 };
-    const { st, pending } = await loadState();
-    const keep = pending.filter((r) => !ids.includes(r?.id));
-    await saveState(null, { ...st, pending: keep });
-    return { removed: pending.length - keep.length };
+    let removed = 0;
+    await patchState(({ pending }) => {
+      const keep = pending.filter((r) => !ids.includes(r?.id));
+      removed = pending.length - keep.length;
+      return removed > 0 ? { pending: keep } : null;
+    });
+    return { removed };
   }
 
   // Diagnostics (tests / cto panel later): tiers + counters + queue depth.

--- a/src/server/ctoWatchers.mjs
+++ b/src/server/ctoWatchers.mjs
@@ -38,7 +38,7 @@
 // without a hit, or when the underlying fact/pattern is archived.
 
 import { randomBytes } from "node:crypto";
-import { patchEngineState } from "./ctoStores.mjs";
+import { patchEngineState, patchStore } from "./ctoStores.mjs";
 
 // Closed set of predicate kinds (spec §13.4). Adding a kind is a spec change.
 export const PREDICATE_KINDS = Object.freeze(["event-pattern", "rate-threshold", "usage-burn"]);
@@ -497,8 +497,19 @@ export function createStandingQueryEngine(deps = {}) {
     }
   }
 
-  async function saveAll(watchers) {
-    await store.save({ watchers: Array.isArray(watchers) ? watchers : [] });
+  // BET-1464 defect 3: every watchers.json write routes through patchStore —
+  // the read-fresh-merge-save runs under the store's own mutex, so a writer
+  // derived from a stale snapshot (a hit's accounting, a tick's retirement,
+  // a registration) can no longer erase a concurrent writer's row. The
+  // mutator derives its next list from the FRESH payload and returns an
+  // empty patch to mean "no change, no save".
+  function patchWatchers(mutate) {
+    return patchStore(store, (fresh) => {
+      const all = Array.isArray(fresh?.watchers) ? fresh.watchers : [];
+      const patch = mutate(all);
+      if (!patch) return {};
+      return { watchers: patch };
+    });
   }
 
   async function hit(watch, event = {}) {
@@ -510,16 +521,17 @@ export function createStandingQueryEngine(deps = {}) {
     }
     // Persist the watcher's moved hit accounting.
     try {
-      const all = await loadAll();
-      const idx = all.findIndex((w) => w && w.id === watch.id);
-      if (idx !== -1) {
-        all[idx] = {
+      await patchWatchers((all) => {
+        const idx = all.findIndex((w) => w && w.id === watch.id);
+        if (idx === -1) return null; // the watcher vanished — nothing to persist
+        const next = all.slice();
+        next[idx] = {
           ...all[idx],
           lastHit: now(),
           hits: (typeof all[idx].hits === "number" ? all[idx].hits : 0) + 1,
         };
-        await saveAll(all);
-      }
+        return next;
+      });
     } catch {
       /* best-effort */
     }
@@ -596,12 +608,14 @@ export function createStandingQueryEngine(deps = {}) {
         /* best-effort */
       }
     }
-    // Retirement is cheap to run here too (once per tick).
+    // Retirement is cheap to run here too (once per tick). Under the store
+    // mutex from the FRESH list (BET-1464 defect 3) — the `all` snapshot read
+    // at tick start may already be stale by the time retirement lands.
     try {
-      const { next, retired } = retireWatchers(all, { nowMs: t, archivedSignatures });
-      if (retired.length > 0) {
-        await saveAll(next);
-      }
+      await patchWatchers((freshAll) => {
+        const { next, retired } = retireWatchers(freshAll, { nowMs: t, archivedSignatures });
+        return retired.length > 0 ? next : null;
+      });
     } catch {
       /* best-effort */
     }
@@ -611,25 +625,42 @@ export function createStandingQueryEngine(deps = {}) {
   async function register(input = {}) {
     const built = makeWatcher({ ...input, now });
     if (!built.ok) return { ok: false, error: built.error };
-    const all = await loadAll();
-    // A watcher with the same patternSignature is added alongside (user
-    // registration is distinct from auto-upsert) but the same id is not.
-    if (all.some((w) => w && w.id === built.watch.id)) {
-      return { ok: false, error: `watcher id already exists: ${built.watch.id}` };
+    let duplicate = false;
+    try {
+      await patchWatchers((all) => {
+        // A watcher with the same patternSignature is added alongside (user
+        // registration is distinct from auto-upsert) but the same id is not.
+        if (all.some((w) => w && w.id === built.watch.id)) {
+          duplicate = true;
+          return null;
+        }
+        return [...all, built.watch];
+      });
+    } catch (e) {
+      return { ok: false, error: e?.message ?? "register failed" };
     }
-    await saveAll([...all, built.watch]);
+    if (duplicate) return { ok: false, error: `watcher id already exists: ${built.watch.id}` };
     return { ok: true, data: { watch: built.watch } };
   }
 
   async function unregister(id) {
     if (!id || typeof id !== "string") return { ok: true, data: { removed: false } };
-    const all = await loadAll();
-    const next = all.filter((w) => w && w.id !== id);
-    if (next.length === all.length) return { ok: true, data: { removed: false } };
-    await saveAll(next);
-    windowHits.delete(id);
-    lastBurnHit.delete(id);
-    return { ok: true, data: { removed: true } };
+    let removed = false;
+    try {
+      await patchWatchers((all) => {
+        const next = all.filter((w) => w && w.id !== id);
+        if (next.length === all.length) return null;
+        removed = true;
+        return next;
+      });
+    } catch {
+      return { ok: false, error: "unregister failed" };
+    }
+    if (removed) {
+      windowHits.delete(id);
+      lastBurnHit.delete(id);
+    }
+    return { ok: true, data: { removed } };
   }
 
   async function list() {
@@ -647,14 +678,23 @@ export function createStandingQueryEngine(deps = {}) {
   }
 
   // Auto-create watchers from the last N days of day rollups. Idempotent by
-  // patternSignature (upsert never duplicates).
+  // patternSignature (upsert never duplicates). The upsert runs under the
+  // store mutex from the FRESH list (BET-1464 defect 3).
   async function autoCreate(dayRollups) {
     const candidates = extractRecurringThemes(dayRollups, { now });
     if (candidates.length === 0) return { added: [], updated: [] };
-    const all = await loadAll();
-    const { next, added, updated } = upsertWatchers(all, candidates, { now });
-    if (added.length > 0 || updated.some((u) => u.rearmed)) await saveAll(next);
-    return { added, updated };
+    const result = { added: [], updated: [] };
+    try {
+      await patchWatchers((all) => {
+        const { next, added, updated } = upsertWatchers(all, candidates, { now });
+        result.added = added;
+        result.updated = updated;
+        return added.length > 0 || updated.some((u) => u.rearmed) ? next : null;
+      });
+    } catch {
+      /* best-effort */
+    }
+    return result;
   }
 
   // One-time migration of legacy cto.json watches, guarded by a marker in
@@ -671,10 +711,14 @@ export function createStandingQueryEngine(deps = {}) {
     }
     const converted = migrateLegacyWatches(legacyWatches, { now });
     if (converted.length > 0) {
-      const all = await loadAll();
-      const existingIds = new Set(all.map((w) => w?.id));
-      const fresh = converted.filter((c) => !existingIds.has(c.id));
-      await saveAll([...all, ...fresh]);
+      // Letting a store failure propagate keeps the pre-patchStore contract:
+      // the migration marker below is only stamped once the rows landed, so
+      // a failed save retries on the next invocation.
+      await patchWatchers((all) => {
+        const existingIds = new Set(all.map((w) => w?.id));
+        const fresh = converted.filter((c) => !existingIds.has(c.id));
+        return fresh.length > 0 ? [...all, ...fresh] : null;
+      });
     }
     try {
       // BET-1425: sub-key merge on `watchers` from the FRESH state — this key

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -142,7 +142,7 @@ import * as appControl from "./appControl.mjs";
 import * as cto from "./cto.mjs";
 import * as ctoEngine from "./ctoEngine.mjs";
 import * as ctoBudget from "./ctoBudget.mjs";
-import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore, digestsStore, factsStore } from "./ctoStores.mjs";
+import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore, digestsStore, factsStore, startCtoStoreSweeper, CTO_STORE_SWEEP_INTERVAL_MS } from "./ctoStores.mjs";
 import * as ctoOvernight from "./ctoOvernight.mjs";
 import { computeHealthStats } from "./ctoHealth.mjs";
 import { composeProfileRender } from "./ctoProfile.mjs";
@@ -2436,6 +2436,19 @@ const stopAdaptiveCtoWatchdog = startPoller(adaptiveCtoWatchdog.tick, {
   label: "cto-watchdog",
 });
 void stopAdaptiveCtoWatchdog;
+
+// BET-1464 (§13.1): the CTO store retention sweeper — the last CTO poller the
+// engine/digest/suggest/watchdog family was missing. Sweeps every CTO store on
+// its own retention: the §14.5 activity ledger (180d), the byte-capped
+// inbox/verdict JSONL stores, engine-state sweeps (the writer's `undefined`
+// deletes / array splices), tool usage logs, and per-day budget files. Started
+// alongside the other CTO pollers so it survives exactly as long as the box
+// server does; no restart path needed (a process restart re-runs startup).
+const stopCtoStoreSweeper = startCtoStoreSweeper({
+  intervalMs: CTO_STORE_SWEEP_INTERVAL_MS,
+  label: "cto-store-sweeper",
+});
+void stopCtoStoreSweeper;
 
 // On-call CTO inbound funnel (Issue 2): the single place a CTO-bound event
 // enters the box. Producers (the send_to_cto tool, the watcher poller, a


### PR DESCRIPTION
## BET-1464 — CTO S2a: start the retention sweeper; every CTO store write safe (one shared patch path)

`Base: origin/main @ 7ac2c907`

### Defect 1 — the sweeper is now started
`index.mjs` starts `startCtoStoreSweeper({ intervalMs: CTO_STORE_SWEEP_INTERVAL_MS, label: "cto-store-sweeper" })` in the CTO poller family block (after the watchdog poller), following the exact engine/digest/suggest/watchdog pattern. Wired gate: `ctoSweeperWiring.test.mjs`; behavioral start test in `ctoStores.test.mjs` (real poller, first tick removes an expired ledger row from the sandboxed store).

### Defect 2 — the activity ledger's rewrite is atomic
- ONE write lock (`createMutex`) inside `createLedgerStore`, shared by the appender and the rewrite — an append can no longer land between the sweep's read and its rewrite (the window that silently lost firehose rows), and a crash mid-write can no longer truncate the 180-day audit ledger.
- The rewrite goes through `writeJsonAtomic` (temp + rename) — the SAME single atomic-write implementation every other store uses; the bare `writeFile` is deleted.
- The sweep is one atomic section: `ledgerStore.sweepExpired({ nowMs, retentionMs })` (read-filter-rewrite under the lock); `sweepLedger` delegates to it.

### Defect 3 — patchStore: one shared write path for every CTO store writer
- `patchStore(store, mutator)` in `ctoStores.mjs` generalizes `patchEngineState`: one mutex PER STORE PATH, read-FRESH, per-key merge, atomic save; async mutators hold the mutex across their whole body (the serialization the per-engine write chains used to give); an empty patch (static or returned) is a pure no-op — no save. `patchEngineState` is re-expressed as a thin call over it; its callers are unchanged.
- The five writer files now route through it:
  - `cards.json`: `upsertBlocker`, `upsertOpenCard` (→ upsertDecision/upsertVeto/upsertConnect), `closeOpenCard` (→ resolveById/dismissById), `resolveConnectCards` — all the fire-and-forget call sites named in the issue plus the shared cores behind them.
  - `watchers.json`: `hit`, `register`, `unregister`, tick retirement, `autoCreate`, `migrateLegacy` (saveAll deleted).
  - `trust.json`: `applyOutcome`, `recordAct`, `markAnnounced` (saveState deleted; the shared `stFromRaw` derivation keeps the one-time legacy adoption, which the patch itself persists).
  - `budget.json`: `record` (the per-call spend recorder), `computeSpendable` (both branches derive from FRESH quota rows), `refreshRoi` (holds the mutex across its whole multi-second probe body — a mid-roll spend row can no longer be reverted by the stale snapshot save).
  - `tool-registry.json`: every mutating writer (`dailyScan`, `resolveConnect`, `unNever`, `revokeConsent`, `applyProbeResult`, `applyRelevance`, `appendEvidence`, `applyAsSource`) plus `appendUsage` on `tool-usage.json`. The per-instance `serialized` write chain is deleted — the store-path mutex replaces it, and it is strictly stronger (two registry instances around one file would serialize where the write chain would not).
- Remaining direct saves, deliberately: the retention-sweep family (`sweepInbox`/`sweepVerdicts`/rollups/segments/digests/archive — single-writer sweeper paths, out of the issue's named five) — filed as BET-1482; and trust `loadState`'s one-time legacy-adoption save (idempotent, reader-path, documented).

### Tests (all green, all sandboxed)
- `patchStore`: parallel patches compose; a stale-derived patch cannot erase a concurrent writer's key (scalars AND whole-array replacements); an async mutator holds the mutex across its body (deterministic gate); an empty patch fires no save; validation rejects.
- Ledger: an append concurrent with a sweep is never lost (12-iteration both-orders invariant + a mid-sweep trap with 800 kept rows asserting no truncation).
- Sweeper: starts, sweeps on its interval, stops; `index.mjs` wiring gate.
- Full suite: 3740 pass / 0 fail (PR branch) vs 3731/0 (base) — the +9 are the new gates.

**Files changed:** 10 files, +1130/−584 (`ctoStores.mjs`, `ctoCards.mjs`, `ctoWatchers.mjs`, `ctoTrust.mjs`, `ctoBudget.mjs`, `ctoToolRegistry.mjs`, `index.mjs`, `ctoStores.test.mjs`, `ctoSweeperWiring.test.mjs` [new], `ctoBudgetWiring.test.mjs`).

**Verification results:**
- PR branch (`multica/BET-1464-cto-sweeper-and-store-patch` @ `a5fae490`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3740 pass / 0 fail / 0 skip. Failures: none. log sha256: `e79f3597993253cb0e7819530920f2425e80f9b43e6a41d8f6f072045ddbde65`
- Base (`main` @ `7ac2c907`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3731 pass / 0 fail / 0 skip. Failures: none. log sha256: `0f2937453f49d74d1450fd83f75823724eb77a281d15af9c094e29e44851718f`
- **Conclusion:** 0 pre-existing failures, 0 new failures; the +9 test delta is this PR's new gates.

### Cross-cutting notes
- **Incident disclosure:** one early local run of `node --test` (bypassing the `npm test` sandbox via `scripts/testSandbox.mjs`) wrote to the live box's `~/.manta/cto/` stores. Cleaned up surgically; the one unrecoverable loss is `verdicts.json` entries (the §9 verdict history — the live engine self-heals into cold-start). Synthetic artifacts (facts-archive/proj.json, probes/http-check.yaml, ledger rows, engine-state pendingBlockers) were removed. This is exactly the failure mode BET-1469 (blocked) exists to prevent — consider it supporting evidence.
- **Latency trade:** `refreshRoi` now holds the budget store's mutex across its probes, so `record()` calls queue behind an in-flight roll for its duration (spend metering is fire-and-forget and best-effort). This is the price of never reverting a concurrent spend row — the previous behavior silently lost them.
- **Wiring scanner fix:** `ctoBudgetWiring.test.mjs`'s `depsBlock` was comment-blind — an apostrophe inside a deps comment ("the poller's pct observation") opened a phantom quote and derailed the brace walk across the rest of `index.mjs`, so ANY unrelated edit after the block could flip the gate (mine did). Made the scanner comment-aware; the gate now walks only real code.
- Follow-up filed: BET-1482 (parked, medium) — the sweep-family whole-payload saves.

Self-check: all issue criteria scored 8+ (sweeper start+wiring 9, patchStore generalization 9, five-writer coverage 9, ledger atomicity 9, required test list 9, follow-ups filed 9).
