### PR TITLE
fix(server): bound CTO store growth + surface persist failures (BET-1466 stage 3A)

### DIFF
--- a/src/server/ctoBackfill.mjs
+++ b/src/server/ctoBackfill.mjs
@@ -10,8 +10,8 @@
 //     (recorded in engine-state at kick-off); live ingestion owns ts ≥ it. The
 //     backfill only ever reads ts < startInstant, so a backfilled and a live
 //     segment can never overlap or double-count.
-//   - Spend bound: one-time budget (default $3, config `ctoBackfillCapUsd`),
-//     measured as the cumulative model-ledger cost attributed since the start
+//   - Spend bound: one-time budget (default $3, or the engine's explicit
+//     override), measured as the cumulative model-ledger cost attributed since the start
 //     instant. On hitting the bound it stops at the depth reached and persists
 //     {stoppedAtDepthDays, reason:"budget"}.
 //   - Batch-priority: reduce calls (summaries/rollups) run only while presence
@@ -137,8 +137,8 @@ export function createCtoBackfill(deps = {}) {
     getDb = null, // async () => read-only opencode db | null (index.mjs supplies the real handle)
     presenceCheck = async () => false, // true when present → stop/yield (batch-priority)
     now = () => Date.now(),
-    capUsd = null, // explicit override; else config.ctoBackfillCapUsd; else default
-    depthDays = null, // explicit override; else config.ctoBackfillDays; else default
+    capUsd = null, // explicit override; else DEFAULT_BACKFILL_CAP_USD
+    depthDays = null, // explicit override; else DEFAULT_BACKFILL_DAYS
     maxSessionsPerStep = MAX_SESSIONS_PER_STEP,
     maxRollupsPerStep = MAX_ROLLUPS_PER_STEP,
   } = deps;
@@ -156,15 +156,14 @@ export function createCtoBackfill(deps = {}) {
     }
     return cfg;
   }
-  function cfgNum(key, dflt) {
-    const v = cfg && cfg[key];
-    return typeof v === "number" && Number.isFinite(v) ? v : dflt;
-  }
+  // BET-1466: the config-key lookups that used to sit here read two config
+  // spellings written by no UI, doc, or code path — dead indirection. Only
+  // the explicit engine override or the fallback constant applies.
   function resolveCap() {
-    return capUsd ?? cfgNum("ctoBackfillCapUsd", DEFAULT_BACKFILL_CAP_USD);
+    return capUsd ?? DEFAULT_BACKFILL_CAP_USD;
   }
   function resolveDepth() {
-    return depthDays ?? cfgNum("ctoBackfillDays", DEFAULT_BACKFILL_DAYS);
+    return depthDays ?? DEFAULT_BACKFILL_DAYS;
   }
 
   async function readState() {

--- a/src/server/ctoBackfill.test.mjs
+++ b/src/server/ctoBackfill.test.mjs
@@ -321,3 +321,15 @@ test("batch-priority: while the user is present, the backfill yields and touches
   assert.equal(dbCalls, 0, "present → yields before any work; no db read, no state write");
   assert.equal(engineState._data.backfillDone, undefined, "a present-yield is not a completion");
 });
+
+// BET-1466 item 8: the config-key indirection read spellings written by no
+// UI, doc, or code path — deleted; only the explicit override or the fallback
+// constants resolve cap/depth now.
+test("dead ctoBackfillCapUsd/ctoBackfillDays config lookups are gone; overrides + constants remain", async () => {
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(new URL("./ctoBackfill.mjs", import.meta.url), "utf8");
+  assert.ok(!src.includes("ctoBackfillCapUsd"), "the un-writable cap config key is deleted");
+  assert.ok(!src.includes("ctoBackfillDays"), "the un-writable depth config key is deleted");
+  assert.ok(src.includes("capUsd ?? DEFAULT_BACKFILL_CAP_USD"), "explicit override, else the fallback constant");
+  assert.ok(src.includes("depthDays ?? DEFAULT_BACKFILL_DAYS"), "explicit override, else the fallback constant");
+});

--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -157,7 +157,33 @@ export function recordSpend(payload, { now, usd, calls = 1 } = {}) {
   const key = dayKey(t);
   const prev = dayBucket(p, key);
   const days = { ...p.days, [key]: { usd: dollar(prev.usd) + dollar(usd), calls: num(prev.calls) + ((calls | 0) || 1) } };
-  return { ...p, days, updatedMs: t };
+  // BET-1466: bound the growth inside the only writer that adds buckets.
+  // Day buckets older than the burn-history window are read by nothing
+  // (the burn history reads exactly BURN_HISTORY_DAYS day-starts including
+  // today); ROI month accumulators older than the retention horizon are
+  // beyond the report's honest horizon and are dropped with the pending
+  // rows that feed them. budget.json is not covered by the store sweep.
+  const oldestDay = startOfDay(t) - (BURN_HISTORY_DAYS - 1) * 24 * HOUR_MS;
+  for (const k of Object.keys(days)) {
+    const ts = Number(k);
+    if (Number.isFinite(ts) && ts < oldestDay) delete days[k];
+  }
+  let roi = p.roi;
+  if (roi && typeof roi === "object" && roi.months && typeof roi.months === "object") {
+    const cutoffKey = roiMonthKey(t - ROI_PENDING_RETENTION_MS);
+    let prunedAny = false;
+    const months = {};
+    for (const k of Object.keys(roi.months)) {
+      // Prune only well-formed month keys we understand; keep anything else.
+      if (/^\d{4}-\d{2}$/.test(k) && k < cutoffKey) {
+        prunedAny = true;
+        continue;
+      }
+      months[k] = roi.months[k];
+    }
+    if (prunedAny) roi = { ...roi, months };
+  }
+  return { ...p, days, ...(roi !== p.roi ? { roi } : {}), updatedMs: t };
 }
 
 // True when the budget's most recent record belongs to a day other than the
