### PR TITLE
fix(install): run apt unattended so needrestart can't hang the install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -202,6 +202,43 @@ sudo_priv() {
   esac
 }
 
+# apt_priv <apt-get args…> — the ONE way this installer runs apt.
+#
+# apt on a stock Ubuntu box ASKS QUESTIONS, and the desktop installer runs
+# this script over `ssh -tt` (a real pty) with the child's stdin set to
+# `ignore`. So apt sees a terminal, decides it may prompt, and the prompt is
+# unanswerable by construction: the install blocks FOREVER inside the
+# "Starting the service" stage while the UI's elapsed timer keeps ticking, so
+# it reads as alive. Every retry reproduces it — this is a property of the
+# server's distro, not a transient. Reported from the field on Ubuntu 22.04.
+#
+# Three env knobs close every interactive door. They must be passed PER CALL
+# via `env`, NOT exported: sudo resets the environment (env_reset), so an
+# exported value never survives into the privileged child. Prefixing with
+# `env` works in all four sudo_priv strategies, including the bare-root one
+# where no sudo is involved at all.
+#
+#   DEBIAN_FRONTEND=noninteractive
+#       No debconf dialogs, no conffile "what do you want to do about the
+#       modified configuration file?" prompt.
+#   NEEDRESTART_MODE=a
+#       needrestart ships enabled AND interactive by default since Ubuntu
+#       22.04, hooked into apt via /etc/apt/apt.conf.d/99needrestart. Left
+#       alone it draws the full-screen "Daemons using outdated libraries /
+#       Which services should be restarted?" screen. `a` makes it restart
+#       services itself, silently. THIS is the one that hung a real install.
+#   -o DPkg::Lock::Timeout=600
+#       A freshly provisioned VM runs unattended-upgrades on first boot and
+#       holds the dpkg lock. With no timeout apt waits forever (same
+#       symptom, different cause); with one it waits up to 10 minutes and
+#       then FAILS, which the callers below report as a real error. Unknown
+#       `-o` keys are ignored by older apt, so this is safe on every distro
+#       the preflight admits.
+apt_priv() {
+  sudo_priv env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
+    apt-get -o DPkg::Lock::Timeout=600 "$@"
+}
+
 # setup_askpass — strategy 2: create the SUDO_ASKPASS helper that echoes the
 # staged password, export it, and arrange cleanup on exit (the temp helper
 # dir AND the staged password file are both removed). The desktop installer
@@ -1571,9 +1608,9 @@ main() {
       # empty/stale, which makes `apt-get install debian-keyring …` fail with
       # "Unable to locate package". The Caddy docs run `apt update` up front
       # for exactly this reason.
-      sudo_priv apt-get update \
+      apt_priv update \
         || die "apt-get update failed"
-      sudo_priv apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl \
+      apt_priv install -y debian-keyring debian-archive-keyring apt-transport-https curl \
         || die "apt-get install prerequisites for Caddy failed"
       curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
         | sudo_priv gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
@@ -1615,9 +1652,9 @@ main() {
       install_root_file "$_caddy_list_tmp" /etc/apt/sources.list.d/caddy-stable.list \
         || { rm -f "$_caddy_list_tmp"; die "failed to add Caddy apt repo"; }
       rm -f "$_caddy_list_tmp"
-      sudo_priv apt-get update \
+      apt_priv update \
         || die "apt-get update failed"
-      sudo_priv apt-get install -y caddy \
+      apt_priv install -y caddy \
         || die "apt-get install caddy failed"
       ok "caddy installed ($(caddy version 2>/dev/null || echo unknown))."
     fi

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -3337,6 +3337,94 @@ echo "SHOULD_NOT_REACH=yes"
   assert.doesNotMatch(out, /SHOULD_NOT_REACH=yes/);
 });
 
