### PR TITLE
fix(install,server): advertise the tailnet MagicDNS name and bind both address families

### DIFF
--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -579,11 +579,41 @@ export function mergeGatewayAuth(
 // string array; we want the FIRST IPv4 — Tailscale's order is stable and IPv4
 // comes first on a typical box, but we don't rely on it: we filter).
 //
-// Returns `{ ip: string }` on success, `null` for any failure: invalid JSON,
-// BackendState != "Running", missing TailscaleIPs, or no IPv4 in the list. Raw
-// IP only — we deliberately do NOT return the MagicDNS name. Plain HTTP over
-// the WireGuard tunnel needs the raw IP (MagicDNS resolution requires the
-// `tailscale0` interface up on the requester).
+// Returns `{ ip, ipv6, dnsName }` on success, `null` for any failure: invalid
+// JSON, BackendState != "Running", missing TailscaleIPs, or no IPv4 in the list.
+//
+// `ip` is what the server BINDS its tailnet listener to — always the raw IPv4,
+// never a name (you bind an address, not a hostname).
+//
+// `ipv6` is the box's Tailscale IPv6 (`fd7a:…`), or null. Tailscale assigns
+// BOTH families to every node and MagicDNS publishes both under the name, so a
+// client resolving the name gets two candidate addresses and — on Apple's
+// stack especially — tries the IPv6 one FIRST. A box listening only on its
+// IPv4 therefore has an address that answers and an address that does not, and
+// a client that picks the wrong one stalls instead of failing cleanly.
+//
+// This did not matter while the box advertised a raw IPv4: there was exactly
+// one address to try and it was the bound one. It became reachable the moment
+// the box started advertising a NAME, so the two changes belong together —
+// advertising a name obliges the box to answer on everything that name
+// resolves to.
+//
+// `dnsName` is the box's MagicDNS name (`Self.DNSName`, e.g.
+// "mybox.tail1234.ts.net."), normalized, or `null` when the tailnet has
+// MagicDNS disabled / the field is absent or unusable. It is what the box
+// ADVERTISES to client devices, and the two are deliberately separate:
+//
+//   An earlier revision returned the IP only, reasoning that MagicDNS
+//   resolution needs the tailnet interface up on the requester. That is true
+//   and irrelevant — a requester without the tailnet up cannot reach
+//   100.64.0.0/10 either. What the reasoning missed is that iOS refuses plain
+//   HTTP to a bare IP outright: App Transport Security only exempts the
+//   RFC1918 private ranges, and Tailscale's 100.64/10 (RFC 6598) is not one of
+//   them, while an ATS exception cannot name an IP address at all. So an
+//   IP-only box could be opened in Safari (exempt from an app's ATS policy)
+//   and never by the app — which is exactly how it shipped. A `ts.net` name
+//   CAN carry an ATS exception, so advertising the name is what makes a
+//   tailnet box reachable from the iOS client.
 //
 // IPv4 regex is intentionally permissive (`\d{1,3}` per octet, not `0-255`) —
 // the caller doesn't need to validate octet ranges, just that the shape is
@@ -591,6 +621,37 @@ export function mergeGatewayAuth(
 // address, so an over-permissive regex is harmless here.
 // ---------------------------------------------------------------------------
 const IPV4_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+// Deliberately strict (hex groups + colons only, no zone id, no embedded IPv4
+// form): this value is passed to a bind() call, so "shaped like an address"
+// is the wrong bar — anything unexpected is dropped rather than forwarded.
+const IPV6_RE = /^[0-9a-f]{0,4}(:[0-9a-f]{0,4}){2,7}$/i;
+
+// A MagicDNS name we are willing to advertise. The `.ts.net` suffix is NOT
+// cosmetic and NOT a stylistic preference — it is the acceptance condition of
+// every consumer downstream, and a name failing it is strictly worse than the
+// IP it would replace:
+//   • `isPrivateServerUrl` (src/shared/transport.mjs, and its Swift port in
+//     MantaPairingModels.swift) accepts a hostname ONLY when it is `localhost`
+//     or ends in `.ts.net`. A pair link carrying anything else is REFUSED
+//     WHOLESALE by the app — not downgraded, refused — so an over-permissive
+//     value here breaks pairing completely instead of merely leaving it as
+//     broken as the IP does.
+//   • the iOS ATS exception is written against `ts.net` + subdomains.
+// Hence: validate hard, and fall back to the IP on anything unexpected.
+const TAILNET_DNS_NAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.ts\.net$/;
+
+// Normalize a raw `Self.DNSName` into an advertisable host, or null.
+// Tailscale reports it FQDN-style with a trailing dot ("mybox.tail1234.ts.net.");
+// strip that, lowercase, and require at least one label in front of `.ts.net`
+// (a bare "ts.net" is not a box).
+export function normalizeTailnetDnsName(raw) {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim().replace(/\.+$/, "").toLowerCase();
+  if (trimmed === "" || trimmed.length > 253) return null;
+  if (!TAILNET_DNS_NAME_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
 export function parseTailscaleStatus(jsonText) {
   if (typeof jsonText !== "string" || jsonText.trim() === "") return null;
   let parsed;
@@ -603,17 +664,51 @@ export function parseTailscaleStatus(jsonText) {
   if (parsed.BackendState !== "Running") return null;
   const ips = parsed?.Self?.TailscaleIPs;
   if (!Array.isArray(ips)) return null;
+  // MagicDNS is optional: a null name is a normal, supported outcome (the
+  // caller falls back to the IP), never a reason to reject the whole status.
+  const dnsName = normalizeTailnetDnsName(parsed?.Self?.DNSName);
+  let ip = null;
+  let ipv6 = null;
   for (const candidate of ips) {
-    if (typeof candidate === "string" && IPV4_RE.test(candidate)) {
-      return { ip: candidate };
-    }
+    if (typeof candidate !== "string") continue;
+    if (ip === null && IPV4_RE.test(candidate)) ip = candidate;
+    else if (ipv6 === null && IPV6_RE.test(candidate)) ipv6 = candidate;
   }
-  return null;
+  // An IPv4 remains REQUIRED. It is the identity the box is known by and the
+  // guaranteed-reachable address; an IPv6-only tailnet still falls back to the
+  // public path exactly as before rather than binding a half-usable listener.
+  if (ip === null) return null;
+  return { ip, ipv6, dnsName };
+}
+
+// The addresses the box's tailnet listener must bind, in the order a client is
+// likely to try them. Rendered into MANTA_TAILNET_HOST as a comma-separated
+// list (a single value stays a valid one-element list, so an already-installed
+// box's unit keeps working unchanged).
+export function tailnetBindHosts(status) {
+  if (!status || typeof status.ip !== "string") return [];
+  return status.ipv6 ? [status.ip, status.ipv6] : [status.ip];
 }
 
 // Build the ingress.json payload — pure helper. Validates that tailscale mode
 // carries both an IP and a port (the CLI subcommand below also enforces this,
 // but the pure form lets the test assert without spawning a subprocess).
+//
+// BIND ADDRESS vs ADVERTISED HOST — the one thing to keep straight here.
+// `tailnetIp` is what the server listens on and is ALWAYS recorded; it is the
+// only value that can be handed to `listen()`. `tailnetHostname` (optional) is
+// the MagicDNS name devices should DIAL, and it is what `serverUrl` is built
+// from when present. They are separate fields because they answer different
+// questions, and collapsing them is what produced a box whose advertised URL
+// the iOS client is structurally unable to open (see parseTailscaleStatus).
+// No hostname (MagicDNS disabled on the tailnet) → serverUrl falls back to the
+// IP, i.e. exactly the previous behaviour.
+//
+// A PRESENT-BUT-INVALID hostname is a hard error rather than a silent fallback:
+// the only caller that passes one is install.sh, which passes a value that has
+// already been validated by normalizeTailnetDnsName, so an invalid value here
+// means a hand-run or a bug — and silently degrading it would hide precisely
+// the class of defect this change exists to fix.
 //
 // Returns { ok: true, text, changed } | { ok: false, error }.
 //   text is the rendered JSON (pretty-printed + trailing newline, matching the
@@ -623,7 +718,7 @@ export function parseTailscaleStatus(jsonText) {
 const INGRESS_MODES = new Set(["public", "tailscale"]);
 export function buildIngressJson(
   existingText,
-  { mode, tailnetIp, port } = {},
+  { mode, tailnetIp, tailnetHostname, port } = {},
 ) {
   if (!INGRESS_MODES.has(mode)) {
     return { ok: false, error: `buildIngressJson: mode must be "public" or "tailscale" (got ${JSON.stringify(mode)})` };
@@ -636,7 +731,22 @@ export function buildIngressJson(
     if (!Number.isInteger(port) || port <= 0 || port > 65535) {
       return { ok: false, error: "buildIngressJson: tailscale mode requires port (1-65535)" };
     }
-    next = { mode: "tailscale", tailnetIp, serverUrl: `http://${tailnetIp}:${port}` };
+    let hostname = null;
+    if (tailnetHostname !== undefined && tailnetHostname !== null && tailnetHostname !== "") {
+      hostname = normalizeTailnetDnsName(tailnetHostname);
+      if (hostname === null) {
+        return {
+          ok: false,
+          error: `buildIngressJson: tailnetHostname must be a MagicDNS name ending in .ts.net (got ${JSON.stringify(tailnetHostname)})`,
+        };
+      }
+    }
+    next = {
+      mode: "tailscale",
+      tailnetIp,
+      ...(hostname ? { tailnetHostname: hostname } : {}),
+      serverUrl: `http://${hostname ?? tailnetIp}:${port}`,
+    };
   } else {
     next = { mode: "public" };
   }
@@ -1494,18 +1604,40 @@ async function cliMain(argv) {
     return 0;
   }
   if (cmd === "parse-tailscale-status") {
-    // node install-lib.mjs parse-tailscale-status
+    // node install-lib.mjs parse-tailscale-status [--field ip|dns-name]
     // Reads ALL of stdin (the JSON output of `tailscale status --json`), and
-    // on success prints the chosen Tailscale IPv4 to stdout (no trailing
-    // newline — install.sh's `$()` capture strips them anyway, and a stray
-    // newline would leak into the systemd unit). On any failure exits 1
-    // silently so install.sh's `||` short-circuits the tailscale path.
+    // on success prints ONE field to stdout (no trailing newline —
+    // install.sh's `$()` capture strips them anyway, and a stray newline would
+    // leak into the systemd unit). On any failure exits 1 silently so
+    // install.sh's `||` short-circuits the tailscale path.
+    //
+    // `--field ip` (the default, and the back-compatible behaviour) prints the
+    // box's IPv4 — its tailnet identity. `--field bind-hosts` prints the
+    // comma-separated list of every address the listener must bind (IPv4, plus
+    // the IPv6 when the node has one). `--field dns-name` prints the advertised
+    // MagicDNS name and exits 1 when the tailnet has none — which is NOT an
+    // error condition for the installer, just "fall back to the IP", so its
+    // call site tolerates the non-zero exit rather than dying on it.
+    const field = flags.field ?? "ip";
+    if (field !== "ip" && field !== "dns-name" && field !== "bind-hosts") {
+      process.stderr.write(`parse-tailscale-status: --field must be "ip", "bind-hosts" or "dns-name" (got ${JSON.stringify(field)})\n`);
+      return 2;
+    }
     const chunks = [];
     for await (const c of process.stdin) chunks.push(c);
     const raw = Buffer.concat(chunks).toString("utf-8");
     const res = parseTailscaleStatus(raw);
     if (res === null) {
       return 1;
+    }
+    if (field === "dns-name") {
+      if (!res.dnsName) return 1;
+      process.stdout.write(res.dnsName);
+      return 0;
+    }
+    if (field === "bind-hosts") {
+      process.stdout.write(tailnetBindHosts(res).join(","));
+      return 0;
     }
     process.stdout.write(res.ip);
     return 0;
@@ -1531,6 +1663,7 @@ async function cliMain(argv) {
       return 2;
     }
     let tailnetIp;
+    let tailnetHostname;
     let port;
     if (mode === "tailscale") {
       tailnetIp = flags["tailnet-ip"];
@@ -1538,6 +1671,9 @@ async function cliMain(argv) {
         process.stderr.write("write-ingress: tailscale mode requires --tailnet-ip <ip>\n");
         return 2;
       }
+      // Optional: the MagicDNS name devices dial. Absent → serverUrl falls
+      // back to --tailnet-ip. The bind address is always --tailnet-ip.
+      tailnetHostname = flags["tailnet-hostname"];
       const portStr = flags.port;
       const portNum = portStr ? Number(portStr) : NaN;
       if (!Number.isInteger(portNum) || portNum <= 0 || portNum > 65535) {
@@ -1557,7 +1693,7 @@ async function cliMain(argv) {
         return 1;
       }
     }
-    const res = buildIngressJson(existing, { mode, tailnetIp, port });
+    const res = buildIngressJson(existing, { mode, tailnetIp, tailnetHostname, port });
     if (!res.ok) {
       process.stderr.write(`write-ingress: ${res.error}\n`);
       return 1;
@@ -1583,7 +1719,7 @@ async function cliMain(argv) {
   }
   process.stderr.write(
     `install-lib: unknown command ${JSON.stringify(cmd)}\n` +
-      "  usage: node install-lib.mjs <print-config|check-identity|merge-opencode-config|merge-gateway|wait-for-dns|render-caddy-vhost|upsert-caddy-block|detect-distro|render-systemd-unit|parse-tailscale-status|write-ingress> [--version X] [--file P] [--template P] [--hostname H] [--expected-ip IP] [--max-attempts N] [--interval-ms MS] [--box-id ID] [--port N] [--mode M] [--os-release PATH] [--tailnet-ip IP] [--placeholder K=V]\n",
+      "  usage: node install-lib.mjs <print-config|check-identity|merge-opencode-config|merge-gateway|wait-for-dns|render-caddy-vhost|upsert-caddy-block|detect-distro|render-systemd-unit|parse-tailscale-status|write-ingress> [--version X] [--file P] [--template P] [--hostname H] [--expected-ip IP] [--max-attempts N] [--interval-ms MS] [--box-id ID] [--port N] [--mode M] [--os-release PATH] [--tailnet-ip IP] [--tailnet-hostname H] [--field ip|dns-name] [--placeholder K=V]\n",
   );
   return 2;
 }
@@ -1608,6 +1744,8 @@ function parseFlags(args) {
     "mode",
     "os-release",
     "tailnet-ip",
+    "tailnet-hostname",
+    "field",
     "has-claude-creds",
     "cli-claude",
     "cli-codex",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -525,12 +525,54 @@ public_ingress_preflight() {
 detect_tailscale_ip() {
   local node="$1" lib="$2"
   command -v tailscale >/dev/null 2>&1 || return 1
-  tailscale status --json 2>/dev/null | "$node" "$lib" parse-tailscale-status
+  tailscale status --json 2>/dev/null | "$node" "$lib" parse-tailscale-status --field ip
+}
+
+# detect_tailscale_dns_name <node> <lib> — the box's MagicDNS name
+# (`<host>.<tailnet>.ts.net`), or exit 1 with no output when the tailnet has
+# MagicDNS disabled or the name is unusable.
+#
+# A MISSING NAME IS NOT A FAILURE — it is the documented fallback (advertise
+# the raw IP, i.e. the pre-BET behaviour), so every call site must tolerate the
+# non-zero exit rather than `die` on it. The name matters because it is the
+# only form of this box's address an iOS app can legally open over plain HTTP:
+# App Transport Security exempts the RFC1918 ranges but not Tailscale's
+# 100.64/10, and an ATS exception can name a domain but never an IP. See the
+# comment on parseTailscaleStatus in install-lib.mjs.
+detect_tailscale_dns_name() {
+  local node="$1" lib="$2"
+  command -v tailscale >/dev/null 2>&1 || return 1
+  tailscale status --json 2>/dev/null | "$node" "$lib" parse-tailscale-status --field dns-name
+}
+
+# detect_tailscale_bind_hosts <node> <lib> — the comma-separated list of every
+# address the tailnet listener must bind: the IPv4, plus the IPv6 when the node
+# has one.
+#
+# Both are needed because MagicDNS publishes BOTH under the box's name, and a
+# client resolving that name will try the IPv6 first. Binding only the IPv4
+# leaves an advertised address that never answers — which stalls a connection
+# rather than refusing it. See parseTailscaleStatus in install-lib.mjs.
+detect_tailscale_bind_hosts() {
+  local node="$1" lib="$2"
+  command -v tailscale >/dev/null 2>&1 || return 1
+  tailscale status --json 2>/dev/null | "$node" "$lib" parse-tailscale-status --field bind-hosts
 }
 
 # resolve_ingress_mode <node> <lib> — resolve the ingress path honoring the
 # MANTA_INGRESS override (auto | public | tailscale), setting INGRESS_MODE
-# ("public" | "tailscale") and TAILNET_IP. MANTA_INGRESS=public FORCES public
+# ("public" | "tailscale") plus four tailnet vars. Keep the bind/advertise
+# split: a listener needs an address, a client needs a name it is allowed to
+# dial, and those are not the same string.
+#   TAILNET_IP         the box's tailnet identity — always an IPv4.
+#   TAILNET_BIND_HOSTS every address the listener binds, comma-separated
+#                      (IPv4 + IPv6), because the advertised name resolves to
+#                      both and an unbound one stalls callers.
+#   TAILNET_HOSTNAME   the advertised MagicDNS name; empty when the tailnet
+#                      has none.
+#   TAILNET_URL_HOST   what goes in a URL: the name if there is one, else the IP.
+#
+# MANTA_INGRESS=public FORCES public
 # even when Tailscale is up (the box wants a public address regardless of a
 # running tailnet); MANTA_INGRESS=tailscale forces tailnet and dies if
 # detection fails; auto picks tailnet iff Tailscale is up. Because the
@@ -540,6 +582,9 @@ resolve_ingress_mode() {
   local node="$1" lib="$2"
   MANTA_INGRESS="${MANTA_INGRESS:-auto}"
   TAILNET_IP=""
+  TAILNET_HOSTNAME=""
+  TAILNET_URL_HOST=""
+  TAILNET_BIND_HOSTS=""
   case "$MANTA_INGRESS" in
     public) ;;
     tailscale)
@@ -552,7 +597,17 @@ resolve_ingress_mode() {
     *) die "MANTA_INGRESS must be auto, public, or tailscale (got: $MANTA_INGRESS)" ;;
   esac
   INGRESS_MODE="public"
-  if [ -n "$TAILNET_IP" ]; then INGRESS_MODE="tailscale"; fi
+  if [ -n "$TAILNET_IP" ]; then
+    INGRESS_MODE="tailscale"
+    # Best-effort: MagicDNS is a per-tailnet setting a box does not control.
+    # `|| true` because no name is a supported outcome, not an install failure.
+    TAILNET_HOSTNAME="$(detect_tailscale_dns_name "$node" "$lib" 2>/dev/null || true)"
+    TAILNET_URL_HOST="${TAILNET_HOSTNAME:-$TAILNET_IP}"
+    # Every address the listener binds. Falls back to the IPv4 alone if the
+    # lookup fails, which is exactly the previous behaviour.
+    TAILNET_BIND_HOSTS="$(detect_tailscale_bind_hosts "$node" "$lib" 2>/dev/null || true)"
+    TAILNET_BIND_HOSTS="${TAILNET_BIND_HOSTS:-$TAILNET_IP}"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -1170,7 +1225,7 @@ main() {
       -e "s|@@MANTA_HOME@@|$MANTA_HOME|g" \
       -e "s|@@NODE_BIN@@|$NODE|g" \
       -e "s|@@MANTA_PORT@@|$MANTA_PORT|g" \
-      -e "s|@@MANTA_TAILNET_HOST@@|${TAILNET_IP:-}|g" \
+      -e "s|@@MANTA_TAILNET_HOST@@|${TAILNET_BIND_HOSTS:-}|g" \
       -e "s|@@OPENCODE_BIN@@|${OPENCODE_BIN:-}|g" \
       -e "s|@@AUTH_DIR@@|$AUTH_DIR|g" \
       -e "s|@@AGENT_PATH@@|$(launchd_agent_path)|g" \
@@ -1349,11 +1404,17 @@ main() {
   # and writes 0600 atomically (write <file>.tmp then rename).
   INGRESS_JSON="$AUTH_DIR/ingress.json"
   if [ "$DRY_RUN" = "1" ]; then
-    dry_log "would persist ingress decision to $INGRESS_JSON (mode=$INGRESS_MODE${TAILNET_IP:+, tailnetIp=$TAILNET_IP})"
+    dry_log "would persist ingress decision to $INGRESS_JSON (mode=$INGRESS_MODE${TAILNET_IP:+, tailnetIp=$TAILNET_IP}${TAILNET_HOSTNAME:+, tailnetHostname=$TAILNET_HOSTNAME})"
   else
     ING_ARGS=("$NODE" "$LIB" write-ingress --file "$INGRESS_JSON" --mode "$INGRESS_MODE")
     if [ -n "$TAILNET_IP" ]; then
       ING_ARGS+=(--tailnet-ip "$TAILNET_IP" --port "$MANTA_PORT")
+      # Only passed when detection produced one; write-ingress rejects a
+      # malformed value rather than silently falling back to the IP, so an
+      # empty flag must never be sent.
+      if [ -n "$TAILNET_HOSTNAME" ]; then
+        ING_ARGS+=(--tailnet-hostname "$TAILNET_HOSTNAME")
+      fi
     fi
     "${ING_ARGS[@]}" >/dev/null 2>/tmp/manta-ingress.err \
       || warn "write-ingress failed (see /tmp/manta-ingress.err) — \`manta pair\` will fall back to public-default connect block."
@@ -1369,7 +1430,7 @@ main() {
       -e "s|@@MANTA_HOME@@|$MANTA_HOME|g" \
       -e "s|@@NODE_BIN@@|$NODE|g" \
       -e "s|@@MANTA_PORT@@|$MANTA_PORT|g" \
-      -e "s|@@MANTA_TAILNET_HOST@@|$TAILNET_IP|g" \
+      -e "s|@@MANTA_TAILNET_HOST@@|${TAILNET_BIND_HOSTS:-}|g" \
       -e "s|@@AGENT_PATH@@|$(launchd_agent_path)|g" \
       -e "s|@@MANTA_CHANNEL@@|${MANTA_CHANNEL:-prod}|g" \
       "$UNIT_SRC" > "$UNIT_DIR/manta-server.service"
@@ -1398,7 +1459,7 @@ main() {
   else
     warn "systemctl not found (not a systemd host?). Starting the server in the background instead."
     warn "It will NOT survive reboot — set up your own supervisor for that."
-    ( MANTA_MOBILE_HOST=127.0.0.1 MANTA_MOBILE_PORT="$MANTA_PORT" MANTA_TAILNET_HOST="$TAILNET_IP" nohup "$NODE" "$MANTA_HOME/src/server/index.mjs" >"$AUTH_DIR/server.log" 2>&1 & )
+    ( MANTA_MOBILE_HOST=127.0.0.1 MANTA_MOBILE_PORT="$MANTA_PORT" MANTA_TAILNET_HOST="${TAILNET_BIND_HOSTS:-}" nohup "$NODE" "$MANTA_HOME/src/server/index.mjs" >"$AUTH_DIR/server.log" 2>&1 & )
     SERVER_MANAGED=nohup
   fi
 
@@ -1496,7 +1557,7 @@ main() {
     # Tailscale path (BET-267): skip Caddy install + DNS wait + vhost write +
     # caddy reload. B/C (gateway register + merge-gateway) still
     # run below — the gateway_token is still needed for APNs push.
-    log "Tailscale detected ($TAILNET_IP) — skipping Caddy + public DNS; devices connect over the tailnet."
+    log "Tailscale detected ($TAILNET_IP${TAILNET_HOSTNAME:+, MagicDNS $TAILNET_HOSTNAME}) — skipping Caddy + public DNS; devices connect over the tailnet."
   elif [ "$IS_MACOS" = "1" ]; then
     # macOS path (BET-274 / BET-276): no apt, no Caddy, no public DNS, no
     # Let's Encrypt. The box is loopback-only on the Mac; remote access
@@ -1907,10 +1968,22 @@ EOF
     cat <<EOF
 
 Tailscale detected ($TAILNET_IP) — your server is reachable over the tailnet at
-http://$TAILNET_IP:$MANTA_PORT (plain HTTP; WireGuard encrypts the hop). No public
-DNS, no Caddy, no Let's Encrypt on this path. Devices on the same tailnet can
-connect directly; off-tailnet devices need Tailscale access first.
+http://${TAILNET_URL_HOST:-$TAILNET_IP}:$MANTA_PORT (plain HTTP; WireGuard encrypts the hop). No
+public DNS, no Caddy, no Let's Encrypt on this path. Devices on the same tailnet
+can connect directly; off-tailnet devices need Tailscale access first.
 EOF
+    if [ -z "${TAILNET_HOSTNAME:-}" ]; then
+      cat <<EOF
+
+NOTE: this tailnet has no MagicDNS name for this machine, so the address above
+is a raw Tailscale IP. The iOS app cannot open a plain-HTTP address in
+Tailscale's 100.64.0.0/10 range (Apple's transport policy exempts the classic
+private ranges but not that one, and the exception it does honour can only name
+a domain). Turn MagicDNS on for your tailnet and re-run this installer to be
+advertised as http://<name>.<tailnet>.ts.net:$MANTA_PORT instead — the desktop
+app and a browser work either way.
+EOF
+    fi
   else
     cat <<EOF
 

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -22,6 +22,8 @@ import {
   mergeOpencodeConfig,
   mergeGatewayAuth,
   parseTailscaleStatus,
+  normalizeTailnetDnsName,
+  tailnetBindHosts,
   buildIngressJson,
   waitForDns,
   renderCaddyVhost,
@@ -36,6 +38,15 @@ import {
   DESKTOP_DMG_URL,
   IOS_APP_URL,
 } from "./install-lib.mjs";
+// The acceptance gate every client applies to a pair link's server URL. Imported
+// (not re-implemented) so the installer's advertised URL is asserted against the
+// SAME predicate the app enforces — a copy here could drift and let the
+// installer emit a URL the app refuses outright.
+import { isPrivateServerUrl } from "../src/shared/transport.mjs";
+// The consumer of MANTA_TAILNET_HOST. Imported so the installer's emitted
+// format is asserted against the parser that actually reads it — the two ends
+// of that variable live in different files and must not drift apart.
+import { parseTailnetHosts } from "../src/server/tailnet.mjs";
 
 const HOME = "/home/tester";
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -3166,6 +3177,94 @@ echo "MODE=$INGRESS_MODE IP=$TAILNET_IP"
   assert.doesNotMatch(out, /IP=100/, "MANTA_INGRESS=public must not pick up the running Tailscale IP");
 });
 
+test("resolve_ingress_mode advertises the MagicDNS name while binding the IP", () => {
+  // The whole point of the split: TAILNET_IP is what the listener binds,
+  // TAILNET_URL_HOST is what a device dials. They must not collapse — an
+  // IP-only advertisement is unopenable by the iOS client (Apple's transport
+  // policy exempts the RFC1918 ranges but not Tailscale's 100.64/10, and its
+  // domain exceptions cannot name an IP).
+  const out = runBootstrap({
+    preBody: `
+detect_tailscale_ip() { printf '%s' '100.64.1.5'; }
+detect_tailscale_dns_name() { printf '%s' 'mybox.tail1234.ts.net'; }
+detect_tailscale_bind_hosts() { printf '%s' '100.64.1.5'; }
+MANTA_INGRESS=auto
+resolve_ingress_mode node lib
+echo "MODE=$INGRESS_MODE BIND=$TAILNET_IP URLHOST=$TAILNET_URL_HOST"
+`,
+  });
+  assert.match(out, /MODE=tailscale/);
+  assert.match(out, /BIND=100\.64\.1\.5/, "the listener must still bind the IP");
+  assert.match(out, /URLHOST=mybox\.tail1234\.ts\.net/, "devices must be given the name");
+});
+
+test("resolve_ingress_mode collects every address the listener must bind", () => {
+  // TAILNET_BIND_HOSTS becomes MANTA_TAILNET_HOST in the unit file. It must
+  // carry the IPv6 as well as the IPv4, because the name the box now
+  // advertises resolves to both and an unbound one stalls callers.
+  const out = runBootstrap({
+    preBody: `
+detect_tailscale_ip() { printf '%s' '100.64.1.5'; }
+detect_tailscale_dns_name() { printf '%s' 'mybox.tail1234.ts.net'; }
+detect_tailscale_bind_hosts() { printf '%s' '100.64.1.5,fd7a:115c:a1e0::1'; }
+MANTA_INGRESS=auto
+resolve_ingress_mode node lib
+echo "BINDS=$TAILNET_BIND_HOSTS"
+`,
+  });
+  assert.match(out, /BINDS=100\.64\.1\.5,fd7a:115c:a1e0::1/);
+});
+
+test("resolve_ingress_mode falls back to binding the IPv4 alone if the bind lookup fails", () => {
+  // A detection failure must degrade to the previous single-address behaviour,
+  // never to an empty MANTA_TAILNET_HOST — an empty value is a WILDCARD bind,
+  // which would expose this listener to every interface instead of the tailnet.
+  const out = runBootstrap({
+    preBody: `
+detect_tailscale_ip() { printf '%s' '100.64.1.5'; }
+detect_tailscale_dns_name() { return 1; }
+detect_tailscale_bind_hosts() { return 1; }
+MANTA_INGRESS=auto
+resolve_ingress_mode node lib
+echo "BINDS=[$TAILNET_BIND_HOSTS]"
+`,
+  });
+  assert.match(out, /BINDS=\[100\.64\.1\.5\]/);
+});
+
+test("resolve_ingress_mode falls back to the IP when the tailnet has no MagicDNS name", () => {
+  // MagicDNS is a tailnet-wide setting the box does not control, so its
+  // absence must degrade to the previous behaviour, never fail the install.
+  const out = runBootstrap({
+    preBody: `
+detect_tailscale_ip() { printf '%s' '100.64.1.5'; }
+detect_tailscale_dns_name() { return 1; }   # MagicDNS off
+detect_tailscale_bind_hosts() { printf '%s' '100.64.1.5'; }
+MANTA_INGRESS=auto
+resolve_ingress_mode node lib
+echo "MODE=$INGRESS_MODE BIND=$TAILNET_IP URLHOST=$TAILNET_URL_HOST NAME=[$TAILNET_HOSTNAME]"
+`,
+  });
+  assert.match(out, /MODE=tailscale/);
+  assert.match(out, /BIND=100\.64\.1\.5/);
+  assert.match(out, /URLHOST=100\.64\.1\.5/);
+  assert.match(out, /NAME=\[\]/, "no name detected → empty, so the flag is never passed");
+});
+
+test("resolve_ingress_mode leaves the tailnet host empty on the public path", () => {
+  const out = runBootstrap({
+    preBody: `
+detect_tailscale_ip() { return 1; }
+detect_tailscale_dns_name() { printf '%s' 'should.not.be.read.ts.net'; }
+MANTA_INGRESS=auto
+resolve_ingress_mode node lib
+echo "MODE=$INGRESS_MODE URLHOST=[$TAILNET_URL_HOST]"
+`,
+  });
+  assert.match(out, /MODE=public/);
+  assert.match(out, /URLHOST=\[\]/, "a public box must not carry a tailnet URL host");
+});
+
 test("BET-980: MANTA_INGRESS=public + Tailscale up + no root → D1 gate fires (fatal)", () => {
   // Regression for the reviewer Block: the preflight must classify a
   // MANTA_INGRESS=public box as the public path even when Tailscale is
@@ -3554,7 +3653,7 @@ test("parseTailscaleStatus returns the first IPv4 when BackendState is Running",
     Self: { TailscaleIPs: ["100.64.1.5", "fd7a:115c:a1e0::1"] },
   });
   const res = parseTailscaleStatus(fixture);
-  assert.deepEqual(res, { ip: "100.64.1.5" });
+  assert.deepEqual(res, { ip: "100.64.1.5", ipv6: "fd7a:115c:a1e0::1", dnsName: null });
 });
 
 test("parseTailscaleStatus picks IPv4 even when IPv6 comes first in the list", () => {
@@ -3566,7 +3665,7 @@ test("parseTailscaleStatus picks IPv4 even when IPv6 comes first in the list", (
     Self: { TailscaleIPs: ["fd7a:115c:a1e0::1", "fd00::1", "100.99.99.99"] },
   });
   const res = parseTailscaleStatus(fixture);
-  assert.deepEqual(res, { ip: "100.99.99.99" });
+  assert.deepEqual(res, { ip: "100.99.99.99", ipv6: "fd7a:115c:a1e0::1", dnsName: null });
 });
 
 test("parseTailscaleStatus returns null when BackendState is not Running", () => {
@@ -3599,6 +3698,127 @@ test("parseTailscaleStatus returns null on invalid JSON", () => {
   assert.equal(parseTailscaleStatus(null), null);
 });
 
+test("parseTailscaleStatus returns the MagicDNS name alongside the IP", () => {
+  // The headline of the advertise-a-name change: the box binds the IP but
+  // advertises the name, because the name is the only form of this address an
+  // iOS app is permitted to open over plain HTTP. Tailscale reports DNSName
+  // FQDN-style with a trailing dot — it is normalized away here so the value
+  // can be dropped straight into a URL.
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["100.64.1.5"], DNSName: "mybox.tail1234.ts.net." },
+  });
+  assert.deepEqual(parseTailscaleStatus(fixture), {
+    ip: "100.64.1.5",
+    ipv6: null,
+    dnsName: "mybox.tail1234.ts.net",
+  });
+});
+
+test("parseTailscaleStatus keeps the IP when MagicDNS is off or the name is unusable", () => {
+  // MagicDNS is a per-tailnet setting the box does not control, so a missing
+  // or unusable name is a NORMAL outcome that must degrade to the IP — never
+  // reject the whole status (which would drop the box onto the public path).
+  const cases = [
+    undefined,
+    "",
+    ".",
+    // Not a ts.net name. Refused deliberately: isPrivateServerUrl (and its
+    // Swift port) accepts a hostname only for `localhost` / `.ts.net`, and a
+    // pair link carrying anything else is refused WHOLESALE by the app — worse
+    // than the IP fallback it would displace.
+    "mybox.example.com",
+    "mybox.internal",
+    // A bare suffix is not a box.
+    "ts.net",
+    // Malformed labels.
+    "-bad.tail1234.ts.net",
+    "bad-.tail1234.ts.net",
+    "has space.tail1234.ts.net",
+  ];
+  for (const dnsName of cases) {
+    const fixture = JSON.stringify({
+      BackendState: "Running",
+      Self: { TailscaleIPs: ["100.64.1.5"], ...(dnsName === undefined ? {} : { DNSName: dnsName }) },
+    });
+    assert.deepEqual(
+      parseTailscaleStatus(fixture),
+      { ip: "100.64.1.5", ipv6: null, dnsName: null },
+      `expected no advertised name for DNSName=${JSON.stringify(dnsName)}`,
+    );
+  }
+});
+
+test("parseTailscaleStatus reports the IPv6 so the listener can bind it too", () => {
+  // MagicDNS publishes both families under the name, so advertising the name
+  // obliges the box to answer on both. Discarding the IPv6 (as this did while
+  // only an IPv4 was ever advertised) leaves an address that stalls callers.
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: {
+      TailscaleIPs: ["100.64.1.5", "fd7a:115c:a1e0::1"],
+      DNSName: "mybox.tail1234.ts.net.",
+    },
+  });
+  assert.deepEqual(parseTailscaleStatus(fixture), {
+    ip: "100.64.1.5",
+    ipv6: "fd7a:115c:a1e0::1",
+    dnsName: "mybox.tail1234.ts.net",
+  });
+  assert.deepEqual(tailnetBindHosts(parseTailscaleStatus(fixture)), [
+    "100.64.1.5",
+    "fd7a:115c:a1e0::1",
+  ]);
+});
+
+test("parseTailscaleStatus still requires an IPv4, and binds it alone when there is no IPv6", () => {
+  // The IPv4 is the box's tailnet identity and its guaranteed-reachable
+  // address. An IPv6-only tailnet falls back to the public path rather than
+  // binding a half-usable listener — same as before.
+  const v6only = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["fd7a:115c:a1e0::1"] },
+  });
+  assert.equal(parseTailscaleStatus(v6only), null);
+
+  const v4only = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["100.64.1.5"] },
+  });
+  const res = parseTailscaleStatus(v4only);
+  assert.deepEqual(res, { ip: "100.64.1.5", ipv6: null, dnsName: null });
+  assert.deepEqual(tailnetBindHosts(res), ["100.64.1.5"]);
+  assert.deepEqual(tailnetBindHosts(null), []);
+});
+
+test("parse-tailscale-status CLI --field bind-hosts prints the comma-separated bind list", () => {
+  // This exact string becomes MANTA_TAILNET_HOST in the unit file, so it must
+  // carry no trailing newline and no spaces.
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["100.64.1.5", "fd7a:115c:a1e0::1"] },
+  });
+  const out = execSync(
+    `node ${join(__dirname, "install-lib.mjs")} parse-tailscale-status --field bind-hosts`,
+    { input: fixture, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+  );
+  assert.equal(out, "100.64.1.5,fd7a:115c:a1e0::1");
+  // And the server must read back exactly what the installer wrote — the two
+  // sides of MANTA_TAILNET_HOST asserted against each other rather than
+  // separately, so the wire format cannot drift.
+  assert.deepEqual(parseTailnetHosts(out), ["100.64.1.5", "fd7a:115c:a1e0::1"]);
+});
+
+test("normalizeTailnetDnsName lowercases, strips trailing dots, and gates on .ts.net", () => {
+  assert.equal(normalizeTailnetDnsName("MyBox.Tail1234.TS.NET."), "mybox.tail1234.ts.net");
+  assert.equal(normalizeTailnetDnsName("  mybox.tail1234.ts.net  "), "mybox.tail1234.ts.net");
+  assert.equal(normalizeTailnetDnsName("my-box-2.tail1234.ts.net"), "my-box-2.tail1234.ts.net");
+  assert.equal(normalizeTailnetDnsName("mybox.example.com"), null);
+  assert.equal(normalizeTailnetDnsName("ts.net"), null);
+  assert.equal(normalizeTailnetDnsName(null), null);
+  assert.equal(normalizeTailnetDnsName(`${"a".repeat(250)}.ts.net`), null);
+});
+
 test("buildIngressJson tailscale mode emits {mode, tailnetIp, serverUrl}", () => {
   // The install persists this exact shape to ~/.manta/ingress.json on
   // the tailnet path; `manta pair` reads it back to compose the connect
@@ -3617,6 +3837,87 @@ test("buildIngressJson tailscale mode emits {mode, tailnetIp, serverUrl}", () =>
     serverUrl: "http://100.64.1.5:8787",
   });
   assert.equal(res.changed, true);
+});
+
+test("buildIngressJson advertises the MagicDNS name but still records the bind IP", () => {
+  // The bind/advertise split. tailnetIp is the ONLY thing that can be handed
+  // to listen(), so it is always recorded; serverUrl is what a device dials,
+  // so it carries the name. Collapsing the two is what shipped a box whose
+  // advertised URL the iOS client is structurally unable to open.
+  const res = buildIngressJson("", {
+    mode: "tailscale",
+    tailnetIp: "100.64.1.5",
+    tailnetHostname: "mybox.tail1234.ts.net",
+    port: 8787,
+  });
+  assert.equal(res.ok, true);
+  assert.deepEqual(JSON.parse(res.text), {
+    mode: "tailscale",
+    tailnetIp: "100.64.1.5",
+    tailnetHostname: "mybox.tail1234.ts.net",
+    serverUrl: "http://mybox.tail1234.ts.net:8787",
+  });
+});
+
+test("buildIngressJson falls back to the IP when no MagicDNS name is supplied", () => {
+  // Absent/empty hostname == the pre-existing behaviour, byte for byte, so a
+  // MagicDNS-less tailnet is no worse off than before.
+  const withIp = buildIngressJson("", { mode: "tailscale", tailnetIp: "100.64.1.5", port: 8787 });
+  for (const absent of [undefined, null, ""]) {
+    const res = buildIngressJson("", {
+      mode: "tailscale",
+      tailnetIp: "100.64.1.5",
+      tailnetHostname: absent,
+      port: 8787,
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.text, withIp.text, `expected IP fallback for ${JSON.stringify(absent)}`);
+    assert.equal(JSON.parse(res.text).serverUrl, "http://100.64.1.5:8787");
+  }
+});
+
+test("buildIngressJson normalizes the hostname and rejects a non-ts.net one", () => {
+  const normalized = buildIngressJson("", {
+    mode: "tailscale",
+    tailnetIp: "100.64.1.5",
+    tailnetHostname: "MyBox.Tail1234.ts.net.",
+    port: 8787,
+  });
+  assert.equal(normalized.ok, true);
+  assert.equal(JSON.parse(normalized.text).serverUrl, "http://mybox.tail1234.ts.net:8787");
+
+  // A present-but-invalid hostname is a LOUD failure, not a silent fallback:
+  // the only caller passes an already-validated value, so an invalid one means
+  // a bug, and degrading it quietly would hide the exact class of defect this
+  // split exists to fix.
+  const rejected = buildIngressJson("", {
+    mode: "tailscale",
+    tailnetIp: "100.64.1.5",
+    tailnetHostname: "mybox.example.com",
+    port: 8787,
+  });
+  assert.equal(rejected.ok, false);
+  assert.match(rejected.error, /ts\.net/);
+});
+
+test("buildIngressJson tailscale serverUrl always passes isPrivateServerUrl", () => {
+  // The gate every consumer applies (src/shared/transport.mjs and its Swift
+  // port): a pair link whose server URL fails this is REFUSED WHOLESALE by the
+  // app. Both branches of the fallback must satisfy it.
+  for (const hostname of [undefined, "mybox.tail1234.ts.net"]) {
+    const res = buildIngressJson("", {
+      mode: "tailscale",
+      tailnetIp: "100.64.1.5",
+      tailnetHostname: hostname,
+      port: 8787,
+    });
+    assert.equal(res.ok, true);
+    assert.equal(
+      isPrivateServerUrl(JSON.parse(res.text).serverUrl),
+      true,
+      `serverUrl must stay private-gated for hostname=${JSON.stringify(hostname)}`,
+    );
+  }
 });
 
 test("buildIngressJson tailscale mode requires a valid IPv4 + port", () => {
@@ -3665,6 +3966,54 @@ test("parse-tailscale-status CLI subcommand prints the IP on a running fixture",
   // No trailing newline: install.sh captures via `$()` which strips it,
   // and a stray newline would leak into the systemd unit's environment line.
   assert.equal(out, "100.64.1.5");
+});
+
+test("parse-tailscale-status CLI --field dns-name prints the MagicDNS name", () => {
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["100.64.1.5"], DNSName: "mybox.tail1234.ts.net." },
+  });
+  const out = execSync(
+    `node ${join(__dirname, "install-lib.mjs")} parse-tailscale-status --field dns-name`,
+    { input: fixture, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+  );
+  assert.equal(out, "mybox.tail1234.ts.net");
+});
+
+test("parse-tailscale-status CLI --field dns-name exits 1 when MagicDNS is off", () => {
+  // Exit 1 here means "no name", NOT "tailscale is down" — install.sh's call
+  // site tolerates it and falls back to the IP. If this ever became fatal, a
+  // MagicDNS-less tailnet would fail to install at all.
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["100.64.1.5"] },
+  });
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} parse-tailscale-status --field dns-name`,
+      { input: fixture, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    assert.fail("parse-tailscale-status --field dns-name must exit non-zero with no name");
+  } catch (e) {
+    assert.equal(e.status, 1);
+    assert.equal(e.stdout ?? "", "", "no stdout on failure");
+  }
+});
+
+test("parse-tailscale-status CLI rejects an unknown --field", () => {
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["100.64.1.5"] },
+  });
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} parse-tailscale-status --field hostname`,
+      { input: fixture, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    assert.fail("parse-tailscale-status must reject an unknown --field");
+  } catch (e) {
+    assert.equal(e.status, 2);
+  }
 });
 
 test("parse-tailscale-status CLI subcommand exits 1 on a stopped fixture", () => {
@@ -3731,6 +4080,41 @@ test("write-ingress CLI subcommand persists public mode", () => {
     assert.deepEqual(written, { mode: "public" });
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("write-ingress CLI subcommand persists the advertised MagicDNS hostname", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-write-ingress-magicdns-"));
+  const ingressFile = join(dir, "ingress.json");
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} write-ingress ` +
+        `--file ${ingressFile} --mode tailscale --tailnet-ip 100.64.1.5 ` +
+        `--tailnet-hostname mybox.tail1234.ts.net --port 8787`,
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    assert.deepEqual(JSON.parse(readFileSync(ingressFile, "utf-8")), {
+      mode: "tailscale",
+      tailnetIp: "100.64.1.5",
+      tailnetHostname: "mybox.tail1234.ts.net",
+      serverUrl: "http://mybox.tail1234.ts.net:8787",
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("write-ingress CLI subcommand rejects a non-ts.net --tailnet-hostname", () => {
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} write-ingress ` +
+        `--file /tmp/__bad_host__ --mode tailscale --tailnet-ip 100.64.1.5 ` +
+        `--tailnet-hostname mybox.example.com --port 8787`,
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    assert.fail("write-ingress must reject a non-ts.net --tailnet-hostname");
+  } catch (e) {
+    assert.match(e.stderr ?? "", /ts\.net/);
   }
 });
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -32,6 +32,7 @@ import { createConstraintStore, extractionInstruction, transcriptText } from "./
 import { createTuner, TUNE_IDLE_SWEEP_MS, GUARD_CACHE_HIT_DROP_PTS, GUARD_SUSTAIN_MS } from "./optimizer/tuner.mjs";
 import { parseConstraints } from "../shared/constraintPin.mjs";
 import { startPoller } from "./startPoller.mjs";
+import { parseTailnetHosts } from "./tailnet.mjs";
 import { getDb } from "./opencodeDb.mjs";
 import {
   resolvePolicy,
@@ -5397,16 +5398,26 @@ server.listen(PORT, HOST, () => {
   });
 });
 