@@ -1072,9 +1098,20 @@ function validPrRef(ref) {
             if (computed) months[key] = computed;
           }
 
-          // 4. Hygiene: drop stale pending rows.
+          // 4. Hygiene: age out stale pending rows. The retention horizon
+          // applies to BOTH halves (BET-1466: it used to filter only counted
+          // rows while the never-merged ones — the rows that actually
+          // accumulate — were kept forever). A counted row is a dedupe
+          // fingerprint kept only past any possible re-sample: the delegate
+          // jobs store sweeps terminal records after 7 days, far inside the
+          // 60-day horizon, so a counted row dropped at the horizon can never
+          // be re-counted.
           const cutoff = t - ROI_PENDING_RETENTION_MS;
-          const kept = pending.filter((j) => j.counted === true ? (typeof j.finishedAt === "number" ? j.finishedAt >= cutoff : true) : true);
+          const kept = pending.filter((j) =>
+            j.counted === true
+              ? typeof j.finishedAt === "number" ? j.finishedAt >= cutoff : true
+              : typeof j.finishedAt === "number" && j.finishedAt >= cutoff,
+          );
           const trimmed = kept.slice(-200);
           pending = trimmed;
 

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -747,13 +747,12 @@ test("roiSnapshot: collectingUntil is the first month's end from the day buckets
   assert.equal(snap.collectingUntil, monthWindow(JUL_KEY).endTs);
 });
 
