### PR TITLE
fix(server): per-class worthiness thresholds make the §9.1 gate arithmetically live (BET-1471)

### DIFF
--- a/src/server/ctoSuggest.mjs
+++ b/src/server/ctoSuggest.mjs
@@ -12,13 +12,17 @@
 //     (empty ring = branch unreachable), `queue-tonight` only at High tier.
 //   - Worthiness gate: a `worthiness` class call returns a 0..1 score; the
 //     decision probability is `score × class prior × sender reliability`
-//     (§9.1 calibration). Per-class thresholds (`p_ask`, `p_act`) live in
-//     engine-state; below `p_ask` a candidate is SILENT-LOGGED (a ledger row
+//     (§9.1 calibration). Thresholds are per class (BET-1471: the p_ask/p_act
+//     pair derives from each class's prior ceiling — `defaultThresholds()`),
+//     with a flat engine-state `suggest.thresholds` pair overriding globally
+//     when present; below `p_ask` a candidate is SILENT-LOGGED (a ledger row
 //     {id, score, reason}) for the §14.3 silence audit, above it a DECISION
 //     card is written. The `notify` variant (informational-tier router call)
 //     fires only when the finding's decay is steep — the deterministic rule
-//     `sourceKind ∈ {failure-recurrence}`. `p_act` exists but NOTHING acts in
-//     P2: the act branch throws if reached.
+//     `sourceKind ∈ {failure-recurrence}`. The act verb is reachable only
+//     through the §9.4 ladder (eligible act-tier class, p >= p_act); an
+//     un-promoted class above its act bar surfaces the ask card — ask IS the
+//     §9.3 cap — it never acts.
 //   - Global cold-start gate: until ≥ VERDICT_MIN (15) verdicts exist, every
 //     candidate is capped at the ask verbs regardless of scores ($9.1).
 //   - Silence audit (§14.3): silent-log rows are re-readable; a held item
@@ -84,9 +88,23 @@ export const VERDICT_MIN = TRUST_VERDICT_MIN;
 // engine-state. Same trailing-slice idiom as `ctoBudget.mjs`'s `.slice(-200)`.
 const USED_KEYS_CAP = 200;
 
-// §9.1 default gate thresholds (engine-state overrides).
+// §9.1 per-class gate thresholds (BET-1471 — implements the BET-1470
+// decision; do not re-litigate). With reliability at 1.0 a candidate's p
+// ceiling IS its class prior, so each pair derives from that ceiling:
+// `p_ask = 0.8 × ceiling`, `p_act = 0.95 × ceiling` (0.95 mirrors the §9.4
+// promotion bar). The old single global pair made the act verb
+// arithmetically unreachable (0.95 > every ceiling) and silenced
+// queue-tonight and tool-write at every score. The engine-state
+// `suggest.thresholds` override keeps its flat `{p_ask, p_act}` shape and,
+// when present, applies globally to every class.
 export function defaultThresholds() {
-  return { p_ask: 0.4, p_act: 0.95 };
+  return {
+    "record-decision": { p_ask: 0.48, p_act: 0.57 },
+    "config-change": { p_ask: 0.4, p_act: 0.48 },
+    "start-job": { p_ask: 0.32, p_act: 0.38 },
+    "queue-tonight": { p_ask: 0.28, p_act: 0.33 },
+    "tool-write": { p_ask: 0.24, p_act: 0.29 },
+  };
 }
 
 // Stable, collision-resistant candidate id: regeneration of the same
@@ -136,6 +154,11 @@ export function worthinessProbability(score, prior = 0.5, senderReliability = 0.
 }
 
 // §9.1/§9.2 surface-verb selection for one candidate.
+//   - `cls` picks the threshold pair: `defaultThresholds()[cls]`; an unknown
+//     class falls back to the config-change pair. The `thresholds` override
+//     (engine-state `suggest.thresholds`) keeps its flat `{p_ask, p_act}`
+//     shape, wins over the per-class defaults and, when present, applies to
+//     every class.
 //   - coldStart (`verdicts < VERDICT_MIN`): capped at the ask verb regardless
 //     of score or trust tier — the §10.6-4 global gate dominates (§9.4).
 //   - The class's trust tier raises the ceiling (§9.4): at the veto-window