+// ----------------------------------------------------------------------------
+// apt_priv — apt must never be able to ask a question.
+//
+// The desktop installer runs install.sh over `ssh -tt` with the child's stdin
+// set to `ignore`: apt sees a real terminal, so it feels free to prompt, and
+// nothing can answer. A field report on Ubuntu 22.04 hung forever at the
+// "Starting the service" stage on needrestart's "Which services should be
+// restarted?" screen, and reproduced on every retry because it is a property
+// of the distro, not a transient. These tests pin the three knobs that close
+// that door and the chokepoint that guarantees no apt call bypasses them.
+// ----------------------------------------------------------------------------
+
+test("apt_priv: apt runs fully unattended (frontend + needrestart + lock timeout)", () => {
+  const out = runBootstrap({
+    preBody: `
+SUDO_STRATEGY=nopasswd
+sudo() { echo "SUDO_ARGS=$*"; }
+apt_priv install -y caddy
+`,
+  });
+  // Routed through sudo_priv (so the resolved strategy still applies)…
+  assert.match(out, /SUDO_ARGS=-n env /);
+  // …with the environment set PER CALL via `env`, because sudo resets it.
+  assert.match(out, /DEBIAN_FRONTEND=noninteractive/);
+  // needrestart: the knob that actually hung a real install.
+  assert.match(out, /NEEDRESTART_MODE=a/);
+  // A first-boot unattended-upgrades lock must time out, not wait forever.
+  assert.match(out, /apt-get -o DPkg::Lock::Timeout=600 install -y caddy/);
+});
+
+test("apt_priv: the unattended env reaches apt under the bare-root strategy too", () => {
+  // SUDO_STRATEGY=root runs the command with no sudo at all. `env` execs a
+  // REAL binary, so this needs a real fake apt-get on PATH — a shell function
+  // could never intercept it, which is exactly why the knobs are an `env`
+  // prefix and not an export.
+  const dir = mkdtempSync(join(tmpdir(), "manta-aptpriv-"));
+  try {
+    writeFileSync(
+      join(dir, "apt-get"),
+      `#!/usr/bin/env bash
+echo "APT_ARGS=$*"
+echo "FRONTEND=$DEBIAN_FRONTEND"
+echo "NEEDRESTART=$NEEDRESTART_MODE"
+`,
+      { mode: 0o755 },
+    );
+    const out = runBootstrap({
+      env: { PATH: `${dir}:${process.env.PATH}` },
+      preBody: `
+SUDO_STRATEGY=root
+apt_priv update
+`,
+    });
+    assert.match(out, /FRONTEND=noninteractive/);
+    assert.match(out, /NEEDRESTART=a/);
+    assert.match(out, /APT_ARGS=-o DPkg::Lock::Timeout=600 update/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("apt_priv is the ONLY way install.sh runs apt (no call bypasses the chokepoint)", () => {
+  // A single bypassing call site reopens the hang, so assert on the whole
+  // file rather than on any one branch. Comments and the prerequisite hint
+  // strings (which TELL a user to run apt-get by hand, and span several
+  // lines inside one quoted die message) are advice, not invocations — track
+  // the multi-line string state so they are excluded without hand-listing
+  // line numbers.
+  let inString = false;
+  const invocations = [];
+  for (const line of readFileSync(INSTALL_SH, "utf-8").split("\n")) {
+    const wasInString = inString;
+    // An odd number of unescaped double quotes flips the state for the
+    // NEXT line; the current line is judged by the state it started in.
+    if ((line.match(/(?<!\\)"/g) ?? []).length % 2 === 1) inString = !inString;
+    if (wasInString) continue;
+    if (line.trim().startsWith("#")) continue;
+    // The chokepoint's own definition is the one legitimate invocation.
+    if (line.includes("DPkg::Lock::Timeout")) continue;
+    if (/(^|\s|\||&&)\s*(sudo_priv\s+)?apt-get\s/.test(line)) invocations.push(line);
+  }
+  assert.deepEqual(
+    invocations,
+    [],
+    `apt-get called outside apt_priv:\n${invocations.join("\n")}`,
+  );
+});
+
 test("BET-979: setup_askpass creates the SUDO_ASKPASS helper and exports it", () => {
   const dir = mkdtempSync(join(tmpdir(), "manta-setupask-"));
   try {


### PR DESCRIPTION
## Problem

A user on Ubuntu 22.04 could not install. The installer sat forever on **"Starting the service"** and reproduced on every retry — the server was showing needrestart's full-screen *"Daemons using outdated libraries / Which services should be restarted?"* prompt.

Three things combine into a guaranteed hang:

1. The public-HTTPS path installs Caddy via apt, inside the "Starting the service" stage.
2. Ubuntu ships `needrestart` enabled **and interactive** since 22.04, hooked into apt via `/etc/apt/apt.conf.d/99needrestart`. We set no unattended env, so apt is free to ask.
3. The desktop installer runs `install.sh` over `ssh -tt` (a real pty) with the child's stdin set to `ignore`. apt sees a terminal and prompts; nothing can answer.

The elapsed timer keeps ticking, so it reads as alive rather than wedged. This is a property of the server's distro, not a transient — hence "tried a couple of times, no luck".

## Fix

Route every apt call through one `apt_priv` chokepoint:

- `DEBIAN_FRONTEND=noninteractive` — no debconf/conffile dialogs.
- `NEEDRESTART_MODE=a` — needrestart restarts services itself instead of drawing the screen. **This is the one that hung the real install.**
- `-o DPkg::Lock::Timeout=600` — closes the same-symptom hang where a freshly provisioned VM runs `unattended-upgrades` on first boot and holds the dpkg lock. Waits bounded, then fails with a real error instead of forever.

The knobs are an `env` prefix **per call**, not an export: `sudo` resets the environment (`env_reset`), so an exported value never reaches the privileged child. `env` also works under the bare-root strategy where no sudo is involved.

## Tests

- The three knobs are passed and routed through `sudo_priv`.
- They still reach apt under `SUDO_STRATEGY=root` (a real fake `apt-get` on PATH, since `env` execs a binary and a shell function could never intercept it).
- No apt call anywhere in `install.sh` bypasses the chokepoint (whole-file assert, multi-line-string aware so the prerequisite hint text isn't mistaken for an invocation).

## Scope

Installer only. Does not touch the desktop harness or stage reporting — the missing stall watchdog, the unavailable "copy diagnostics" during a run, the overly broad "Starting the service" stage, and the absent Linux install smoke test are all real follow-ups, tracked separately.

## Release note

Merging does not ship this. New installs fetch `install.sh` from the website, so it needs a `web-v*` tag to reach users.