-test("pending rows past the retention horizon are dropped", async () => {
+test("pending rows past the retention horizon are dropped — counted AND never-merged (BET-1466 item 5)", async () => {
   let payload = defaultBudgetPayload();
   const store = { load: async () => payload, save: async (p) => (payload = p) };
   // A stateful jobs reader: the job exists only on the first refresh (the
   // jobs store sweeps terminal records after 7 days — long before the 60d
-  // pending-retention horizon drops a counted row, so a counted job can
-  // never be re-sampled in reality).
+  // pending-retention horizon, so a dropped row is never re-sampled).
   let jobsVisible = true;
   const budget = createCtoBudget({
     store,
@@ -770,11 +769,59 @@ test("pending rows past the retention horizon are dropped", async () => {
   });
   await budget.refreshRoi();
   await budget.refreshRoi();
-  assert.equal(payload.roi.pending.length, 1); // uncounted row is kept for later probes
-  payload.roi.pending[0].counted = true;
-  await store.save(payload);
+  // BET-1466: the uncounted (never-merged) row is the one that used to
+  // accumulate forever — it now ages out at the horizon like counted rows.
+  assert.equal(payload.roi.pending.length, 0);
+});
+
+test("pending retention keeps fresh probe-pending rows and counted fingerprints (BET-1466 item 5)", async () => {
+  let payload = defaultBudgetPayload();
+  payload.roi = {
+    months: {},
+    pending: [
+      { id: "fresh", counted: false, finishedAt: MIDNIGHT - 1_000 }, // probe-pending → kept
+      { id: "staleUncounted", counted: false, finishedAt: MIDNIGHT - ROI_PENDING_RETENTION_MS - 1 }, // aged out (was kept forever)
+      { id: "staleCounted", counted: true, finishedAt: MIDNIGHT - ROI_PENDING_RETENTION_MS - 1 }, // aged out (as before)
+      { id: "countedNoFinish", counted: true, finishedAt: null }, // counted fingerprint without a ts → kept
+    ],
+  };
+  const store = { load: async () => payload, save: async (p) => (payload = p) };
+  const budget = createCtoBudget({
+    store,
+    jobsRead: async () => [],
+    gitProbe: async () => ({ exists: true, isAncestor: false }),
+    discoverJobPr: async () => null, // forge: definitively no PR
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now: () => MIDNIGHT,
+  });
   await budget.refreshRoi();
-  assert.equal(payload.roi.pending.length, 0); // counted stale row swept
+  const ids = payload.roi.pending.map((j) => j.id).sort();
+  assert.deepEqual(ids, ["countedNoFinish", "fresh"]);
+});
+
+// BET-1466 item 4: budget.json is not covered by the store sweep — the spend
+// recorder itself now bounds day-bucket and ROI-month growth.
+test("recordSpend prunes day buckets beyond the burn history and ROI months beyond the horizon", () => {
+  const DAY = 86_400_000;
+  let p = defaultBudgetPayload();
+  p.days[dayKey(MIDNIGHT - 10 * DAY)] = { usd: 9, calls: 9 }; // outside the 7-day burn history
+  p.days[dayKey(MIDNIGHT - 6 * DAY)] = { usd: 1, calls: 1 }; // the oldest in-window day → kept
+  p.roi = {
+    months: {
+      [roiMonthKey(MIDNIGHT - 100 * DAY)]: { merged: 3 }, // past the 60d ROI horizon
+      [roiMonthKey(MIDNIGHT - 40 * DAY)]: { merged: 1 }, // recent → kept
+    },
+    pending: [],
+  };
+  const out = recordSpend(p, { now: MIDNIGHT + 60_000, usd: 0.25 });
+  assert.equal(out.days[dayKey(MIDNIGHT - 10 * DAY)], undefined, "a bucket older than the burn window is dropped");
+  assert.equal(out.days[dayKey(MIDNIGHT - 6 * DAY)].usd, 1, "the oldest in-window bucket survives");
+  assert.equal(out.days[dayKey(MIDNIGHT + 60_000)].usd, 0.25, "today's bucket is written");
+  assert.equal(out.roi.months[roiMonthKey(MIDNIGHT - 100 * DAY)], undefined, "an ROI month past the horizon is dropped");
+  assert.equal(out.roi.months[roiMonthKey(MIDNIGHT - 40 * DAY)].merged, 1, "a recent ROI month survives");
+  assert.equal(out.roi.pending.length, 0, "pending rides along untouched");
 });
 
 test("overnightSpendUsd prices today's job_started estTokens at the model cost (§11.2)", () => {

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -997,34 +997,41 @@ export function createCtoEngine(deps = {}) {
   }
 
   // BET-1391 verdict ledger (§9.5): lazy single instance over the injectable
-  // verdicts store. The facts counter-sink is registered ONCE at construction
+  // verdicts store. The counter sinks are registered ONCE at construction
   // so every recorded verdict routes its §9.5 effects to the sender-reliability
-  // counters (B1) — and is removed by the engine's dispose below.
+  // counters (B1) and friends — and are unregistered by the engine's dispose
+  // below (BET-1466: the claim used to be false, the sinks kept firing after
+  // dispose against disposed engine state).
+  let verdictSinkDisposers = [];
   function getVerdictsEngine() {
     if (verdictsEngine) return verdictsEngine;
     verdictsEngine = createVerdictEngine({ verdicts, now });
-    verdictsEngine.registerCounterSink(factsCounterSink);
-    verdictsEngine.registerCounterSink(tonightCounterSink);
+    verdictSinkDisposers.push(verdictsEngine.registerCounterSink(factsCounterSink));
+    verdictSinkDisposers.push(verdictsEngine.registerCounterSink(tonightCounterSink));
     // BET-1404 (§9.5): tool-as-source verdicts fold into the tool registry's
     // as_source counters — the decay chain's input data. Late-bound registry
     // handle: the tool registry is constructed lazily and the sink fires
     // after any verdict, so resolve getTools() at fold time. Best-effort
     // like every sink.
-    verdictsEngine.registerCounterSink(
-      createAsSourceSink({
-        registry: {
-          applyAsSource: (toolId, effects) => getTools().applyAsSource(toolId, effects),
-        },
-      }),
+    verdictSinkDisposers.push(
+      verdictsEngine.registerCounterSink(
+        createAsSourceSink({
+          registry: {
+            applyAsSource: (toolId, effects) => getTools().applyAsSource(toolId, effects),
+          },
+        }),
+      ),
     );
     // BET-1403 (§9.4): the trust counters ride the same §9.5 sink registry —
     // per-action-class Beta counters over class-attributed suggestion
     // verdicts. Best-effort like every sink: a failure never breaks verdict
     // recording.
     const t = getTrust();
-    verdictsEngine.registerCounterSink((effects, entry) => {
-      void t.noteVerdictEffects(effects, entry).catch(() => {});
-    });
+    verdictSinkDisposers.push(
+      verdictsEngine.registerCounterSink((effects, entry) => {
+        void t.noteVerdictEffects(effects, entry).catch(() => {});
+      }),
+    );
     return verdictsEngine;
   }
 
@@ -1640,15 +1647,15 @@ export function createCtoEngine(deps = {}) {
     const trough = typeof profile?.getQuietTrough === "function" ? profile.getQuietTrough() : null;
     const runNow = pendingRunNow;
     pendingRunNow = false;
-    let ledgerRowsAll = [];
+    let recentLedger = [];
     try {
-      ledgerRowsAll = (await ledger.read()) ?? [];
+      // BET-1466: every consumer below looks at the last 24h at most (the
+      // watcher candidates; dispatchPlan at rows since the window opened) —
+      // request the bounded range instead of reading the whole ledger file.
+      recentLedger = (await ledger.read({ from: t - 24 * HOUR_MS })) ?? [];
     } catch {
-      ledgerRowsAll = [];
+      recentLedger = [];
     }
-    const recentLedger = ledgerRowsAll.filter(
-      (r) => typeof r?.ts !== "number" || r.ts >= t - 24 * HOUR_MS,
-    );
     const candidates = [
       ...queueCandidatesFromRows(await tonightQueueRows()),
       ...watcherCandidatesFromRows(recentLedger),
@@ -1700,7 +1707,7 @@ export function createCtoEngine(deps = {}) {
         plan: out.plan,
         trough,
         projects,
-        ledgerRows: ledgerRowsAll,
+        ledgerRows: recentLedger,
         windowOpenedMs: win.openedMs,
       }).catch(() => {});
     }
@@ -2243,6 +2250,16 @@ export function createCtoEngine(deps = {}) {
     disposed = true;
     stopTimers();
     stopCardTimer();
+    // BET-1466: drop the verdict counter sinks (registered lazily by
+    // getVerdictsEngine). Without this a post-dispose verdict still folds
+    // effects into this engine's reliability/registry state.
+    for (const d of verdictSinkDisposers.splice(0)) {
+      try {
+        d();
+      } catch {
+        /* best-effort */
+      }
+    }
   }
 
   async function getState() {
@@ -2483,9 +2500,6 @@ export function createCtoEngine(deps = {}) {
       return getTools();
     },
     toolsScan: () => toolsTick(),
-    get cards() {
-      return cards;
-    },
     // BET-1419 tonight verbs (§10.4 drill-down + §9.2 veto card actions).
     tonightList,
     tonightAdd,

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -884,3 +884,79 @@ test("isRunningCtoRow: single shared definition of a running CTO job row (BET-14
   assert.equal(isRunningCtoRow(undefined), false);
   assert.equal(isRunningCtoRow("cto/running"), false);
 });
+
+// ---------------------------------------------------------------------------
+// BET-1466 stage-3A
+// ---------------------------------------------------------------------------
+
+test("overnightTick reads the ledger with a 24h lower bound instead of the whole file (BET-1466 item 3)", async () => {
+  const readCalls = [];
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true, ctoOvernight: true }),
+    ledger: {
+      append: async () => {},
+      read: async (opts) => {
+        readCalls.push(opts ?? null);
+        return [];
+      },
+    },
+    engineState: {
+      load: async () => ({}),
+      save: async () => {},
+    },
+    killSwitch: { isPaused: async () => false, pause: async () => {}, resume: async () => {} },
+    tierGet: async () => "high",
+    overnight: { tick: async () => ({ window: null, ledgerRows: [] }) },
+    now: () => 5_000_000_000_000,
+  });
+  await engine.tick();
+  assert.equal(readCalls.length >= 1, true, "the overnight tick read the ledger");
+  const HOUR = 3_600_000;
+  for (const opts of readCalls) {
+    assert.ok(opts && typeof opts === "object", "read() is called with an options object");
+    assert.equal(opts.from, 5_000_000_000_000 - 24 * HOUR, "the read is bounded to the last 24h");
+  }
+});
+
+test("dispose unregisters the verdict counter sinks (BET-1466 item 7)", async () => {
+  let esState = {};
+  let verdictsState = { entries: [] };
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true }),
+    ledger: { append: async () => {} },
+    engineState: {
+      load: async () => esState,
+      save: async (p) => {
+        esState = p;
+      },
+    },
+    killSwitch: { isPaused: async () => false, pause: async () => {}, resume: async () => {} },
+    verdicts: {
+      load: async () => verdictsState,
+      save: async (p) => {
+        verdictsState = p;
+      },
+    },
+    now: () => 5_000_000_000_000,
+  });
+  const res = await engine.recordVerdict({ subject: { type: "fact", id: "f1", sender: "user" }, verdict: "accept" });
+  assert.equal(res.ok, true, "the verdict itself records");
+  // The sink folds asynchronously (best-effort void promise) — let it land.
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  const before = esState.factReliability?.user?.confirmed ?? 0;
+  assert.ok(before >= 1, "the sink folded the verdict into sender reliability");
+  engine.dispose();
+  await engine.recordVerdict({ subject: { type: "fact", id: "f2", sender: "user" }, verdict: "accept" });
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  const after = esState.factReliability?.user?.confirmed ?? 0;
+  assert.equal(after, before, "a post-dispose verdict no longer folds into reliability");
+});
+
+test("the engine surface declares get cards() exactly once (BET-1466 item 7: duplicate key deleted)", async () => {
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(new URL("./ctoEngine.mjs", import.meta.url), "utf8");
+  const count = src.split("get cards()").length - 1;
+  assert.equal(count, 1, "a duplicated object-literal key silently shadows its twin");
+});