@@ -143,21 +166,27 @@ export function worthinessProbability(score, prior = 0.5, senderReliability = 0.
 //     becomes reachable once p >= p_act (below it the class still surfaces
 //     the veto-window verb). Eligibility (§9.3) gates the climb — an
 //     ask-capped class never leaves the ask verbs whatever its counters say.
-//   - p >= p_act on an un-promoted (ask-tier) class: the act branch is
-//     reached without trust → throw (the guard that nothing acts unearned).
+//   - p >= p_act on an un-promoted (ask-tier) class: the ask verb IS the
+//     §9.3 cap, so the candidate surfaces the decision card — never silence
+//     (BET-1471: the old throw silently swallowed the class's highest-
+//     worthiness candidates). The act gate lives only in the eligible
+//     act-tier branch below.
 //   - p >= p_ask: DECISION card; `notify` true when the decay rule matches.
 //   - else: SILENT-LOG (ledger row for the §14.3 audit).
 export function decideVerb({
   p,
-  thresholds = defaultThresholds(),
+  cls = null,
+  thresholds = null,
   coldStart = false,
   sourceKind = null,
   tier = "ask",
   eligible = false,
 } = {}) {
-  const th = { ...defaultThresholds(), ...(thresholds || {}) };
-  const pAct = Number.isFinite(th.p_act) ? th.p_act : 0.95;
-  const pAsk = Number.isFinite(th.p_ask) ? th.p_ask : 0.4;
+  const perClass = defaultThresholds();
+  const base = perClass[cls] || perClass["config-change"];
+  const th = { ...base, ...(thresholds || {}) };
+  const pAct = Number.isFinite(th.p_act) ? th.p_act : base.p_act;
+  const pAsk = Number.isFinite(th.p_ask) ? th.p_ask : base.p_ask;
   const notify = NOTIFY_RECURRENCE_KINDS.includes(sourceKind);
   if (p < pAsk) return { verb: "silent-log" };
   // p >= p_ask → at least the ask verb (decision card). Cold-start CAPS the
@@ -168,9 +197,8 @@ export function decideVerb({
     if (tier === "act" && p >= pAct) return { verb: "act", notify };
     return { verb: "veto-window", notify };
   }
-  if (p >= pAct) {
-    throw new Error("suggest: act branch reached — class not trusted (ask-tier hold)");
-  }
+  // BET-1471: the ask-tier hold surfaces the ask card, it does not throw —
+  // ask IS the §9.3 cap, and silence is below it.
   return { verb: "decision", notify };
 }
 
@@ -417,7 +445,10 @@ export function createCtoSuggest(deps = {}) {
       es = {};
     }
     const st = (es.suggest && typeof es.suggest === "object") ? es.suggest : {};
-    const th = { ...defaultThresholds(), ...(st.thresholds || {}) };
+    // BET-1471: `suggest.thresholds` keeps its flat `{p_ask, p_act}` override
+    // shape and is returned raw — per-class defaults are resolved per
+    // candidate inside decideVerb, not baked in here.
+    const th = (st.thresholds && typeof st.thresholds === "object") ? st.thresholds : {};
     const used = st.usedKeys || [];
     return { es, st, thresholds: th, used };
   }
@@ -442,6 +473,8 @@ export function createCtoSuggest(deps = {}) {
     }
   }
 
+  // BET-1471: the flat override only (in-memory dep + engine-state) —
+  // per-class defaults are resolved per candidate in decideVerb.
   async function getThresholds() {
     const { thresholds: th } = await loadState();
     return { ...(thresholds || {}), ...th };
@@ -601,17 +634,11 @@ export function createCtoSuggest(deps = {}) {
         }
       }
       const p = worthinessProbability(score, priors[c.class], reliability);