-if (TAILNET_HOST) {
+// One listener per tailnet address. MANTA_TAILNET_HOST is a comma-separated
+// LIST because MagicDNS publishes both the node's IPv4 and its IPv6 under the
+// same name — binding only one of them leaves an advertised address that
+// stalls callers instead of refusing them. See src/server/tailnet.mjs.
+//
+// Each address gets its own server + independent retry: an IPv6 that cannot be
+// bound (a tailnet without IPv6, a host with it disabled) must never take the
+// working IPv4 listener down with it.
+for (const tailnetHost of parseTailnetHosts(TAILNET_HOST)) {
   const tailnetServer = createServer(handleRequest);
   tailnetServer.on("upgrade", handleUpgrade);
+  // IPv6 literals need brackets in a URL, but NOT when handed to listen().
+  const display = tailnetHost.includes(":") ? `[${tailnetHost}]` : tailnetHost;
   const listenTailnet = () => {
-    tailnetServer.listen(PORT, TAILNET_HOST, () => {
-      console.log(`manta listening on http://${TAILNET_HOST}:${PORT} (tailnet)`);
+    tailnetServer.listen(PORT, tailnetHost, () => {
+      console.log(`manta listening on http://${display}:${PORT} (tailnet)`);
     });
   };
   tailnetServer.on("error", (err) => {
-    console.warn(`[tailnet] listener error (${err.code ?? err.message}); retrying in 30s`);
+    console.warn(`[tailnet ${display}] listener error (${err.code ?? err.message}); retrying in 30s`);
     const t = setTimeout(listenTailnet, 30_000);
     t.unref();
   });

--- a/src/server/tailnet.mjs
+++ b/src/server/tailnet.mjs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------
+// Tailnet listener addressing.
+//
+// `MANTA_TAILNET_HOST` carries EVERY address the box's tailnet listener must
+// bind, comma-separated — not one address. Tailscale assigns each node both an
+// IPv4 (100.64.0.0/10) and an IPv6 (fd7a:…), and MagicDNS publishes BOTH under
+// the node's name. A client that resolves the name therefore gets two
+// candidate addresses and, on Apple's stack especially, tries the IPv6 first.
+//
+// Binding only the IPv4 leaves an advertised address that nothing answers on.
+// That does not fail cleanly — a connection to an address that is routable but
+// unbound can sit until it times out, which surfaces as an app that hangs
+// rather than one that reports it cannot connect. That was invisible while the
+// box advertised a bare IPv4 (one address, and it was the bound one) and became
+// reachable the moment it started advertising a name.
+//
+// The value is a LIST rather than a second variable so an already-installed
+// box's unit keeps working untouched: a single address is a valid one-element
+// list, so an old unit file and a new one mean the same thing.
+//
+// Bind is still explicit per-address and never a wildcard: the whole point of
+// this listener is that it is reachable on the tailnet and nowhere else, and
+// `::`/`0.0.0.0` would expose it far more widely than intended.
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a `MANTA_TAILNET_HOST` value into the addresses to bind.
+ *
+ * Tolerant of whitespace, empty entries and duplicates (a hand-edited unit
+ * file is a real thing), and order-preserving so the primary IPv4 is bound
+ * first. Returns `[]` for an unset/blank value, which is the public-path case
+ * where the tailnet listener is a no-op.
+ *
+ * @param {string|undefined|null} raw
+ * @returns {string[]}
+ */
+export function parseTailnetHosts(raw) {
+  if (typeof raw !== "string") return [];
+  const seen = new Set();
+  const out = [];
+  for (const part of raw.split(",")) {
+    const host = part.trim();
+    if (host === "" || seen.has(host)) continue;
+    seen.add(host);
+    out.push(host);
+  }
+  return out;
+}

--- a/src/server/tailnet.test.mjs
+++ b/src/server/tailnet.test.mjs
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseTailnetHosts } from "./tailnet.mjs";
+
+test("parseTailnetHosts binds both address families a MagicDNS name resolves to", () => {
+  // The regression this exists for: MagicDNS publishes the node's IPv4 AND its
+  // IPv6 under one name, and a client (Apple's stack especially) tries the
+  // IPv6 first. Binding only the IPv4 leaves an advertised address nothing
+  // answers on, which stalls a caller rather than refusing it.
+  assert.deepEqual(
+    parseTailnetHosts("100.64.1.5,fd7a:115c:a1e0::1"),
+    ["100.64.1.5", "fd7a:115c:a1e0::1"],
+  );
+});
+
+test("parseTailnetHosts keeps the IPv4 first", () => {
+  // Order is preserved so the guaranteed-reachable address is bound first and
+  // a failure on the second cannot delay it.
+  const hosts = parseTailnetHosts("100.64.1.5,fd7a:115c:a1e0::1");
+  assert.equal(hosts[0], "100.64.1.5");
+});
+
+test("parseTailnetHosts accepts a single address unchanged", () => {
+  // Back-compat with an already-installed box: its unit file carries one
+  // address, and a one-element list must mean exactly what it did before.
+  assert.deepEqual(parseTailnetHosts("100.64.1.5"), ["100.64.1.5"]);
+});
+
+test("parseTailnetHosts returns [] for an unset or blank value", () => {
+  // The public path: no tailnet listener at all. Must be an empty list, not a
+  // list containing an empty string — binding "" is a wildcard bind, which
+  // would expose this listener far beyond the tailnet.
+  for (const raw of ["", "   ", ",", " , , ", undefined, null, 42, {}]) {
+    assert.deepEqual(parseTailnetHosts(raw), [], `expected [] for ${JSON.stringify(raw)}`);
+  }
+});
+
+test("parseTailnetHosts tolerates whitespace and duplicates", () => {
+  // Unit files get hand-edited; a stray space or a repeated address must not
+  // produce a bind on "" or a second listener racing the first for the port.
+  assert.deepEqual(
+    parseTailnetHosts(" 100.64.1.5 , fd7a:115c:a1e0::1 , 100.64.1.5 "),
+    ["100.64.1.5", "fd7a:115c:a1e0::1"],
+  );
+});


### PR DESCRIPTION
## The bug

A Tailscale box advertises itself as `http://100.64.x.x:8787` — a raw IPv4 in the CGNAT range. **The iOS app cannot open that address at all**, and no app-side exception can be written for it:

- Apple's transport policy allows cleartext to the classic private ranges (`10.x`, `172.16–31.x`, `192.168.x`) via `NSAllowsLocalNetworking`. Tailscale uses `100.64/10`, which is RFC 6598 shared address space and is **not** in that set.
- An ATS exception entry names a **domain**. There is no way to express an IP literal, so the address the installer hands out is inexpressible.

This is why the `ts.net` ATS exception in `ios-v1.0.23` changed nothing: it is correct, and it covers a hostname shape the product never produced. Safari on the same phone worked throughout — a browser is exempt from an app's ATS policy — which made the box look reachable and pointed the diagnosis at the app rather than at what the box advertises.

## Two coupled changes

**1. Advertise the MagicDNS name, fall back to the IP.** When the tailnet has a name, the box advertises `http://<host>.<tailnet>.ts.net:8787`; a `ts.net` name *can* carry an ATS exception, and 1.0.23 already ships one. With no name the output is byte-identical to before, and the installer prints why the iOS app will not work on that address.

The name is validated hard and a non-`ts.net` value is **refused rather than used**. `isPrivateServerUrl` (and its Swift port) accepts a hostname only for `localhost`/`.ts.net`, so a pair link carrying anything else is refused *wholesale* by the app — strictly worse than the IP fallback it would displace.

**2. Bind every address the name resolves to.** Tailscale assigns each node an IPv4 *and* an IPv6, and MagicDNS publishes both; clients try the IPv6 first. The detection code picked the IPv4 and discarded the IPv6, so nothing answered on half of what the name resolves to — and a connection to a routable-but-unbound address **stalls rather than fails**, surfacing as an app that hangs on the linking screen.

That was unreachable while a bare IPv4 was advertised (one address, and it was the bound one). It became reachable the moment the box advertised a name, so the two changes ship together.

Bind address and advertised host are now separate throughout: a listener needs an address, a client needs a name it is permitted to dial. `MANTA_TAILNET_HOST` carries the bind list comma-separated, so an already-installed box's unit file stays valid as a one-element list, and each address gets an independent listener + retry so a missing IPv6 cannot take the working IPv4 down.

## Deploying this

`self-update.sh` restarts the unit but never re-renders it, so an existing box needs the **installer re-run** — not a self-update — to pick up either half. Sequence: merge → tag `server-v<n>` → re-run `install.sh` on the box. Confirm with `ss -tlnH | grep 8787`, which should now show an `fd7a:…` entry beside the `100.x` one.

## Verification

`npm run typecheck` clean; `npm test` green on this base (198 vitest files / 3884 tests, 3775 node:test).

Tests cover: MagicDNS extraction, normalization and `ts.net` gating; the IP fallback; IPv4-still-required (an IPv6-only tailnet still falls back to the public path); the bind-host list asserted across **both ends** of `MANTA_TAILNET_HOST` (the installer's emitter against the server's parser, so the wire format cannot drift); the advertised URL asserted against the real `isPrivateServerUrl` rather than a local copy; and the bind/advertise split in `install.sh` under bash.

## What this does not fix

A tailnet with MagicDNS **disabled** still lands on the IP fallback and still cannot be reached by the iOS app. Closing that needs the app-side change — permitting cleartext to private addresses generally — which would also fix plain-LAN boxes, currently broken for the same reason. Worth queuing separately.