--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -639,15 +639,22 @@ export function createFactsEngine(deps = {}) {
       return {};
     }
   }
+  // BET-1466: reports success instead of swallowing — callers that surface a
+  // user-facing result (submitProposal) must not claim ok when nothing
+  // reached disk. Fire-and-forget callers (bumpReliability and friends)
+  // ignore the return and keep their old silent shape.
   async function saveState(s) {
+    const patch = {};
+    for (const key of FACTS_STATE_KEYS) {
+      if (key in s) patch[key] = s[key];
+    }
+    // BET-1425: per-key RMW (load-fresh → merge owned keys → atomic save).
     try {
-      const patch = {};
-      for (const key of FACTS_STATE_KEYS) {
-        if (key in s) patch[key] = s[key];
-      }
-      // BET-1425: per-key RMW (load-fresh → merge owned keys → atomic save).
       await patchEngineState(patch, { engineState });
-    } catch {}
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   function currentHalfLives(tuning) {
@@ -714,7 +721,19 @@ export function createFactsEngine(deps = {}) {
     if (!validateProposal(proposal)) return { ok: false, error: "invalid proposal" };
     const state = await loadState();
     const res = enqueueProposal(state, proposal);
-    if (res.added) await saveState(res.state);
+    if (res.added) {
+      // BET-1466: the enqueue lives only in the freshly-loaded state object —
+      // until saveState persists it, the proposal exists nowhere. Report the
+      // persist failure instead of a phantom ok.
+      const saved = await saveState(res.state);
+      if (!saved) {
+        return {
+          ok: false,
+          error: "proposal accepted in memory but the persist failed; it was not queued",
+          proposalId: proposal.proposalId,
+        };
+      }
+    }
     return { ok: res.added, added: res.added, reason: res.reason, proposalId: proposal.proposalId };
   }
 

--- a/src/server/ctoFacts.test.mjs
+++ b/src/server/ctoFacts.test.mjs
@@ -664,3 +664,38 @@ test("viewRender picks the first project when none given, sorts rows, and touche
   await engine.viewRender(null, { touch: false });
   assert.equal(inmemory.get("f:alpha").facts.find((f) => f.id === "cto:young").access_count, young.access_count);
 });
+
+// BET-1466 item 6: a persist failure must not surface as a queued proposal.
+test("submitProposal reports ok:false when the engine-state persist fails", async () => {
+  const failingState = {
+    load: async () => ({}),
+    save: async () => {
+      throw new Error("disk full");
+    },
+  };
+  const engine = createFactsEngine({
+    facts: {
+      load: async () => ({ v: 1, facts: [] }),
+      save: async () => {},
+      dir: "facts-dir-placeholder",
+    },
+    archive: {
+      load: async () => ({ v: 1, entries: [] }),
+      save: async () => {},
+    },
+    engineState: failingState,
+    ledger: { append: async () => {} },
+    listProjects: async () => ["alpha"],
+    now: () => 1000 * D,
+  });
+  const res = await engine.submitProposal({
+    proposalId: "pp",
+    project: "alpha",
+    kind: "status",
+    statement: "persist will fail",
+    refs: ["s1"],
+    sender: "cto",
+  });
+  assert.equal(res.ok, false, "a phantom ok is no longer returned");
+  assert.match(res.error || "", /persist failed/);
+});

--- a/src/server/ctoOvernight.mjs
+++ b/src/server/ctoOvernight.mjs
@@ -149,9 +149,26 @@ export function normalizeWindow(prev) {
     // explicit consent after a cancel). It expires naturally when the next
     // trough has a different startMs, so a veto never suppresses tomorrow.
     vetoedTroughStartMs: finiteOrNull(w.vetoedTroughStartMs),
+    // BET-1466: the trough start whose zero-candidates night was already
+    // reported to the ledger. Same expiry as the veto stamp — a long trough
+    // produces one `no-candidates` row, not one per tick.
+    lastNoCandidatesTroughStartMs: finiteOrNull(w.lastNoCandidatesTroughStartMs),
     countdown,
     lastEvaluatedMs: finiteOrNull(w.lastEvaluatedMs),
   };
+}
+
+// BET-1466: do the two normalized window states differ beyond the per-tick
+// evaluation bookkeeping? `lastEvaluatedMs` is bumped by every evaluation by
+// definition, so it alone never justifies persisting. Both sides go through
+// normalizeWindow (same literal key order → stable stringify) so a raw
+// persisted window compares equal to its normalized re-computation.
+function windowChanges(prev, next) {
+  const a = { ...normalizeWindow(prev) };
+  const b = { ...normalizeWindow(next) };
+  delete a.lastEvaluatedMs;
+  delete b.lastEvaluatedMs;
+  return JSON.stringify(a) !== JSON.stringify(b);
 }
 
 export function defaultWindow() {
@@ -282,9 +299,18 @@ export function evaluateWindow(prev, input) {
 
   if (zeroCandidates) {
     // §11.4: a night with zero candidates opens no window at all — not even
-    // on run-now (there is nothing to run).
+    // on run-now (there is nothing to run). BET-1466: the row is stamped with
+    // the trough it describes — emit only when this trough has not been
+    // reported yet, so a long trough yields one row instead of one per tick.
     if (inTrough && (signal || runNow)) {
-      rows.push(ledgerRow("cto.overnight.no-candidates", now, { reason: "zero candidates; no window" }));
+      const troughStart = finiteOrNull(trough?.startMs);
+      if (troughStart !== null && troughStart !== w.lastNoCandidatesTroughStartMs) {
+        rows.push(ledgerRow("cto.overnight.no-candidates", now, { reason: "zero candidates; no window" }));
+        return {
+          window: normalizeWindow({ ...w, countdown, lastNoCandidatesTroughStartMs: troughStart, lastEvaluatedMs: now }),
+          ledgerRows: rows,
+        };
+      }
     }
     return { window: normalizeWindow({ ...w, countdown, lastEvaluatedMs: now }), ledgerRows: rows };
   }
@@ -840,7 +866,12 @@ export function createOvernightScheduler({ store = defaultOvernightStore(), now 
         plan = selectPortfolio(ranked, { budgetFrac, pinnedOrder: window.pinnedOrder });
       }
 
-      await store.save({ ...payload, window }).catch(() => {});
+      // BET-1466: `lastEvaluatedMs` changes on every tick by definition, so
+      // it never justifies a save. When nothing else in the window state
+      // moved (the common idle trough tick), skip the write entirely.
+      if (windowChanges(prevWindow, window)) {
+        await store.save({ ...payload, window }).catch(() => {});
+      }
       await ledgerAppend(ledgerRows);
       return { window, plan, ledgerRows };
     },

--- a/src/server/ctoOvernight.mjs
+++ b/src/server/ctoOvernight.mjs
@@ -868,8 +868,11 @@ export function createOvernightScheduler({ store = defaultOvernightStore(), now 
 
       // BET-1466: `lastEvaluatedMs` changes on every tick by definition, so
       // it never justifies a save. When nothing else in the window state
-      // moved (the common idle trough tick), skip the write entirely.
-      if (windowChanges(prevWindow, window)) {
+      // moved (the common idle trough tick), skip the write entirely — but
+      // the very first persist still lays the row down: a persisted window
+      // (even a closed, empty one) is the machine's liveness marker that
+      // readWindow consumers (e.g. the veto card) key on.
+      if (prevWindow == null || windowChanges(prevWindow, window)) {
         await store.save({ ...payload, window }).catch(() => {});
       }
       await ledgerAppend(ledgerRows);

--- a/src/server/ctoOvernight.test.mjs
+++ b/src/server/ctoOvernight.test.mjs
@@ -140,6 +140,44 @@ test("zero candidates → no window at all (§11.4 graceful-empty), even on run-
   }
 });
 
+// BET-1466 item 2: the no-candidates row is stamped with its trough (one row
+// per trough, not one per tick) and an unchanged window state is not re-saved.
+test("no-candidates row emits once per trough; idle trough ticks skip the save", async () => {
+  let saves = 0;
+  let saved = { v: 1, window: null };
+  const ledgerRows = [];
+  let clock = T0 + H;
+  const scheduler = createOvernightScheduler({
+    store: {
+      load: async () => saved,
+      save: async (d) => {
+        saves += 1;
+        saved = d;
+      },
+    },
+    now: () => clock,
+    budget: async () => FAT,
+    ledger: { append: async (row) => ledgerRows.push(row) },
+  });
+  // The scheduler reads its clock from the injected `now` (input.now is not
+  // consulted by tick), so the test advances the clock between ticks.
+  const input = (trough) => tickInput({ candidateCount: 0, candidates: [], trough });
+  const t1 = await scheduler.tick(input(TROUGH));
+  assert.equal(t1.ledgerRows.filter((r) => r.kind === "cto.overnight.no-candidates").length, 1);
+  assert.equal(saves, 1, "the first report stamps the trough start and saves");
+  // Same trough, a minute later: no new row, and the save is skipped.
+  clock = T0 + H + 60_000;
+  const t2 = await scheduler.tick(input(TROUGH));
+  assert.equal(t2.ledgerRows.filter((r) => r.kind === "cto.overnight.no-candidates").length, 0);
+  assert.equal(saves, 1, "an unchanged window state is not re-saved");
+  // A NEW trough reports again (the old stamp expires with its trough).
+  const nextTrough = { startMs: T0 + 24 * H, endMs: T0 + 30 * H };
+  clock = T0 + 25 * H;
+  const t3 = await scheduler.tick(input(nextTrough));
+  assert.equal(t3.ledgerRows.filter((r) => r.kind === "cto.overnight.no-candidates").length, 1);
+  assert.equal(saves, 2, "the new trough's stamp is persisted");
+});
+
 test("a fulfilled veto countdown is cleared by the open it announced", () => {
   const due = T0 + 30 * 60_000;
   let window = scheduleCountdown(null, { now: T0, dueMs: due });

--- a/src/server/ctoWatchers.mjs
+++ b/src/server/ctoWatchers.mjs
@@ -38,7 +38,7 @@
 // without a hit, or when the underlying fact/pattern is archived.
 
 import { randomBytes } from "node:crypto";
-import { patchEngineState, patchStore } from "./ctoStores.mjs";
+import { RETENTION_MS, patchEngineState, patchStore } from "./ctoStores.mjs";
 
 // Closed set of predicate kinds (spec §13.4). Adding a kind is a spec change.
 export const PREDICATE_KINDS = Object.freeze(["event-pattern", "rate-threshold", "usage-burn"]);
@@ -278,6 +278,31 @@ export function retireWatchers(watchers, { nowMs = Date.now(), inactiveAfterMs =
   return { next, retired };
 }
 
+// BET-1466: bound the growth of retired rows. `retireWatchers` only ever ADDS
+// the flag — nothing removed a retired entry, so they accumulated forever. The
+// bound reuses the day-rollup retention (ctoStores RETENTION_MS): the
+// auto-create source a resurfacing theme would re-arm from is itself retained
+// only that long, so a retired row kept past it is dead weight. Returns the
+// kept list plus what was dropped, so the caller saves only on a real change.
+export function pruneRetiredWatchers(watchers, { nowMs = Date.now(), retentionMs = RETENTION_MS["rollups/day"] } = {}) {
+  const next = [];
+  const dropped = [];
+  const cutoff = nowMs - retentionMs;
+  for (const w of Array.isArray(watchers) ? watchers : []) {
+    if (
+      w &&
+      w.retired === true &&
+      typeof w.retiredAt === "number" &&
+      w.retiredAt < cutoff
+    ) {
+      dropped.push({ id: w.id, patternSignature: w.patternSignature });
+      continue;
+    }
+    next.push(w);
+  }
+  return { next, dropped };
+}
+
 // ---------------------------------------------------------------------------
 // Migration from the legacy poller store (cto.json) — idempotent
 // ---------------------------------------------------------------------------
@@ -487,14 +512,22 @@ export function createStandingQueryEngine(deps = {}) {
   const windowHits = new Map();
   // watcherId -> last usage-burn hit ts (so burn doesn't re-fire every tick).
   const lastBurnHit = new Map();
+  // BET-1466: the watchers list, read once and reused across the burst of
+  // evidence events that follow. evaluateEvent runs per ledger row (one
+  // fire-and-forget call each) and used to re-read the whole file for every
+  // event; the list only changes through this engine's own writes, so the
+  // cache is refreshed directly from each patch and starts null per instance.
+  let listCache = null;
 
   async function loadAll() {
+    if (listCache) return listCache;
     try {
       const payload = await store.load();
-      return Array.isArray(payload?.watchers) ? payload.watchers : [];
+      listCache = Array.isArray(payload?.watchers) ? payload.watchers : [];
     } catch {
-      return [];
+      listCache = [];
     }
+    return listCache;
   }
 
   // BET-1464 defect 3: every watchers.json write routes through patchStore —
@@ -502,13 +535,18 @@ export function createStandingQueryEngine(deps = {}) {
   // derived from a stale snapshot (a hit's accounting, a tick's retirement,
   // a registration) can no longer erase a concurrent writer's row. The
   // mutator derives its next list from the FRESH payload and returns an
-  // empty patch to mean "no change, no save".
+  // empty patch to mean "no change, no save". The post-patch hook keeps the
+  // list cache coherent: whatever the store now holds is the list future
+  // evaluations match against.
   function patchWatchers(mutate) {
     return patchStore(store, (fresh) => {
       const all = Array.isArray(fresh?.watchers) ? fresh.watchers : [];
       const patch = mutate(all);
       if (!patch) return {};
       return { watchers: patch };
+    }).then((saved) => {
+      if (saved && Array.isArray(saved?.watchers)) listCache = saved.watchers;
+      return saved;
     });
   }
 
@@ -610,11 +648,15 @@ export function createStandingQueryEngine(deps = {}) {
     }
     // Retirement is cheap to run here too (once per tick). Under the store
     // mutex from the FRESH list (BET-1464 defect 3) — the `all` snapshot read
-    // at tick start may already be stale by the time retirement lands.
+    // at tick start may already be stale by the time retirement lands. The
+    // same pass drops retired rows older than the retention bound (BET-1466:
+    // `retireWatchers` only ever adds the flag, so retired rows used to
+    // accumulate forever).
     try {
       await patchWatchers((freshAll) => {
         const { next, retired } = retireWatchers(freshAll, { nowMs: t, archivedSignatures });
-        return retired.length > 0 ? next : null;
+        const { next: pruned, dropped } = pruneRetiredWatchers(next, { nowMs: t });
+        return retired.length > 0 || dropped.length > 0 ? pruned : null;
       });
     } catch {
       /* best-effort */
@@ -664,7 +706,16 @@ export function createStandingQueryEngine(deps = {}) {
   }
 
   async function list() {
-    return (await loadAll()).map((w) => ({
+    // The user-facing read: always fresh (rare, and its freshness is the
+    // point) — the cache exists for the per-event evaluation burst only.
+    let all = [];
+    try {
+      const payload = await store.load();
+      all = Array.isArray(payload?.watchers) ? payload.watchers : [];
+    } catch {
+      all = [];
+    }
+    return all.map((w) => ({
       id: w.id,
       patternSignature: w.patternSignature,
       predicate: w.predicate,

--- a/src/server/ctoWatchers.test.mjs
+++ b/src/server/ctoWatchers.test.mjs
@@ -30,8 +30,10 @@ import {
   extractRecurringThemes,
   watcherHitPayload,
   collectWatcherHitsFromLedger,
+  pruneRetiredWatchers,
   createStandingQueryEngine,
 } from "./ctoWatchers.mjs";
+import { RETENTION_MS } from "./ctoStores.mjs";
 import { NOTIFY_RECURRENCE_KINDS, collectFindings } from "./ctoSuggest.mjs";
 
 function makeEngineDeps(overrides = {}) {
@@ -204,6 +206,83 @@ test("retireWatchers retires inactive watchers and archived signatures", () => {
   assert.deepEqual(retired.map((r) => r.id).sort(), ["w1", "w3"]);
   assert.equal(retired.find((r) => r.id === "w3").reason, "archived");
   assert.equal(next.find((w) => w.id === "w1").retired, true);
+});
+
+// BET-1466 item 1: retired rows used to accumulate forever — the tick now
+// drops them past the day-rollup retention bound.
+test("pruneRetiredWatchers drops retired rows past the day-rollup retention, keeps the rest", () => {
+  const nowMs = 3_000_000_000_000;
+  const retention = RETENTION_MS["rollups/day"];
+  const list = [
+    { id: "old", retired: true, retiredAt: nowMs - retention - 1, patternSignature: "s-old" },
+    { id: "edge", retired: true, retiredAt: nowMs - retention, patternSignature: "s-edge" }, // exactly at the bound → kept
+    { id: "fresh", retired: true, retiredAt: nowMs - 1_000, patternSignature: "s-fresh" },
+    { id: "active", retired: false, patternSignature: "s-live" },
+    { id: "no-ts", retired: true, patternSignature: "s-nots" }, // malformed — defensive keep
+  ];
+  const { next, dropped } = pruneRetiredWatchers(list, { nowMs });
+  assert.deepEqual(next.map((w) => w.id).sort(), ["active", "edge", "fresh", "no-ts"]);
+  assert.deepEqual(dropped, [{ id: "old", patternSignature: "s-old" }]);
+});
+
+test("runTick drops retired rows past the retention bound from the store (BET-1466 item 1)", async () => {
+  const state = { watchers: [] };
+  const deps = makeEngineDeps({
+    store: {
+      load: async () => state,
+      save: async (p) => {
+        state.watchers = p.watchers;
+      },
+    },
+  });
+  const eng = createStandingQueryEngine(deps);
+  await eng.register({ predicate: { kind: EVENT_PATTERN, params: { pattern: "boom" } } });
+  await eng.register({ predicate: { kind: EVENT_PATTERN, params: { pattern: "calm" } } });
+  const retention = RETENTION_MS["rollups/day"];
+  const t = 3_000_000_000_000;
+  // Age one watcher's retirement past the bound and leave the other fresh.
+  state.watchers[0].retired = true;
+  state.watchers[0].retiredAt = t - retention - 1;
+  state.watchers[1].retired = true;
+  state.watchers[1].retiredAt = t - 1_000;
+  // A later tick (far future) runs the same retirement+prune pass.
+  const agedEng = createStandingQueryEngine({ ...deps, now: () => t });
+  await agedEng.runTick();
+  // Only the fresh-retired row survives; the past-bound one is gone.
+  assert.equal(state.watchers.length, 1);
+  assert.equal(state.watchers[0].retired, true);
+  assert.equal(state.watchers[0].retiredAt, t - 1_000);
+  // Idempotent: a second tick drops nothing further.
+  await agedEng.runTick();
+  assert.equal(state.watchers.length, 1);
+});
+
+test("engine list reads are fresh but per-event evaluation reads the file once per burst (BET-1466 item 1b)", async () => {
+  let loads = 0;
+  const deps = makeEngineDeps();
+  deps.store = {
+    load: async () => {
+      loads += 1;
+      return { watchers: deps.savedWatchers ?? [] };
+    },
+    save: async (p) => {
+      deps.savedWatchers = p.watchers;
+    },
+  };
+  const eng = createStandingQueryEngine(deps);
+  await eng.register({ predicate: { kind: EVENT_PATTERN, params: { pattern: "boom" } } });
+  const loadsAfterRegister = loads;
+  // A burst of evidence events: one file read total (the cache from the burst's
+  // first evaluation is reused; the register's own write refreshed it).
+  await eng.evaluateEvent({ text: "nothing", kind: "prompt" });
+  await eng.evaluateEvent({ text: "still nothing", kind: "prompt" });
+  await eng.evaluateEvent({ text: "quiet", kind: "tool" });
+  assert.equal(loads, loadsAfterRegister, "the burst reuses one read; no per-event file reads");
+  assert.equal(deps.ledgerRows.filter((r) => r.kind === "watcher.hit").length, 0);
+  // list() stays a fresh read (user-facing surface).
+  const list = await eng.list();
+  assert.equal(list.length, 1);
+  assert.equal(loads > loadsAfterRegister, true);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements all 8 items of the CTO stage-3A data-durability batch (BET-1466, §14.5/§14.6 durability + §4.3/§11/§9 items):

1. **ctoWatchers** — retired rows no longer accumulate forever: `runTick` drops them past the day-rollup retention (`RETENTION_MS["rollups/day"]` reused; no new constant), via a new exported pure `pruneRetiredWatchers` wired into the existing retirement patch (save only on change). The per-evidence-event file re-read is gone: the watchers list is read once per burst and the cache is refreshed directly from every `patchWatchers` save; the user-facing `list()` still reads fresh.
2. **ctoOvernight** — the `no-candidates` ledger row is stamped with its trough (`lastNoCandidatesTroughStartMs`, same expiry semantics as the veto stamp): one row per trough, not one per tick. The window save is skipped when the normalized state is unchanged beyond `lastEvaluatedMs` — except the very first persist, which lays the window row down (it is the liveness marker `readWindow()` consumers key on; found by the BET-1419 integration tests).
3. **ctoEngine** — `overnightTick` reads the ledger with a 24h lower bound (`ledger.read({ from: t - 24 * HOUR_MS })`) instead of the whole 180-day file; the in-memory re-filter is deleted.
4. **ctoBudget** — `recordSpend` now bounds growth inside the only writer that adds buckets: day buckets older than the burn-history window (nothing reads them) and ROI months older than the retention horizon are dropped. `budget.json` is not covered by the store sweep.
5. **ctoBudget** — the pending-row retention predicate is inverted: uncounted (never-merged) rows — the ones that actually accumulate — now age out at `ROI_PENDING_RETENTION_MS`; counted rows keep the existing horizon rule (safe: the delegate jobs store sweeps terminal records after 7 days, far inside the 60-day horizon, so a dropped counted row is never re-sampled).
6. **ctoFacts** — `saveState` reports success/failure instead of swallowing, and `submitProposal` returns `{ ok: false, error }` when the persist failed instead of a phantom ok (the enqueue exists only in the discarded in-memory state at that point).
7. **ctoEngine** — deleted the duplicate `get cards()` object-literal key (the later twin silently shadowed the first); `dispose()` now actually unregisters the four verdict counter sinks (the registration comment claimed this; it was false).
8. **ctoBackfill** — deleted the dead config-key lookups (`ctoBackfillCapUsd` / `ctoBackfillDays` — spellings written by no UI, doc, or code path); only the explicit engine override or the fallback constants resolve cap/depth now. `cfgNum` (then unused) removed; stale header comment corrected.

**No new constants introduced** — every bound reuses an existing one (`RETENTION_MS["rollups/day"]`, `BURN_HISTORY_DAYS`, `ROI_PENDING_RETENTION_MS`, `DEFAULT_BACKFILL_*`, `24 * HOUR_MS`).

## Tests

One test per numbered item (item 1: three — pure prune, runTick drop, burst read-count; item 7: two — source-level single-declaration + sink unregistration against a live engine with post-dispose verdicts). The pre-existing "pending rows past the retention horizon" test was updated to pin the corrected semantics (it pinned the old keep-forever behavior). Full suite: 3761 pass / 0 fail (base: 3750/0).

## Cross-cutting notes

- **Item 2 consequence (spec-prescribed):** with day buckets pruned to the 7-day burn-history window, `monthSpendUsd` for the current ROI month reads only the trailing ~7 days once a month is older than that. The ambient cap enforcement is unaffected (it reads today's bucket); the ROI report's monthly spend figure degrades by design per the issue's prescription. Follow-up filed: BET-1473 (edge where a box down >7 days across a month close recomputes the closed month from pruned buckets).
- Pre-existing (observed, out of scope): `pending.slice(-200)` can drop a counted row while its job is still in the jobs store (>200 counted CTO jobs within the 7-day sweep window) — re-sampling would double-count. The new retention filter shrinks the exposure. Parked: BET-1474.

Base: origin/main @ 41d4db1d