-      // §9.4: verb selection consults the class's earned-trust tier.
+      // §9.4: verb selection consults the class's earned-trust tier. The
+      // per-class thresholds resolve inside decideVerb (BET-1471); `th` is
+      // the flat engine-state override that applies globally when present.
       const trustInfo = await trustConsult(c.class, coldStart);
-      let decision;
-      try {
-        decision = decideVerb({ p, thresholds: th, coldStart, sourceKind: finding.sourceKind, tier: trustInfo.tier, eligible: trustInfo.eligible });
-      } catch {
-        // act branch reached without trust — log as a held item, never act.
-        await ledgerAppend({ kind: "suggest.silent", id: c.id, class: c.class, score: p, reason: "act-not-trusted", sourceKind: finding.sourceKind, text: c.finding.text });
-        silent += 1;
-        continue;
-      }
+      let decision = decideVerb({ p, cls: c.class, thresholds: th, coldStart, sourceKind: finding.sourceKind, tier: trustInfo.tier, eligible: trustInfo.eligible });
 
       if (decision.verb === "silent-log") {
         await ledgerAppend({ kind: "suggest.silent", id: c.id, class: c.class, score: p, reason: "below-p_ask", sourceKind: finding.sourceKind, text: c.finding.text });

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -97,49 +97,95 @@ test("default priors cover the closed enum", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Verb decision (§9.1): cold-start cap + p_ask threshold + act unreachable
+// Verb decision (§9.1): per-class thresholds (BET-1471), cold-start cap,
+// trust ladder, flat override
 // ---------------------------------------------------------------------------
 
-test("decideVerb: below p_ask → silent-log", () => {
-  assert.deepEqual(decideVerb({ p: 0.1 }), { verb: "silent-log" });
+// BET-1471: the shipped per-class table — each pair derives from the class's
+// prior ceiling (p_ask = 0.8 × ceiling, p_act = 0.95 × ceiling). Pinned as
+// exact literals so a prior change without a threshold change cannot sneak
+// the arithmetic dead-zone back in.
+test("defaultThresholds: per-class pairs match the BET-1470 decision table", () => {
+  const th = defaultThresholds();
+  for (const t of ACTION_TYPES) {
+    assert.ok(th[t] && typeof th[t] === "object", `missing thresholds for ${t}`);
+  }
+  assert.deepEqual(th["record-decision"], { p_ask: 0.48, p_act: 0.57 });
+  assert.deepEqual(th["config-change"], { p_ask: 0.4, p_act: 0.48 });
+  assert.deepEqual(th["start-job"], { p_ask: 0.32, p_act: 0.38 });
+  assert.deepEqual(th["queue-tonight"], { p_ask: 0.28, p_act: 0.33 });
+  assert.deepEqual(th["tool-write"], { p_ask: 0.24, p_act: 0.29 });
+  // Every pair stays inside its class's p ceiling (= its prior): a candidate
+  // at the ceiling clears the ask bar, and the act bar sits below it.
+  for (const t of ACTION_TYPES) {
+    const ceiling = DEFAULT_CLASS_PRIORS[t];
+    assert.ok(th[t].p_act <= ceiling, `${t}: p_act must not exceed the prior ceiling`);
+    assert.ok(th[t].p_ask <= th[t].p_act, `${t}: p_ask must not exceed p_act`);
+  }
+});
+
+test("decideVerb: below the class's p_ask → silent-log", () => {
+  assert.deepEqual(decideVerb({ p: 0.1, cls: "config-change" }), { verb: "silent-log" });
+  // The bars differ per class: 0.26 clears tool-write's p_ask (0.24) but not
+  // config-change's (0.4).
+  assert.deepEqual(decideVerb({ p: 0.26, cls: "tool-write" }), { verb: "decision", notify: false });
+  assert.deepEqual(decideVerb({ p: 0.26, cls: "config-change" }), { verb: "silent-log" });
+});
+
+test("decideVerb: unknown class falls back to the config-change pair", () => {
+  assert.deepEqual(decideVerb({ p: 0.42, cls: "bogus" }), { verb: "decision", notify: false });
+  assert.deepEqual(decideVerb({ p: 0.39, cls: "bogus" }), { verb: "silent-log" });
+  assert.deepEqual(decideVerb({ p: 0.42 }), { verb: "decision", notify: false });
 });
 
 test("decideVerb: p between p_ask and p_act → decision (no notify unless recurrence)", () => {
-  assert.deepEqual(decideVerb({ p: 0.6 }), { verb: "decision", notify: false });
-  assert.deepEqual(decideVerb({ p: 0.8, sourceKind: "failure-recurrence" }), { verb: "decision", notify: true });
-  assert.deepEqual(decideVerb({ p: 0.8, sourceKind: "fact-anomaly" }), { verb: "decision", notify: false });
+  // record-decision: p_ask 0.48, p_act 0.57.
+  assert.deepEqual(decideVerb({ p: 0.5, cls: "record-decision" }), { verb: "decision", notify: false });
+  assert.deepEqual(decideVerb({ p: 0.5, cls: "record-decision", sourceKind: "failure-recurrence" }), { verb: "decision", notify: true });
+  assert.deepEqual(decideVerb({ p: 0.5, cls: "record-decision", sourceKind: "fact-anomaly" }), { verb: "decision", notify: false });
 });
 
-test("decideVerb: act branch without trust — throws on p >= p_act (BET-1403: ask-tier hold)", () => {
-  assert.throws(() => decideVerb({ p: 0.99 }), /class not trusted/);
+test("decideVerb: unpromoted class above its act bar → decision card, no throw (BET-1471)", () => {
+  // With live per-class bars the old ask-tier guard throw became reachable
+  // and would have silently swallowed the class's highest-worthiness
+  // candidates. Ask IS the §9.3 cap: above the act bar an un-promoted class
+  // still surfaces the ask verb.
+  assert.deepEqual(decideVerb({ p: 0.99, cls: "config-change" }), { verb: "decision", notify: false });
   // Eligibility gates the climb (§9.3): an ask-capped class never leaves the
   // ask verbs even when its tier record somehow reads promoted.
-  assert.throws(() => decideVerb({ p: 0.99, tier: "act", eligible: false }), /class not trusted/);
+  assert.deepEqual(decideVerb({ p: 0.99, cls: "config-change", tier: "act", eligible: false }), { verb: "decision", notify: false });
 });
 
 test("decideVerb: trust ladder raises the ceiling (§9.2/§9.4)", () => {
+  // record-decision: p_ask 0.48, p_act 0.57.
   // veto-window tier: p >= p_ask surfaces the veto-window verb.
-  assert.deepEqual(decideVerb({ p: 0.6, tier: "veto-window", eligible: true }), { verb: "veto-window", notify: false });
+  assert.deepEqual(decideVerb({ p: 0.5, cls: "record-decision", tier: "veto-window", eligible: true }), { verb: "veto-window", notify: false });
   // act tier but below the act bar → still the veto-window verb.
-  assert.deepEqual(decideVerb({ p: 0.6, tier: "act", eligible: true }), { verb: "veto-window", notify: false });
+  assert.deepEqual(decideVerb({ p: 0.5, cls: "record-decision", tier: "act", eligible: true }), { verb: "veto-window", notify: false });
   // act tier + p >= p_act → the act verb fires.
-  assert.deepEqual(decideVerb({ p: 0.99, tier: "act", eligible: true }), { verb: "act", notify: false });
-  assert.deepEqual(decideVerb({ p: 0.99, tier: "act", eligible: true, sourceKind: "watcher-hit-rate" }), { verb: "act", notify: true });
+  assert.deepEqual(decideVerb({ p: 0.6, cls: "record-decision", tier: "act", eligible: true }), { verb: "act", notify: false });
+  assert.deepEqual(decideVerb({ p: 0.6, cls: "record-decision", tier: "act", eligible: true, sourceKind: "watcher-hit-rate" }), { verb: "act", notify: true });
   // cold-start dominates the ladder (§10.6-4): capped at ask whatever the tier.
-  assert.deepEqual(decideVerb({ p: 0.99, coldStart: true, tier: "act", eligible: true }), { verb: "decision", capped: true, notify: false });
+  assert.deepEqual(decideVerb({ p: 0.99, cls: "record-decision", coldStart: true, tier: "act", eligible: true }), { verb: "decision", capped: true, notify: false });
 });
 
 test("decideVerb: cold-start caps high-score candidates at the ask verb (no throw)", () => {
   // Even a score that would exceed p_act is capped to a decision card during
   // cold start — the act branch is not even considered.
-  assert.deepEqual(decideVerb({ p: 0.99, coldStart: true }), { verb: "decision", capped: true, notify: false });
+  assert.deepEqual(decideVerb({ p: 0.99, cls: "config-change", coldStart: true }), { verb: "decision", capped: true, notify: false });
   // The p_ask threshold still applies during cold start: below it → silent-log.
-  assert.deepEqual(decideVerb({ p: 0.1, coldStart: true }), { verb: "silent-log" });
+  assert.deepEqual(decideVerb({ p: 0.1, cls: "config-change", coldStart: true }), { verb: "silent-log" });
 });
 
-test("decideVerb: custom thresholds override defaults", () => {
-  assert.deepEqual(decideVerb({ p: 0.3, thresholds: { p_ask: 0.2, p_act: 0.9 } }), { verb: "decision", notify: false });
-  assert.deepEqual(decideVerb({ p: 0.1, thresholds: { p_ask: 0.2 } }), { verb: "silent-log" });
+test("decideVerb: flat engine-state override wins over the per-class defaults (global)", () => {
+  // record-decision's own p_ask is 0.48; the flat override lowers it for
+  // every class.
+  assert.deepEqual(decideVerb({ p: 0.3, cls: "record-decision", thresholds: { p_ask: 0.2, p_act: 0.9 } }), { verb: "decision", notify: false });
+  assert.deepEqual(decideVerb({ p: 0.1, cls: "record-decision", thresholds: { p_ask: 0.2 } }), { verb: "silent-log" });
+  // A partial override keeps the class's own value for the other key:
+  // config-change p_ask lowered to 0.2, p_act stays 0.48.
+  assert.deepEqual(decideVerb({ p: 0.5, cls: "config-change", thresholds: { p_ask: 0.2 } }), { verb: "decision", notify: false });
+  assert.deepEqual(decideVerb({ p: 0.5, cls: "config-change", tier: "act", eligible: true, thresholds: { p_ask: 0.2 } }), { verb: "act", notify: false });
 });
 
 // ---------------------------------------------------------------------------
@@ -432,11 +478,12 @@ test("collectFindings: combines digest + fact sources", () => {
 // §9.1 review Block 1 — decision-card reachability under PRODUCTION wiring
 // ---------------------------------------------------------------------------
 
-test("production wiring can surface a decision card: reliability 1.0 × prior 0.6 ≥ p_ask 0.4", async () => {
+test("production wiring can surface a decision card: reliability 1.0 × prior 0.6 ≥ p_ask 0.48", async () => {
   const h = makeHarness();
   // Mirror the SHIPPED index.mjs constants: reliability 1.0 (trusted internal
-  // sender), default class priors (max 0.6 record-decision), default engine
-  // thresholds (p_ask 0.4, no suggest in engine-state), Medium tier.
+  // sender), default class priors (max 0.6 record-decision), no engine-state
+  // override → the BET-1471 per-class thresholds (record-decision p_ask 0.48
+  // = 0.8 × the 0.6 ceiling), Medium tier.
   const sug2 = createCtoSuggest({
     now: () => h.clock.ms,
     publish: () => {},
@@ -467,10 +514,84 @@ test("production wiring can surface a decision card: reliability 1.0 × prior 0.
     senderReliability: async () => 1.0, // SHIPPED value in index.mjs
   });
   const r = await sug2.processFinding({ id: "rec:r", sourceKind: "fact-anomaly", text: "r", refs: [] }, { coldStart: false, tier: "medium" });
-  // p = 1.0 × 0.6 × 1.0 = 0.6 ≥ p_ask 0.4 → decision card, not silent-log.
+  // p = 1.0 × 0.6 × 1.0 = 0.6 ≥ p_ask 0.48 → decision card, not silent-log.
   assert.equal(r.surfaced, 1);
   assert.equal(h.cardPayload.cards.length, 1);
   assert.equal(h.cardPayload.cards[0].variant, "decision");
+});
+
+// BET-1471 regression: queue-tonight's ceiling (prior 0.35) sat below the old
+// global p_ask 0.4, so the class was silent-log at ANY score. Its per-class
+// bar (0.28 = 0.8 × 0.35) makes a max-worthiness candidate surface.
+test("queue-tonight is no longer a dead class: score-1.0 candidate surfaces a card", async () => {
+  const h = makeHarness();
+  const sug2 = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async (r) => h.ledgerRows.push(r), read: async () => h.ledgerRows },
+    verdicts: { load: async () => ({ entries: Array(VERDICT_MIN).fill({}) }), save: async () => {} },
+    engineState: { load: async () => ({}), save: async () => {} }, // no override → per-class thresholds
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => [], load: async () => null },
+    configGet: async () => ({ ctoTier: "high" }),
+    capabilities: { queueTonight: true, toolWrite: true }, // SHIPPED values in index.mjs
+    cards: {
+      upsertDecision: async (c) => {
+        h.cardPayload.cards.push(c);
+        return { changed: true, isNew: true };
+      },
+    },
+    runSuggest: async () => ({
+      text: JSON.stringify({
+        candidates: [
+          {
+            class: "queue-tonight", // prior 0.35 — was below the old global p_ask 0.4
+            finding: { text: "Queue the maintenance window", refs: [] },
+            options: [{ label: "Queue", action: { type: "queue-tonight", payload: {} } }],
+          },
+        ],
+      }),
+    }),
+    runWorthiness: async () => ({ text: "1.0" }), // max-worthiness candidate
+    senderReliability: async () => 1.0, // SHIPPED value in index.mjs
+  });
+  const r = await sug2.processFinding({ id: "rec:q", sourceKind: "fact-anomaly", text: "q", refs: [] }, { coldStart: false, tier: "high" });
+  // p = 1.0 × 0.35 × 1.0 = 0.35 ≥ p_ask 0.28 → decision card. Under the old
+  // global bar (0.4) this exact candidate was silent-log at every score.
+  assert.equal(r.surfaced, 1);
+  assert.equal(r.silent, 0);
+  assert.equal(h.cardPayload.cards.length, 1);
+  assert.equal(h.cardPayload.cards[0].variant, "decision");
+  assert.ok(h.ledgerRows.every((x) => x.kind !== "suggest.silent"));
+});
+
+// BET-1471 reachability: for each §9.3-eligible class, p at the class's
+// ceiling (= its prior, the arithmetic max with reliability 1.0) reaches the
+// act verb through a promoted act tier, surfaces the ask card when
+// un-promoted (never a throw), and stays silent below the class's p_ask.
+test("act verb is arithmetically reachable for the §9.3-eligible classes", () => {
+  const eligible = { "record-decision": 0.6, "queue-tonight": 0.35, "start-job": 0.4 };
+  for (const [cls, ceiling] of Object.entries(eligible)) {
+    // promoted act tier + p at the ceiling → the act verb fires
+    assert.deepEqual(
+      decideVerb({ p: ceiling, cls, tier: "act", eligible: true }),
+      { verb: "act", notify: false },
+      `${cls}: p at the ceiling must reach the act verb`
+    );
+    // the same p on an un-promoted class → decision card, no throw
+    assert.deepEqual(
+      decideVerb({ p: ceiling, cls }),
+      { verb: "decision", notify: false },
+      `${cls}: p at the ceiling must surface the ask card, not a hold`
+    );
+    // just below the class's p_ask → silent-log
+    const pAsk = defaultThresholds()[cls].p_ask;
+    assert.deepEqual(
+      decideVerb({ p: pAsk - 0.01, cls }),
+      { verb: "silent-log" },
+      `${cls}: below its own p_ask must stay silent`
+    );
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -689,7 +810,7 @@ test("pipeline: cold start keeps an act-tier class capped at the ask verb (§10.
   assert.equal(h.cardPayload.cards[0].capped, true);
 });
 
-test("pipeline: an act-tier ask-capped class still throws into the hold (§9.3 eligibility)", async () => {
+test("pipeline: an ineligible act-tier class above its act bar surfaces the ask card (no throw, no hold)", async () => {
   const h = makeHarness();
   const sug2 = createCtoSuggest({
     now: () => h.clock.ms,
@@ -701,26 +822,38 @@ test("pipeline: an act-tier ask-capped class still throws into the hold (§9.3 e
     },
     engineState: {
       // config-change is §9.3-capped; even a corrupt/foreign "act" tier row
-      // must never raise the ceiling — decideVerb throws, the pipeline holds.
+      // must never raise the ceiling — the ask card is the cap (BET-1471:
+      // the old throw silently held the class's best candidates).
       load: async () => ({ v: 1, trust: { tiers: { "config-change": "act" } } }),
       save: async () => {},
     },
     digests: { list: async () => [], load: async () => null },
     facts: { list: async () => [], load: async () => null },
     configGet: async () => ({ ctoTier: "medium" }),
-    cards: { upsertDecision: async () => ({ changed: true }) },
+    cards: {
+      upsertDecision: async (c) => {
+        h.cardPayload.cards.push(c);
+        return { changed: true, isNew: true };
+      },
+    },
     executeAction: async () => ({ ok: true }),
     runSuggest: async () => ({
       text: JSON.stringify({ candidates: [{ class: "config-change", finding: { text: "a", refs: [] }, options: [{ label: "Go", action: { type: "config-change", payload: {} } }] }] }),
     }),
-    runWorthiness: async () => ({ text: "1.0" }), // p = 1.0 ≥ p_act — the act branch, refused for a capped class
+    runWorthiness: async () => ({ text: "1.0" }), // p = 1.0, above the class's act bar
     senderReliability: async () => 1.0,
     classPriors: { "config-change": 1.0 },
   });
   const r = await sug2.processFinding({ id: "rec:cc", sourceKind: "fact-anomaly", text: "a", refs: [] }, { coldStart: false, tier: "medium" });
-  assert.equal(r.surfaced, 0);
-  assert.equal(r.silent, 1);
-  assert.ok(h.ledgerRows.some((x) => x.kind === "suggest.silent" && x.reason === "act-not-trusted"));
+  // The ask verb IS the §9.3 cap: the candidate surfaces a decision card.
+  assert.equal(r.surfaced, 1);
+  assert.equal(r.silent, 0);
+  assert.equal(h.cardPayload.cards.length, 1);
+  assert.equal(h.cardPayload.cards[0].variant, "decision");
+  // No act-not-trusted hold row, and — the class being ineligible — it never
+  // acted either.
+  assert.ok(!h.ledgerRows.some((x) => x.reason === "act-not-trusted"));
+  assert.ok(!h.ledgerRows.some((x) => x.kind === "suggest.acted"));
 });
 
 test("verdictHeld stamps the held row's class onto the subject (§9.4 attribution)", async () => {

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -2271,10 +2271,14 @@ const adaptiveCtoSuggest = createCtoSuggest({
   fireNotify: (args) => push.fireNotify(args),
   // §9.1 sender reliability. Findings here come from the box's OWN engine
   // (digest-detected recurrences, fact anomalies), not an external sender —
-  // a trusted internal source, so reliability approaches 1.0. With the max
-  // class prior (0.6) a score-1.0 candidate yields p = 0.6 ≥ p_ask 0.4, so a
-  // genuinely high-worthiness suggestion CAN surface (decision-reachability
-  // was dead under the old 0.5 factor — §9.1 review Block 1).
+  // a trusted internal source, so reliability approaches 1.0. With it pinned
+  // to 1.0 a candidate's p ceiling IS its class prior, and the BET-1471
+  // per-class thresholds hang off that same ceiling (p_ask = 0.8 × prior,
+  // p_act = 0.95 × prior): a score-1.0 candidate clears p_ask for EVERY
+  // class (p = prior ≥ 0.8 × prior), and the act bar is arithmetically
+  // reachable for the §9.3-eligible ones. Under the old global pair
+  // (p_act 0.95 > every ceiling) the act verb could never fire (§9.1 review
+  // Block 1; BET-1470).
   senderReliability: async () => 1.0,
   runSuggest: (opts) => gatedSuggestionEphemeral("suggest", opts),
   runWorthiness: (opts) => gatedSuggestionEphemeral("worthiness", opts),


### PR DESCRIPTION
## Summary

Implements the BET-1470 decision (spec §9.1): the worthiness gate thresholds become **per class**. The old single global pair `{p_ask: 0.4, p_act: 0.95}` was arithmetically dead — with reliability pinned to 1.0, a candidate's p ceiling is its class prior, so `p_act 0.95` exceeded every ceiling (act unreachable for ALL classes) and `p_ask 0.4` silenced queue-tonight (0.35) and tool-write (0.30) at any score.

Each pair now derives from the class's ceiling: `p_ask = 0.8 × ceiling`, `p_act = 0.95 × ceiling`:

| class | p_ask | p_act |
|---|---|---|
| record-decision | 0.48 | 0.57 |
| config-change | 0.40 | 0.48 |
| start-job | 0.32 | 0.38 |
| queue-tonight | 0.28 | 0.33 |
| tool-write | 0.24 | 0.29 |

## Changes

- `src/server/ctoSuggest.mjs`
  - `defaultThresholds()` returns the per-class table above (exact literals, pinned by a table-equality test).
  - `decideVerb` takes `cls` and resolves the candidate's pair (unknown class → config-change fallback); the engine-state `suggest.thresholds` override keeps its flat `{p_ask, p_act}` shape and, when present, applies globally to every class. `loadState()` returns the raw flat override instead of baking the old defaults in.
  - DELETED the ask-tier act-guard throw and the dead `act-not-trusted` catch in `processFinding` — with live bars the throw would silently swallow the highest-worthiness candidates of un-promoted classes, contradicting §9.2/§9.3 (ask IS the cap; silence is below it). The act gate remains `eligible && tier === "act"` + ctoTrust's earned tiers + the cold-start cap.
  - `processFinding` passes the candidate's class to `decideVerb`.
- `src/server/index.mjs`: reachability comment block updated to the per-class arithmetic. `senderReliability: async () => 1.0` itself is UNCHANGED.
- Tests (`src/server/ctoSuggest.test.mjs`, no new files): table-equality test; reachability properties for the three §9.3-eligible classes (act at ceiling / ask card when un-promoted / silent below the class's own p_ask); queue-tonight no-longer-dead regression; the ask-tier-hold unit + pipeline tests rewritten to pin the new behaviour (decision card, no throw, no `act-not-trusted` row); flat-override-wins tests.

Untouched: `DEFAULT_CLASS_PRIORS`, `worthinessProbability`, the trust ladder, cold-start, the data gates, no new config keys, no spec edit (code now matches §9.1 as written).

Base: origin/main @ ae51c84d

## Verification results

- PR branch (`multica/BET-1471-per-class-thresholds` @ b3c12f78):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3738 pass / 0 fail / 0 skip. Failures: none. log sha256: `848f5351eb77b4323a9d9fb0acf503aba1a14851c89fb45332768396e417e229`
- Base (`main` @ ae51c84d):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3734 pass / 0 fail / 0 skip. Failures: none. log sha256: `cfb8dd7bfba093cdc193194cafbc0e33e36b7adef9542701fe1d400b459e4699`
- **Conclusion:** 0 pre-existing failures, 0 new failures; +4 net tests on the PR branch (table-equality, unknown-class fallback, queue-tonight regression, reachability properties) with the hold tests rewritten to the new pinned behaviour.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
