### PR TITLE
BET-1468: CTO pane never asserts unverified good news (loading, error, dead controls)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -32,6 +32,7 @@ import {
   digestBusy,
   blockerTarget,
   resting,
+  mayShowResting,
   relativeTime,
   finishedVariant,
   formatEta,
@@ -152,6 +153,21 @@ export function CtoPanel({
   const [finished, setFinished] = useState<CtoFinishedItem[]>([]);
   const [ledgerCard, setLedgerCard] = useState<BlockerCard | null>(null);
   const [logsItem, setLogsItem] = useState<CtoFinishedItem | null>(null);
+  // BET-1468 item 1: the three overview reads used to end in `.catch(() =>
+  // {})` — an offline box / stale token left the lists empty with no signal,
+  // and `resting()` reads "everything empty" as "nothing needs you". Track
+  // whether the first load has resolved and whether it failed so the resting
+  // line can be gated on both (see `mayShowResting` in ctoView.ts).
+  const [overviewLoaded, setOverviewLoaded] = useState(false);
+  const [overviewLoadError, setOverviewLoadError] = useState<string | null>(null);
+  const reportOverviewError = useCallback(
+    (label: string) => (e: unknown) => {
+      const msg = e instanceof Error ? e.message : String(e);
+      setOverviewLoadError(msg);
+      pushToast({ id: `cto-overview-err-${Date.now()}`, message: `Couldn't refresh ${label}: ${msg}` });
+    },
+    [pushToast],
+  );
 
   // BET-1392: decision cards (§9.1) render in their own section; the Blocker
   // section keeps the ask/health cards only. The held (silent-log) list backs
@@ -205,17 +221,24 @@ export function CtoPanel({
     [projects],
   );
 
-  // Initial reads + regeneration-completion reload after a generation.
-  useEffect(() => {
-    void window.api?.ctoDigestGet?.()
+  // Initial reads (and the Retry button below, on failure).
+  const loadOverview = useCallback(() => {
+    setOverviewLoadError(null);
+    const p1 = window.api?.ctoDigestGet?.()
       .then((r) => setDigest(r.digest))
-      .catch(() => {});
-    void window.api?.ctoCardsGet?.()
+      .catch(reportOverviewError("the digest"));
+    const p2 = window.api?.ctoCardsGet?.()
       .then((r) => setCards(r.cards))
-      .catch(() => {});
-    void window.api?.ctoFinishedGet?.()
+      .catch(reportOverviewError("the blocker cards"));
+    const p3 = window.api?.ctoFinishedGet?.()
       .then((r) => setFinished(r.items))
-      .catch(() => {});
+      .catch(reportOverviewError("the finished rail"));
+    void Promise.all([p1, p2, p3]).finally(() => setOverviewLoaded(true));
+  }, [reportOverviewError]);
+
+  useEffect(() => {
+    loadOverview();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Reload the digest + finished rails when a generation completes, and the
@@ -225,19 +248,19 @@ export function CtoPanel({
     busyRef.current = busy;
     const generationSettled = prev && !busy;
     if (generationSettled) {
-      void window.api?.ctoDigestGet?.().then((r) => setDigest(r.digest)).catch(() => {});
-      void window.api?.ctoFinishedGet?.().then((r) => setFinished(r.items)).catch(() => {});
+      void window.api?.ctoDigestGet?.().then((r) => setDigest(r.digest)).catch(reportOverviewError("the digest"));
+      void window.api?.ctoFinishedGet?.().then((r) => setFinished(r.items)).catch(reportOverviewError("the finished rail"));
       setDidSettle(true);
     }
-  }, [busy]);
+  }, [busy, reportOverviewError]);
 
   useEffect(() => {
     if (typeof state?.needsYouCount === "number") {
       void window.api?.ctoCardsGet?.()
         .then((r) => setCards(r.cards))
-        .catch(() => {});
+        .catch(reportOverviewError("the blocker cards"));
     }
-  }, [state?.needsYouCount]);
+  }, [state?.needsYouCount, reportOverviewError]);
 
   // --- Now rail composition (§10.4) ---------------------------------------
   const nowCards = useMemo<NowCard[]>(() => {
@@ -330,8 +353,21 @@ export function CtoPanel({
   );
 
   const refreshCards = useCallback(() => {
-    void window.api?.ctoCardsGet?.().then((r) => setCards(r.cards)).catch(() => {});
-  }, []);
+    void window.api?.ctoCardsGet?.().then((r) => setCards(r.cards)).catch(reportOverviewError("the blocker cards"));
+  }, [reportOverviewError]);
+
+  // BET-1468 item 4: the §9.2/§9.3/§7.4 action handlers below each POST an
+  // action that either resolves `{ok:false}` (toasted by its own .then) OR
+  // REJECTS (an AuthRequiredError on a stale token, or a network failure —
+  // §401). An empty `.catch(() => {})` swallowed that second case: with a
+  // stale token every one of these controls did nothing and said nothing.
+  // One handler, every call site, instead of writing the same catch six times.
+  const catchActionError = useCallback(
+    (label: string) => (e: unknown) => {
+      pushToast({ id: `cto-act-err-${Date.now()}`, message: `Couldn't ${label}: ${e instanceof Error ? e.message : String(e)}` });
+    },
+    [pushToast],
+  );
 
   const handleSuggestionAction = useCallback(
     (card: DecisionCardRow, option: SuggestionOption) => {
@@ -339,7 +375,9 @@ export function CtoPanel({
         const r = await executeSuggestionOption({ option, api: suggestionApi });
         if (r.ok) {
           // acted-on = accept judgment through the B3 verdict route.
-          void window.api?.ctoVerdict?.({ subject: { type: "suggestion", id: card.id, class: option.action?.type }, verdict: "accept" }).catch(() => {});
+          void window.api
+            ?.ctoVerdict?.({ subject: { type: "suggestion", id: card.id, class: option.action?.type }, verdict: "accept" })
+            .catch(catchActionError("record the acceptance judgment"));
           pushToast({ id: `sugg-${Date.now()}`, message: `Applied: ${option.label}` });
           refreshCards();
         } else {
@@ -347,15 +385,25 @@ export function CtoPanel({
         }
       })();
     },
-    [suggestionApi, pushToast, refreshCards],
+    [suggestionApi, pushToast, refreshCards, catchActionError],
   );
 
+  // BET-1468 item 5: the verdict write was fire-and-forget with an empty
+  // catch, racing an un-awaited `refreshCards()` — a failed dismiss silently
+  // left the pipeline never learning the judgment, while the card visually
+  // vanished (refreshCards ran regardless). Chain it like every sibling
+  // action below: await, toast a failure, then refresh either way.
   const handleSuggestionDismiss = useCallback(
     (card: DecisionCardRow) => {
-      void window.api?.ctoVerdict?.({ subject: { type: "suggestion", id: card.id }, verdict: "dismiss" }).catch(() => {});
-      refreshCards();
+      void window.api
+        ?.ctoVerdict?.({ subject: { type: "suggestion", id: card.id }, verdict: "dismiss" })
+        .then((r) => {
+          if (!r?.ok) pushToast({ id: `sugg-dismiss-fail-${Date.now()}`, message: `Couldn't dismiss: ${r?.error ?? "unknown error"}` });
+        })
+        .catch(catchActionError("dismiss the suggestion"))
+        .finally(refreshCards);
     },
-    [refreshCards],
+    [refreshCards, pushToast, catchActionError],
   );
 
   // BET-1395 connect asks (§7.4): the three-way answer is a registry write
@@ -391,16 +439,22 @@ export function CtoPanel({
             pushToast({ id: `connect-fail-${Date.now()}`, message: `Couldn't record answer: ${r?.error ?? "unknown"}` });
           }
         })
-        .catch(() => {})
+        .catch(catchActionError("record the connect answer"))
         .finally(refreshCards);
     },
-    [pushToast, refreshCards],
+    [pushToast, refreshCards, catchActionError],
   );
 
   // BET-1419 tonight + veto actions (§9.2/§10.4). The veto card's Cancel
   // tonight is a veto VERDICT on the veto-window subject — the server route
   // performs the actual cancel (pause + close) before recording it. Run-now
   // and the drill-down edits go through the tonight verb route.
+  //
+  // BET-1468 item 6: a rejected fetch (stale token, offline box) used to wipe
+  // `tonightTasks`/`tonightWindowOpen` to empty here, so a genuinely queued
+  // plan flashed to "Nothing queued." while the box kept running it, and
+  // `tonightPinned` was left stale (contradicting the now-empty list). Keep
+  // whatever was last loaded and toast the failure instead of erasing it.
   const refreshTonight = useCallback(() => {
     setTonightLoading(true);
     void window.api
@@ -410,12 +464,9 @@ export function CtoPanel({
         setTonightPinned(Array.isArray(r.window?.pinnedOrder) && r.window.pinnedOrder.length > 0);
         setTonightWindowOpen(r.window?.state === "open");
       })
-      .catch(() => {
-        setTonightTasks([]);
-        setTonightWindowOpen(false);
-      })
+      .catch(catchActionError("refresh tonight's plan"))
       .finally(() => setTonightLoading(false));
-  }, []);
+  }, [catchActionError]);
 
   const handleVetoCancel = useCallback(
     (card: VetoCardRow) => {
@@ -427,10 +478,10 @@ export function CtoPanel({
         .then((r) => {
           if (!r?.ok) pushToast({ id: `veto-${Date.now()}`, message: `Couldn't cancel tonight: ${r?.error ?? "unknown"}` });
         })
-        .catch(() => {})
+        .catch(catchActionError("cancel tonight"))
         .finally(refreshCards);
     },
-    [pushToast, refreshCards],
+    [pushToast, refreshCards, catchActionError],
   );
 
   const handleVetoEditPlan = useCallback(() => {
@@ -446,10 +497,10 @@ export function CtoPanel({
           if (!r?.ok) pushToast({ id: `runnow-${Date.now()}`, message: `Couldn't start overnight now: ${r?.error ?? "unknown"}` });
           else pushToast({ id: `runnow-${Date.now()}`, message: "Overnight run starting" });
         })
-        .catch(() => {})
+        .catch(catchActionError("start overnight now"))
         .finally(refreshCards);
     },
-    [pushToast, refreshCards],
+    [pushToast, refreshCards, catchActionError],
   );
 
   const handleTonightToggle = useCallback(() => {
@@ -465,12 +516,12 @@ export function CtoPanel({
       .then((r) => {
         if (!r?.ok) pushToast({ id: `tonight-${Date.now()}`, message: `Couldn't cancel tonight: ${r?.error ?? "unknown"}` });
       })
-      .catch(() => {})
+      .catch(catchActionError("cancel the overnight plan"))
       .finally(() => {
         refreshCards();
         refreshTonight();
       });
-  }, [pushToast, refreshCards, refreshTonight]);
+  }, [pushToast, refreshCards, refreshTonight, catchActionError]);
 
   const handleTonightRemove = useCallback(
     (id: string) => {
@@ -479,10 +530,10 @@ export function CtoPanel({
         .then((r) => {
           if (!r?.ok) pushToast({ id: `tonight-${Date.now()}`, message: `Couldn't remove the task: ${r?.error ?? "unknown"}` });
         })
-        .catch(() => {})
+        .catch(catchActionError("remove the task"))
         .finally(refreshTonight);
     },
-    [pushToast, refreshTonight],
+    [pushToast, refreshTonight, catchActionError],
   );
 
   // Reorder via the up/down arrows — PINS the order for the current window
@@ -499,10 +550,10 @@ export function CtoPanel({
         .then((r) => {
           if (!r?.ok) pushToast({ id: `tonight-${Date.now()}`, message: `Couldn't reorder: ${r?.error ?? "unknown"}` });
         })
-        .catch(() => {})
+        .catch(catchActionError("reorder tasks"))
         .finally(refreshTonight);
     },
-    [tonightTasks, pushToast, refreshTonight],
+    [tonightTasks, pushToast, refreshTonight, catchActionError],
   );
 
   // Keep the veto countdown live between state events.
@@ -513,18 +564,33 @@ export function CtoPanel({
   }, []);
 
   // §14.3 silence audit: open / refresh the held list (from the digest aside).
+  // BET-1468 item 6: a failed load used to reset `heldRows` to `[]`, so the
+  // modal opened claiming "Nothing held back." right after the digest said
+  // otherwise. Keep whatever was last loaded (the Refresh button in the empty
+  // state covers retry) and toast the failure instead.
   const openHeld = useCallback(() => {
-    void window.api?.ctoHeldList?.().then((r) => setHeldRows(r.rows)).catch(() => setHeldRows([])).finally(() => setHeldOpen(true));
-  }, []);
+    void window.api?.ctoHeldList?.().then((r) => setHeldRows(r.rows)).catch(catchActionError("load held suggestions")).finally(() => setHeldOpen(true));
+  }, [catchActionError]);
+  // BET-1468 item 6: the row was removed from the list unconditionally even
+  // when the verdict POST failed (or threw on a stale token) — the user sees
+  // it accepted/dismissed while the pipeline never recorded the judgment.
+  // Only remove it once the server confirms the verdict landed.
   const handleHeldVerdict = useCallback(
     (row: CtoHeldRow, verdict: "accept" | "dismiss") => {
       void (async () => {
-        const r = await window.api?.ctoHeldVerdict?.({ id: row.id, verdict });
-        if (!r?.ok) pushToast({ id: `held-${Date.now()}`, message: `Couldn't ${verdict} held suggestion: ${r?.error ?? "unknown"}` });
-        setHeldRows((prev) => prev.filter((x) => x.id !== row.id));
+        try {
+          const r = await window.api?.ctoHeldVerdict?.({ id: row.id, verdict });
+          if (r?.ok) {
+            setHeldRows((prev) => prev.filter((x) => x.id !== row.id));
+          } else {
+            pushToast({ id: `held-${Date.now()}`, message: `Couldn't ${verdict} held suggestion: ${r?.error ?? "unknown"}` });
+          }
+        } catch (e) {
+          catchActionError(`${verdict} the held suggestion`)(e);
+        }
       })();
     },
-    [pushToast],
+    [pushToast, catchActionError],
   );
   // BET-1447: the digest "view evidence →" chip must always act (no dead
   // controls). Same decision table as the blackboard fact chips: jump to the
@@ -539,7 +605,10 @@ export function CtoPanel({
     pushToast({ id: `cto-ev-${ref}`, message: `Copied evidence ref: ${ref}` });
   };
   const handleItemOpen = (item: { id: string; text: string; refs?: string[] }) => {
-    void window.api?.ctoDigestOpened?.({ item: item.id, expand: false, digestId: digest?.id ?? null }).catch(() => {});
+    // Best-effort §14.1 ledger write — httpApi.ts documents this as
+    // non-critical to rendering. The visible action (jump/copy below) always
+    // happens regardless of whether this instrumentation call lands.
+    void window.api?.ctoDigestOpened?.({ item: item.id, expand: false, digestId: digest?.id ?? null }).catch(() => { /* non-critical, see httpApi.ts */ });
     const evidence = digestEvidenceAction(item.refs, knownSessions, item.id);
     if (evidence.kind === "jump") {
       onOpenSession(evidence.ref);
@@ -548,23 +617,30 @@ export function CtoPanel({
     }
   };
   const handleItemExpand = (item: { id: string }) => {
-    void window.api?.ctoDigestOpened?.({ item: item.id, expand: true, digestId: digest?.id ?? null }).catch(() => {});
+    // Same best-effort §14.1 write as handleItemOpen — expanding the item is
+    // the visible action here and already happened by the time this fires.
+    void window.api?.ctoDigestOpened?.({ item: item.id, expand: true, digestId: digest?.id ?? null }).catch(() => { /* non-critical, see httpApi.ts */ });
   };
 
   // --- resting gate (§10.6-1) ----------------------------------------------
+  // BET-1468 item 1: "Nothing needs you ✓" is a confident claim — it must
+  // never render before the first overview load resolves (empty state on
+  // open) or after that load failed (an offline box / stale token would
+  // otherwise read as a false all-clear). `mayShowResting` is the pure gate.
   const isResting = resting({
     cards,
     nowActive: nowCards,
     finished,
     digestHasItems: (digest?.items?.length ?? 0) > 0,
   });
+  const showResting = mayShowResting({ loaded: overviewLoaded, loadError: !!overviewLoadError, isResting });
 
   const restingRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (didSettle && isResting) {
+    if (didSettle && showResting) {
       restingRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
     }
-  }, [didSettle, isResting]);
+  }, [didSettle, showResting]);
 
   if (view === "settings") {
     return (
@@ -684,8 +760,10 @@ export function CtoPanel({
           ) : null}
         </div>
 
-        {/* Resting state (§10.6-1): only when every section is empty. */}
-        {isResting && (
+        {/* Resting state (§10.6-1): only when every section is empty AND the
+            overview actually loaded (never on open, never on a failed load —
+            see `mayShowResting`). */}
+        {showResting && (
           <div ref={restingRef} className="flex flex-col items-center gap-1 py-12">
             <div className="text-text-muted">
               Nothing needs you <span aria-hidden>✓</span>
@@ -695,9 +773,33 @@ export function CtoPanel({
             </div>
           </div>
         )}
+
+        {/* BET-1468 item 1: a failed overview load must say so, not render
+            an empty resting state that reads as a false all-clear. */}
+        {overviewLoadError && (
+          <div className="flex flex-col items-center gap-1 py-12">
+            <div className="text-sm text-text-muted">Couldn&rsquo;t load the CTO overview: {overviewLoadError}</div>
+            <button
+              type="button"
+              onClick={loadOverview}
+              className="text-sm text-accent underline hover:text-accent-strong"
+            >
+              Retry
+            </button>
+          </div>
+        )}
       </div>
 
-      {ledgerCard && <LedgerFallbackModal card={ledgerCard} onClose={() => setLedgerCard(null)} />}
+      {ledgerCard && (
+        <LedgerFallbackModal
+          card={ledgerCard}
+          onClose={() => setLedgerCard(null)}
+          onOpenLedger={() => {
+            setLedgerCard(null);
+            setView("ledger");
+          }}
+        />
+      )}
       {logsItem && logsItem.kind === "job" && (
         <JobLogsModal
           name={logsItem.name}

--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -153,8 +153,8 @@ export function CtoPanel({
   const [finished, setFinished] = useState<CtoFinishedItem[]>([]);
   const [ledgerCard, setLedgerCard] = useState<BlockerCard | null>(null);
   const [logsItem, setLogsItem] = useState<CtoFinishedItem | null>(null);
-  // BET-1468 item 1: the three overview reads used to end in `.catch(() =>
-  // {})` — an offline box / stale token left the lists empty with no signal,
+  // BET-1468 item 1: the three overview reads used to end in an empty no-op
+  // catch — an offline box / stale token left the lists empty with no signal,
   // and `resting()` reads "everything empty" as "nothing needs you". Track
   // whether the first load has resolved and whether it failed so the resting
   // line can be gated on both (see `mayShowResting` in ctoView.ts).
@@ -330,8 +330,23 @@ export function CtoPanel({
     }
   };
 
-  const handleRegen = () => {
-    void window.api?.ctoDigestNow?.();
+  // BET-1468 item 3: the pane's primary button used to discard its result —
+  // `void ctoDigestNow()` — while httpApi returns `{ok:false, error}` "so the
+  // pane can toast the cause" and THROWS AuthRequiredError on a 401. Pressed
+  // while paused/disabled/offline it did nothing at all. Await and report BOTH
+  // branches (the AGENTS.md rule); success says so too, because the fresh
+  // digest only lands later, when the generation settles.
+  const handleRegen = async () => {
+    try {
+      const r = await window.api?.ctoDigestNow?.();
+      if (r && !r.ok) {
+        pushToast({ id: `regen-${Date.now()}`, message: `Couldn't regenerate the digest: ${r.error ?? "unknown error"}` });
+      } else {
+        pushToast({ id: `regen-${Date.now()}`, message: "Digest regeneration started — the pane refreshes when it lands" });
+      }
+    } catch (e) {
+      pushToast({ id: `regen-${Date.now()}`, message: `Couldn't regenerate the digest: ${e instanceof Error ? e.message : String(e)}` });
+    }
   };
 
   // BET-1392 decision-card actions (§9.1). The existing renderer api surface is
@@ -359,7 +374,7 @@ export function CtoPanel({
   // BET-1468 item 4: the §9.2/§9.3/§7.4 action handlers below each POST an
   // action that either resolves `{ok:false}` (toasted by its own .then) OR
   // REJECTS (an AuthRequiredError on a stale token, or a network failure —
-  // §401). An empty `.catch(() => {})` swallowed that second case: with a
+  // §401). An empty no-op catch swallowed that second case: with a
   // stale token every one of these controls did nothing and said nothing.
   // One handler, every call site, instead of writing the same catch six times.
   const catchActionError = useCallback(
@@ -915,11 +930,31 @@ function SettingsView({
   // usage snapshots (provider window notes), read once on settings-open.
   const [budget, setBudget] = useState<{ days?: Record<string, { usd?: number } | undefined>; quota?: Record<string, { provider?: string; mode?: string | null; reserve?: number | null; mape14?: number | null } | undefined> } | null>(null);
   const [usageSnaps, setUsageSnaps] = useState<{ provider?: string; windows?: { kind?: string; label?: string; resetsAt?: number | null }[] | null }[]>([]);
-
+  // BET-1468 item 2: `config` starts null and the four reads had no `.catch()`
+  // at all — while loading, every control displayed a default the box never
+  // sent (the effort radios showed "Low" on a High-tier box and a click wrote
+  // that downgrade through), and on a failure the pane stayed there forever.
+  // Track load state; the Behavior/Tonight cards stay gated on `config`.
+  const [settingsLoadError, setSettingsLoadError] = useState<string | null>(null);
+  const aliveRef = useRef(true);
   useEffect(() => {
-    let alive = true;
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+  const reportSettingsLoadError = useCallback(
+    (label: string) => (e: unknown) => {
+      const msg = e instanceof Error ? e.message : String(e);
+      setSettingsLoadError(msg);
+      pushToast({ id: `cto-set-err-${Date.now()}`, message: `Couldn't load ${label}: ${msg}` });
+    },
+    [pushToast],
+  );
+  const loadSettings = useCallback(() => {
+    setSettingsLoadError(null);
     void window.api.configGet().then((c) => {
-      if (!alive) return;
+      if (!aliveRef.current) return;
       setConfig({
         ctoEnabled: !!c?.ctoEnabled,
         ctoTier: c?.ctoTier,
@@ -930,23 +965,24 @@ function SettingsView({
       });
       setCapText(String(c?.ctoAmbientCap ?? DEFAULT_AMBIENT_CAP_USD));
       setNightCapText(c?.ctoNightCapUsd != null ? String(c.ctoNightCapUsd) : "");
-    });
+    }).catch(reportSettingsLoadError("the CTO settings"));
     void window.api.ctoHealthGet().then((h) => {
-      if (alive) setHealth(h.stats);
-    });
+      if (aliveRef.current) setHealth(h.stats);
+    }).catch(reportSettingsLoadError("the health stats"));
     // BET-1405 (§10.5 card 3): the persisted budget payload (day buckets +
     // quota cache) and the usage snapshots (provider window notes) — one read
-    // on settings-open, never polled. Rejections degrade to absent data.
+    // on settings-open, never polled.
     void window.api.ctoQuotaRead().then((b) => {
-      if (alive) setBudget(b ?? null);
-    });
+      if (aliveRef.current) setBudget(b ?? null);
+    }).catch(reportSettingsLoadError("the budget history"));
     void window.api.usageList().then((snaps) => {
-      if (alive) setUsageSnaps(Array.isArray(snaps) ? snaps : []);
-    });
-    return () => {
-      alive = false;
-    };
-  }, []);
+      if (aliveRef.current) setUsageSnaps(Array.isArray(snaps) ? snaps : []);
+    }).catch(reportSettingsLoadError("the usage snapshots"));
+  }, [reportSettingsLoadError]);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
 
   const applyConfig = useCallback(
     async (patch: Partial<CtoSettingsConfig>) => {
@@ -956,7 +992,10 @@ function SettingsView({
         const next = (await window.api.configUpdate(patch)) as CtoSettingsConfig;
         setConfig((c) => ({ ...c, ...patch, ctoAmbientCap: next?.ctoAmbientCap }));
       } catch (e) {
-        setConfig(prev ?? {});
+        // BET-1468 item 2: restore exactly what was on screen before the
+        // optimistic patch — the old `prev ?? {}` fabricated an empty config
+        // (and lost the patch state) whenever the write failed.
+        setConfig(prev);
         pushToast({
           id: `cto-cfg-${Date.now()}`,
           message: `Couldn't update: ${e instanceof Error ? e.message : String(e)}`,
@@ -1038,6 +1077,27 @@ function SettingsView({
 
         <div className="mt-4 space-y-6">
           {/* ---------- Behavior card (§10.5 card 1, P1 subset) ---------- */}
+          {/* BET-1468 item 2: never render controls over a config the box has
+              not sent — the `?? false` / `?? "low"` defaults read as facts, and
+              a click on the effort dial wrote the fake tier through. Gate the
+              card on the read; the Loading… line matches the sibling
+              drill-downs, the failure case gets a Retry that re-runs the read. */}
+          {config === null ? (
+            settingsLoadError ? (
+              <div className="rounded-lg border border-border-subtle p-4">
+                <div className="text-sm text-text-muted">Couldn&rsquo;t load the CTO settings: {settingsLoadError}</div>
+                <button
+                  type="button"
+                  onClick={loadSettings}
+                  className="mt-2 text-sm text-accent underline hover:text-accent-strong"
+                >
+                  Retry
+                </button>
+              </div>
+            ) : (
+              <p className="text-sm text-text-faint">Loading…</p>
+            )
+          ) : (
           <section className="rounded-lg border border-border-subtle p-4">
             <h3 className="text-sm font-semibold text-text">Behavior</h3>
             <p className="mt-1 text-sm text-text-faint">
@@ -1211,6 +1271,23 @@ function SettingsView({
               </div>
             </div>
           </section>
+          )}
+
+          {/* BET-1468 item 2: the config read landed but a secondary read
+              failed — say so (the toast already fired) with a Retry, instead
+              of leaving the health/budget sections silently empty. */}
+          {config !== null && settingsLoadError ? (
+            <div className="rounded-lg border border-border-subtle p-3">
+              <div className="text-sm text-text-muted">Couldn&rsquo;t load everything: {settingsLoadError}</div>
+              <button
+                type="button"
+                onClick={loadSettings}
+                className="mt-2 text-sm text-accent underline hover:text-accent-strong"
+              >
+                Retry
+              </button>
+            </div>
+          ) : null}
 
           {/* ---------- Health card (§10.5 card 2) ---------- */}
           <section className="rounded-lg border border-border-subtle p-4">
@@ -1253,14 +1330,20 @@ function SettingsView({
           </section>
 
           {/* ---------- Tonight's budget (§10.5 card 3, BET-1405) ---------- */}
-          <TonightBudgetCard
-            tier={config?.ctoTier ?? "low"}
-            overnightOn={!!config?.ctoOvernight}
-            ambientCapUsd={config?.ctoAmbientCap ?? DEFAULT_AMBIENT_CAP_USD}
-            nightCapUsd={config?.ctoNightCapUsd ?? DEFAULT_NIGHT_CAP_USD}
-            budget={budget}
-            usageSnaps={usageSnaps}
-          />
+          {/* BET-1468 item 2: gated like the Behavior card — `tier ?? "low"`
+              here used to render "Overnight work is off — there is no night
+              pool to gauge", a false statement about a High-tier box, while
+              the read was still in flight (or after it failed). */}
+          {config !== null ? (
+            <TonightBudgetCard
+              tier={config?.ctoTier ?? "low"}
+              overnightOn={!!config?.ctoOvernight}
+              ambientCapUsd={config?.ctoAmbientCap ?? DEFAULT_AMBIENT_CAP_USD}
+              nightCapUsd={config?.ctoNightCapUsd ?? DEFAULT_NIGHT_CAP_USD}
+              budget={budget}
+              usageSnaps={usageSnaps}
+            />
+          ) : null}
 
           {/* ---------- Internals: rows 1-4 of the §10.5 drill-down list ---------- */}
           <section className="rounded-lg border border-border-subtle p-4">
@@ -1647,14 +1730,38 @@ function ProfileView({
   const [tab, setTab] = useState<ProfileTab>("profile");
   const [render, setRender] = useState<CtoProfileRender | null>(null);
   const [loading, setLoading] = useState(true);
+  // BET-1468 item 7: `loading` used to clear only on the success path, so a
+  // 401 left this drill-down on a permanent "Loading…" with no error and no
+  // retry. Track the failure; keep the last good render on it.
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [editDim, setEditDim] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
 
   const refresh = useCallback(async () => {
-    const r = await window.api.ctoProfileGet();
-    setRender(r);
-    setLoading(false);
-  }, []);
+    try {
+      const r = await window.api.ctoProfileGet();
+      // httpApi degrades a failed read to `emptyProfileRender()` (compiledAt
+      // 0 by construction; a server success always stamps a time). Treat that
+      // as the failure it is instead of claiming "nothing here yet".
+      if (r.compiledAt === 0) {
+        setLoadError("the profile read failed");
+        return;
+      }
+      setRender(r);
+      setLoadError(null);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : String(e));
+      pushToast({ id: `cto-prof-load-${Date.now()}`, message: `Couldn't load the profile: ${e instanceof Error ? e.message : String(e)}` });
+    } finally {
+      setLoading(false);
+    }
+  }, [pushToast]);
+
+  const retryProfileLoad = useCallback(() => {
+    setLoading(true);
+    setLoadError(null);
+    void refresh();
+  }, [refresh]);
 
   useEffect(() => {
     void refresh();
@@ -1667,33 +1774,45 @@ function ProfileView({
       return;
     }
     const clamped = Math.min(1, Math.max(0, value));
-    const res = await window.api.ctoProfileEdit({ dimension: skill.dimension, value: clamped });
-    if (!res.ok) {
-      pushToast({ id: `cto-edit-fail-${skill.dimension}`, message: res.error ?? "Edit failed" });
-      return;
+    try {
+      const res = await window.api.ctoProfileEdit({ dimension: skill.dimension, value: clamped });
+      if (!res.ok) {
+        pushToast({ id: `cto-edit-fail-${skill.dimension}`, message: res.error ?? "Edit failed" });
+        return;
+      }
+      setRender(res);
+      setEditDim(null);
+      pushToast({ id: `cto-edit-ok-${skill.dimension}`, message: `Stated ${skill.dimension} as ${clamped}` });
+    } catch (e) {
+      pushToast({ id: `cto-edit-fail-${skill.dimension}`, message: `Couldn't save the edit: ${e instanceof Error ? e.message : String(e)}` });
     }
-    setRender(res);
-    setEditDim(null);
-    pushToast({ id: `cto-edit-ok-${skill.dimension}`, message: `Stated ${skill.dimension} as ${clamped}` });
   };
 
   const suppress = async (cls: string) => {
-    const res = await window.api.ctoProfileSuppress({ inference: cls });
-    if (!res.ok) {
-      pushToast({ id: `cto-sup-fail-${cls}`, message: res.error ?? "Couldn't delete" });
-      return;
+    try {
+      const res = await window.api.ctoProfileSuppress({ inference: cls });
+      if (!res.ok) {
+        pushToast({ id: `cto-sup-fail-${cls}`, message: res.error ?? "Couldn't delete" });
+        return;
+      }
+      setRender(res);
+      pushToast({ id: `cto-sup-ok-${cls}`, message: "Sensitive inference deleted for 90 days" });
+    } catch (e) {
+      pushToast({ id: `cto-sup-fail-${cls}`, message: `Couldn't delete the inference: ${e instanceof Error ? e.message : String(e)}` });
     }
-    setRender(res);
-    pushToast({ id: `cto-sup-ok-${cls}`, message: "Sensitive inference deleted for 90 days" });
   };
 
   const delJournal = async (id: string) => {
-    const res = await window.api.ctoJournalDelete({ id });
-    if (!res.ok) {
-      pushToast({ id: `cto-jdel-${id}`, message: "Couldn't delete the entry" });
-      return;
+    try {
+      const res = await window.api.ctoJournalDelete({ id });
+      if (!res.ok) {
+        pushToast({ id: `cto-jdel-${id}`, message: "Couldn't delete the entry" });
+        return;
+      }
+      void refresh();
+    } catch (e) {
+      pushToast({ id: `cto-jdel-${id}`, message: `Couldn't delete the entry: ${e instanceof Error ? e.message : String(e)}` });
     }
-    void refresh();
   };
 
   // Deep-link an evidence ref. Refs are bare provenance strings in the render
@@ -1746,6 +1865,13 @@ function ProfileView({
 
         {loading ? (
           <p className="text-sm text-text-faint">Loading…</p>
+        ) : loadError ? (
+          <div className="mt-4 flex flex-col items-start gap-1">
+            <p className="text-sm text-text-muted">Couldn&rsquo;t load the profile: {loadError}</p>
+            <button type="button" onClick={retryProfileLoad} className="text-sm text-accent underline hover:text-accent-strong">
+              Retry
+            </button>
+          </div>
         ) : tab === "journal" ? (
           <JournalTab render={render} delJournal={delJournal} />
         ) : (
@@ -1988,7 +2114,7 @@ function ProfileView({
           </div>
         )}
 
-        {!loading && empty && <p className="mt-8 text-sm text-text-faint">Nothing here yet — the CTO fills this in as it learns.</p>}
+        {!loading && !loadError && empty && <p className="mt-8 text-sm text-text-faint">Nothing here yet — the CTO fills this in as it learns.</p>}
       </div>
     </div>
   );
@@ -2312,6 +2438,10 @@ function BlackboardView({
   );
   const [render, setRender] = useState<CtoFactsRender | null>(null);
   const [loading, setLoading] = useState(true);
+  // BET-1468 item 7: same hole as Profile — `loading` cleared on success only,
+  // so a 401 hung this view on "Loading…" forever. Track the failure and keep
+  // the last good render (the project chip row stays switchable).
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [tab, setTab] = useState<"facts" | "archive">("facts");
   const [archive, setArchive] = useState<CtoFactRow[]>([]);
   const [archiveTotal, setArchiveTotal] = useState(0);
@@ -2320,10 +2450,31 @@ function BlackboardView({
   const [correction, setCorrection] = useState("");
 
   const refresh = useCallback(async () => {
-    const r = await window.api.ctoFactsGet({});
-    setRender(r);
-    setLoading(false);
-  }, []);
+    try {
+      const r = await window.api.ctoFactsGet({});
+      // httpApi degrades a failed read to `emptyFactsRender()` (compiledAt 0
+      // by construction; a server success always stamps a time). Treating it
+      // as success would swap the board — and the project chip row — for an
+      // empty render the user cannot switch back from (BET-1468 item 6).
+      if (r.compiledAt === 0) {
+        setLoadError("the blackboard read failed");
+        return;
+      }
+      setRender(r);
+      setLoadError(null);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : String(e));
+      pushToast({ id: `bb-load-${Date.now()}`, message: `Couldn't load the blackboard: ${e instanceof Error ? e.message : String(e)}` });
+    } finally {
+      setLoading(false);
+    }
+  }, [pushToast]);
+
+  const retryBoardLoad = useCallback(() => {
+    setLoading(true);
+    setLoadError(null);
+    void refresh();
+  }, [refresh]);
 
   useEffect(() => {
     void refresh();
@@ -2331,14 +2482,19 @@ function BlackboardView({
 
   const loadArchive = useCallback(
     async (project: string | null, before?: number) => {
-      const page = await window.api.ctoFactsArchiveGet({ project, before });
-      if (!page.ok) {
-        pushToast({ id: `bb-arc-${Date.now()}`, message: page.error ?? "Couldn't load the archive" });
-        return;
+      try {
+        const page = await window.api.ctoFactsArchiveGet({ project, before });
+        if (!page.ok) {
+          pushToast({ id: `bb-arc-${Date.now()}`, message: page.error ?? "Couldn't load the archive" });
+          return;
+        }
+        setArchiveTotal(page.total);
+        setNextBefore(page.nextBefore);
+        setArchive((prev) => (before == null ? page.entries : [...prev, ...page.entries]));
+      } catch (e) {
+        // A stale token throws (AuthRequiredError) — say so, keep what's shown.
+        pushToast({ id: `bb-arc-${Date.now()}`, message: `Couldn't load the archive: ${e instanceof Error ? e.message : String(e)}` });
       }
-      setArchiveTotal(page.total);
-      setNextBefore(page.nextBefore);
-      setArchive((prev) => (before == null ? page.entries : [...prev, ...page.entries]));
     },
     [pushToast],
   );
@@ -2349,35 +2505,51 @@ function BlackboardView({
   };
 
   const switchProject = async (project: string) => {
-    const r = await window.api.ctoFactsGet({ project });
-    setRender(r);
-    setArchive([]);
-    setArchiveTotal(0);
-    setNextBefore(null);
-    if (tab === "archive") void loadArchive(project);
+    try {
+      const r = await window.api.ctoFactsGet({ project });
+      if (r.compiledAt === 0) {
+        // Failed read (httpApi degrades to the empty render) — keep the
+        // currently displayed board and its chip row instead of wiping them.
+        pushToast({ id: `bb-switch-${Date.now()}`, message: `Couldn't switch to ${project}` });
+        return;
+      }
+      setRender(r);
+      setArchive([]);
+      setArchiveTotal(0);
+      setNextBefore(null);
+      if (tab === "archive") void loadArchive(project);
+    } catch (e) {
+      pushToast({ id: `bb-switch-${Date.now()}`, message: `Couldn't switch to ${project}: ${e instanceof Error ? e.message : String(e)}` });
+    }
   };
 
   const pin = async (row: CtoFactRow) => {
-    if (!render?.project) return;
-    const res = await window.api.ctoFactPin({ project: render.project, factId: row.id });
-    pushToast(
-      res.ok
-        ? { id: `bb-pin-${row.id}`, message: "Pinned — the access clock was reset" }
-        : { id: `bb-pin-err-${row.id}`, message: res.error ?? "Pin failed" },
-    );
+    try {
+      const res = await window.api.ctoFactPin({ project: render!.project!, factId: row.id });
+      pushToast(
+        res.ok
+          ? { id: `bb-pin-${row.id}`, message: "Pinned — the access clock was reset" }
+          : { id: `bb-pin-err-${row.id}`, message: res.error ?? "Pin failed" },
+      );
+    } catch (e) {
+      pushToast({ id: `bb-pin-err-${row.id}`, message: `Couldn't pin: ${e instanceof Error ? e.message : String(e)}` });
+    }
   };
 
   const submitCorrection = async (row: CtoFactRow) => {
-    if (!render?.project) return;
-    const res = await window.api.ctoFactCorrect({ project: render.project, factId: row.id, statement: correction });
-    if (!res.ok) {
-      pushToast({ id: `bb-corr-err-${row.id}`, message: res.error ?? "Correction failed" });
-      return;
+    try {
+      const res = await window.api.ctoFactCorrect({ project: render!.project!, factId: row.id, statement: correction });
+      if (!res.ok) {
+        pushToast({ id: `bb-corr-err-${row.id}`, message: res.error ?? "Correction failed" });
+        return;
+      }
+      setCorrecting(null);
+      setCorrection("");
+      pushToast({ id: `bb-corr-${row.id}`, message: "Correction applied — the fact was superseded" });
+      void refresh();
+    } catch (e) {
+      pushToast({ id: `bb-corr-err-${row.id}`, message: `Couldn't send the correction: ${e instanceof Error ? e.message : String(e)}` });
     }
-    setCorrecting(null);
-    setCorrection("");
-    pushToast({ id: `bb-corr-${row.id}`, message: "Correction applied — the fact was superseded" });
-    void refresh();
   };
 
   return (
@@ -2425,6 +2597,13 @@ function BlackboardView({
 
         {loading ? (
           <div className="mt-4 text-sm text-text-muted">Loading…</div>
+        ) : loadError ? (
+          <div className="mt-4 flex flex-col items-start gap-1">
+            <div className="text-sm text-text-muted">Couldn&rsquo;t load the blackboard: {loadError}</div>
+            <button type="button" onClick={retryBoardLoad} className="text-sm text-accent underline hover:text-accent-strong">
+              Retry
+            </button>
+          </div>
         ) : tab === "facts" ? (
           <>
             {render && render.active.length > 0 ? (
@@ -2465,22 +2644,28 @@ function BlackboardView({
                         </div>
                       </div>
                     ) : null}
-                    <div className="mt-1 flex gap-2">
-                      <button
-                        type="button"
-                        onClick={() => setCorrecting(correcting === row.id ? null : row.id)}
-                        className="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:text-text"
-                      >
-                        Wrong?
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void pin(row)}
-                        className="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:text-text"
-                      >
-                        Pin
-                      </button>
-                    </div>
+                    {/* BET-1468 item 8: Pin and the Supersede flow (opened by
+                        Wrong?) both act on `render.project` — when the render
+                        arrived without one they used to return silently. A
+                        control that cannot act is not rendered. */}
+                    {render?.project ? (
+                      <div className="mt-1 flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setCorrecting(correcting === row.id ? null : row.id)}
+                          className="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:text-text"
+                        >
+                          Wrong?
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void pin(row)}
+                          className="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:text-text"
+                        >
+                          Pin
+                        </button>
+                      </div>
+                    ) : null}
                   </div>
                 ))}
               </div>
@@ -2557,13 +2742,36 @@ function ToolIntegrationsView({
 }) {
   const [render, setRender] = useState<CtoToolsRender | null>(null);
   const [loading, setLoading] = useState(true);
+  // BET-1468 item 7: same success-only `setLoading(false)` hole as the other
+  // drill-downs — a 401 hung this view on "Loading…" forever.
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [busyTool, setBusyTool] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    const r = await window.api.ctoToolsGet();
-    setRender(r);
-    setLoading(false);
-  }, []);
+    try {
+      const r = await window.api.ctoToolsGet();
+      // httpApi degrades a failed read to `emptyToolsRender()` (compiledAt 0
+      // by construction; a server success always stamps a time) — treat it as
+      // the failure it is instead of claiming no tools are observed.
+      if (r.compiledAt === 0) {
+        setLoadError("the tool registry read failed");
+        return;
+      }
+      setRender(r);
+      setLoadError(null);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : String(e));
+      pushToast({ id: `ti-load-${Date.now()}`, message: `Couldn't load the tool registry: ${e instanceof Error ? e.message : String(e)}` });
+    } finally {
+      setLoading(false);
+    }
+  }, [pushToast]);
+
+  const retryToolsLoad = useCallback(() => {
+    setLoading(true);
+    setLoadError(null);
+    void refresh();
+  }, [refresh]);
 
   useEffect(() => {
     void refresh();
@@ -2571,26 +2779,38 @@ function ToolIntegrationsView({
 
   const revoke = async (row: CtoToolRegistryRow, ring: "metadata" | "deep_read" | "write") => {
     setBusyTool(row.tool);
-    const res = await window.api.ctoToolRevoke({ tool: row.tool, ring });
-    pushToast(
-      res.ok
-        ? { id: `ti-rev-${row.tool}-${ring}`, message: `Revoked ${ring.replace("_", " ")} consent for ${row.displayName}` }
-        : { id: `ti-rev-err-${row.tool}-${ring}`, message: res.error ?? "Revoke failed" },
-    );
-    setBusyTool(null);
-    if (res.ok) void refresh();
+    try {
+      const res = await window.api.ctoToolRevoke({ tool: row.tool, ring });
+      pushToast(
+        res.ok
+          ? { id: `ti-rev-${row.tool}-${ring}`, message: `Revoked ${ring.replace("_", " ")} consent for ${row.displayName}` }
+          : { id: `ti-rev-err-${row.tool}-${ring}`, message: res.error ?? "Revoke failed" },
+      );
+      if (res.ok) void refresh();
+    } catch (e) {
+      pushToast({ id: `ti-rev-err-${row.tool}-${ring}`, message: `Couldn't revoke: ${e instanceof Error ? e.message : String(e)}` });
+    } finally {
+      // BET-1468: the busy flag used to survive a rejection, leaving the
+      // revoke control permanently disabled — a dead control.
+      setBusyTool(null);
+    }
   };
 
   const unnever = async (row: CtoToolRegistryRow) => {
     setBusyTool(row.tool);
-    const res = await window.api.ctoToolUnnever({ tool: row.tool });
-    pushToast(
-      res.ok
-        ? { id: `ti-un-${row.tool}`, message: `${row.displayName} re-enters the lifecycle at observed` }
-        : { id: `ti-un-err-${row.tool}`, message: res.error ?? "Un-never failed" },
-    );
-    setBusyTool(null);
-    if (res.ok) void refresh();
+    try {
+      const res = await window.api.ctoToolUnnever({ tool: row.tool });
+      pushToast(
+        res.ok
+          ? { id: `ti-un-${row.tool}`, message: `${row.displayName} re-enters the lifecycle at observed` }
+          : { id: `ti-un-err-${row.tool}`, message: res.error ?? "Un-never failed" },
+      );
+      if (res.ok) void refresh();
+    } catch (e) {
+      pushToast({ id: `ti-un-err-${row.tool}`, message: `Couldn't clear the never verdict: ${e instanceof Error ? e.message : String(e)}` });
+    } finally {
+      setBusyTool(null);
+    }
   };
 
   const toolBlock = (row: CtoToolRegistryRow) => (
@@ -2683,6 +2903,13 @@ function ToolIntegrationsView({
 
         {loading ? (
           <div className="mt-4 text-sm text-text-muted">Loading…</div>
+        ) : loadError ? (
+          <div className="mt-4 flex flex-col items-start gap-1">
+            <div className="text-sm text-text-muted">Couldn&rsquo;t load the tool registry: {loadError}</div>
+            <button type="button" onClick={retryToolsLoad} className="text-sm text-accent underline hover:text-accent-strong">
+              Retry
+            </button>
+          </div>
         ) : (
           <>
             {render && render.tools.length > 0 ? (

--- a/src/renderer/ctoSections.tsx
+++ b/src/renderer/ctoSections.tsx
@@ -75,16 +75,20 @@ export const BlockerSection = memo(function BlockerSection({
 });
 
 // Minimal inline modal for the Answer-now "target missing" fallback (§10.3):
-// opens the matching ledger entry. The full ledger page ships with the settings
-// issue; until then the modal keeps the fallback branch honest without a dead
-// navigation target. Uses an inline backdrop color to avoid the dim-overlay
-// class owned by the Modal primitive (chrome-ownership rule).
+// opens the matching ledger entry. BET-1468 item 7: the full Activity-ledger
+// page has since shipped (`LedgerView`, reachable from Settings → Internals),
+// so the copy claiming it doesn't exist yet was stale, and Close was the
+// modal's only control — a dead end for a card whose whole point is routing
+// the user somewhere useful. Uses an inline backdrop color to avoid the
+// dim-overlay class owned by the Modal primitive (chrome-ownership rule).
 export const LedgerFallbackModal = memo(function LedgerFallbackModal({
   card,
   onClose,
+  onOpenLedger,
 }: {
   card: BlockerCard;
   onClose: () => void;
+  onOpenLedger: () => void;
 }) {
   return (
     <div
@@ -103,16 +107,22 @@ export const LedgerFallbackModal = memo(function LedgerFallbackModal({
         <p className="mt-1 text-sm text-text-muted">{card.body || "No additional detail."}</p>
         <p className="mt-2 text-xs text-text-faint">
           Ledger entry (source {card.sourceKind}
-          {card.sourceId ? ` ${card.sourceId}` : ""}) — the full ledger page
-          lands with the Settings issue.
+          {card.sourceId ? ` ${card.sourceId}` : ""}) — open the full Activity ledger to see it in context.
         </p>
-        <div className="mt-3 flex justify-end">
+        <div className="mt-3 flex justify-end gap-2">
           <button
             type="button"
             onClick={onClose}
             className="rounded-md px-2 py-1 text-sm text-text hover:bg-fill-hover"
           >
             Close
+          </button>
+          <button
+            type="button"
+            onClick={onOpenLedger}
+            className="rounded-md bg-accent px-2 py-1 text-sm font-medium text-text hover:opacity-90"
+          >
+            Open activity ledger
           </button>
         </div>
       </div>

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -14,6 +14,7 @@ import {
   digestTone,
   digestExpandable,
   resting,
+  mayShowResting,
   stateTone,
   nowCostLabel,
   nowRailMeta,
@@ -336,6 +337,21 @@ describe("resting (§10.6-1 Nothing needs you state)", () => {
   });
   it("null rails are treated as empty", () => {
     expect(resting({ cards: null, nowActive: null, finished: null, digestHasItems: false })).toBe(true);
+  });
+});
+
+describe("mayShowResting (BET-1468 item 1 — no false all-clear)", () => {
+  it("is false before the first load resolves, even if everything is empty", () => {
+    expect(mayShowResting({ loaded: false, loadError: false, isResting: true })).toBe(false);
+  });
+  it("is false when the load failed, even if the stale data is empty", () => {
+    expect(mayShowResting({ loaded: true, loadError: true, isResting: true })).toBe(false);
+  });
+  it("is false when loaded without error but not resting", () => {
+    expect(mayShowResting({ loaded: true, loadError: false, isResting: false })).toBe(false);
+  });
+  it("is true only once loaded, without error, and actually resting", () => {
+    expect(mayShowResting({ loaded: true, loadError: false, isResting: true })).toBe(true);
   });
 });
 

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -462,6 +462,15 @@ export function resting(
   return cards.length === 0 && nowActive.length === 0 && finished.length === 0 && !inputs.digestHasItems;
 }
 
+// BET-1468 item 1: the resting line is a confident claim ("nothing needs
+// you") — it must never render before the first overview load resolves (it
+// flashes true on every open otherwise) or after that load failed (an
+// offline box / stale token would read as a false all-clear on the one
+// surface whose entire job is to say what's blocked).
+export function mayShowResting(inputs: { loaded: boolean; loadError: boolean; isResting: boolean }): boolean {
+  return inputs.loaded && !inputs.loadError && inputs.isResting;
+}
+
 // Now-rail/digest shared: does the list of sessions have any blocked one — the
 // "blocked — question above ↑" chip on a blocked Now card (never repeats the
 // question).


### PR DESCRIPTION
## Summary

CTO S4a (stage 4 of BET-1461 decomposition): the CTO pane must never assert good news it has not verified. Continues the salvaged branch (`multica/BET-1468-cto-pane-loading-error-states`, committed by no-op triage after the first implementer run was watchdog-killed); its items 1, 4, 5, 6a–c and the LedgerFallbackModal are included; this run added items 2, 3, 6d, 7 (drill-downs) and 8.

Per-item (issue numbering):

1. **Overview reads** — `loaded`/`loadError` tracked; `mayShowResting` extracted to `ctoView.ts` (+tests); resting line only renders once loaded without error; failure renders an error line with Retry. *(salvage)*
2. **Settings** — Behavior + Tonight cards gated on the `configGet` read (same Loading… line the sibling drill-downs use); all four reads got `.catch()` → toast + error line with Retry; `applyConfig` failure now restores the previous config instead of `setConfig(prev ?? {})`.
3. **Digest now** — awaited; toasts success ("regeneration started — the pane refreshes when it lands") and both failure shapes (`{ok:false,error}` and the 401 throw).
4. **Overnight/connect actions** — six identical empty catches factored into one `catchActionError(label)` helper. *(salvage)*
5. **Suggestion dismiss** — verdict awaited, failure toasted, refresh in `.finally()`. *(salvage)*
6. **Failure paths no longer destroy on-screen data** — tonight refresh keeps last data; held modal keeps rows; held verdict removal only on `r.ok`; Blackboard `switchProject`/`refresh` keep the last render (chip row stays switchable) using the `compiledAt === 0` marker of httpApi's empty-render degradation.
7. **Drill-downs** — Profile/Blackboard/Tools: `try/finally` loading, error state + Retry; `saveEdit`/`suppress`/`delJournal` and Tools `revoke`/`unnever` (busy flag now cleared in `finally` — it used to survive a rejection and permanently disable the control) all report failure. LedgerFallbackModal copy corrected and gained an "Open activity ledger" button → `setView("ledger")`. *(modal part salvage)*
8. **Silent no-ops** — Pin and Wrong? (Supersede flow) not rendered when `render.project` is null.

## Duplication / reuse notes (anti-spaghetti)

- Item 4: six identical catches → ONE helper (`catchActionError`), in-file precedent.
- Item 2: copied the Profile/Blackboard/Tools loading pattern (issue-designated precedent), no new one invented.
- Item 5: chained like every sibling action's `.finally(refresh)` idiom.
- `ctoDigestOpened` writes remain best-effort with an in-code justification: they are §14.1 instrumentation; the visible action (jump/copy + toast) always happens regardless, so no control can dead-fail.

## Follow-up filed

- BET-1483 (parked, `follow-up`): the `compiledAt === 0` failure marker is a convention spread across three `empty*Render()` factories + three call sites — make failure explicit at the API boundary before it silently regresses.

## Verification results

- PR branch (`multica/BET-1468-wip` → `multica/BET-1468-cto-pane-loading-error-states` @ `8cbe04dc`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0 — vitest 198 files / 3884 pass, 7 skip; node --test 3734 pass, 0 fail. log sha256: `a067b7641c69c965c42523b7100eae11f75ba9531268195ee99a3b2eb3333c03`
- Base (`main` @ `ae51c84d`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0 — vitest 198 files / 3884 pass, 7 skip; node --test 3734 pass, 0 fail.
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved — both branches fully green. `grep -n "catch(() => {})" src/renderer/CtoPanel.tsx` → no matches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Base: origin/main @ `ae51c84d`
