### PR TITLE
fix(renderer): stop CloneFromGitHub tests leaking async past teardown (BET-1479)

### DIFF
--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -89,6 +89,12 @@ function mountPicker(overrides: MountOverrides = {}): void {
     />,
   );
   container = h.container;
+  // Wire the harness root into the module-level `root` so unmount() (test
+  // bodies + afterEach) really unmounts. Without this the unmount was a
+  // silent no-op for mountPicker-based tests: the component's effects never
+  // cleaned up and a mid-flight clone-poll loop kept running past teardown
+  // (BET-1479).
+  root = h.root;
 }
 
 async function flushMicro(): Promise<void> {
@@ -150,8 +156,22 @@ afterEach(() => {
 });
 
 describe("CloneFromGitHub picker", () => {
+  // NOTE (BET-1479): this file mounts real-timer async loops (the clone-poll
+  // chain awaits `setTimeout(…, 500)` between polls). A test that finishes
+  // with one of those loops mid-flight is the only way this file can leak
+  // async work past teardown — guarded today by the effect's `cancelled`
+  // flag, but one weakened guard away from polluting the next test. So every
+  // test whose clone start SUCCEEDS drives the poll loop to a TERMINAL state
+  // (done) inside the test, and the cancellation contract itself is pinned
+  // explicitly by the unmount-mid-clone test below.
   it("keeps a checked repo selected when the search term excludes it, and clones it on submit", async () => {
-    mountPicker();
+    mountPicker({
+      // The submit assertions only read forgeCloneStart; resolving the poll
+      // done here (instead of returning an in-progress clone) keeps the
+      // component's 500ms real-timer poll loop from outliving the test.
+      forgeCloneStatus: () =>
+        Promise.resolve({ ...CLONE_IN_PROGRESS, done: true, ok: true, percent: 100 }),
+    });
     await flushMicro();
 
     clickCheckbox(h!, "Clone alpha");
@@ -176,6 +196,54 @@ describe("CloneFromGitHub picker", () => {
     expect(startCalls.length).toBe(1);
     // The clone runs for the still-selected (but filtered-out) repo.
     expect(startCalls[0][0]).toMatchObject({ url: REPOS[0].cloneUrl });
+  });
+
+  it("stops polling and cancels the job when unmounted mid-clone (no async past teardown, BET-1479)", async () => {
+    // Pins the cancellation contract that keeps this file free of post-test
+    // async: the clone-poll loop must stop issuing status polls once the
+    // picker unmounts, and the in-flight job gets an explicit cancel. If the
+    // effect's `cancelled` guard is ever weakened, polls continue after
+    // teardown and fire into whatever test runs next — the classic source of
+    // cross-test flake (polls attributed to an unrelated test, act warnings
+    // after the file finished). Fake timers make the 500ms poll interval
+    // deterministic.
+    vi.useFakeTimers();
+    let pollCalls = 0;
+    mountPicker({
+      forgeCloneStatus: () => {
+        pollCalls++;
+        return Promise.resolve(CLONE_IN_PROGRESS);
+      },
+    });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    clickCheckbox(h!, "Clone alpha");
+    act(() => {
+      cloneButtonFor("1 selected").click();
+    });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // The loop is live: exactly one start and one status poll so far (the
+    // next poll is scheduled 500ms out, still pending under fake timers).
+    expect((api.calls.forgeCloneStart ?? []).length).toBe(1);
+    expect(pollCalls).toBe(1);
+
+    unmount();
+
+    // The pending 500ms poll timer fires under advanceTimersByTime, but its
+    // await resumes on a microtask — drain it, then confirm the cancelled
+    // loop exited without polling again. The unmount cleanup also issued the
+    // explicit cancel for the in-flight job, exactly once.
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    await flushMicrotasks();
+    expect(pollCalls).toBe(1);
+    const cancelCalls = api.calls.forgeCloneCancel ?? [];
+    expect(cancelCalls.length).toBe(1);
+    expect(cancelCalls[0][0]).toMatchObject({ id: "c1" });
   });
 
   it("puts the repo rows in an overflow-y-auto container that excludes the button row", async () => {


### PR DESCRIPTION
## Root cause

`mountPicker` in `src/renderer/CloneFromGitHub.test.tsx` never wired the harness `root` into the module-level `root` variable used by `unmount()`/afterEach. Every picker-based test's `unmount()` was therefore a **silent no-op on the React tree**: effects never cleaned up, and the original test 1 ("keeps a checked repo selected…") finished with the component's clone-poll loop still live — a 500ms `setTimeout` chain polling `forgeCloneStatus` forever (its mock returned a never-done in-progress clone).

That leaked loop is the one mechanism by which this file can redden CI: after the file's tests pass, the leaked timer chain races vitest's environment teardown and can surface as a worker-level unhandled error *after* all tests are green — no assertion fingerprint, red attributed to the file on unrelated PRs. That matches the reviewer's observation (red seen, no stable fingerprint).

## Repro evidence

- 67 consecutive file-only runs pre-fix (30 isolated + 12 under concurrent full-suite CPU load + 25 after hardening): 0 failures — the leak is deterministic, the red is the rare teardown race, which is why it never reproduced in a stable repro.
- Fingerprint hunt across ~300 CI runs (Aug 22–31, all 125 failures + all 34 `typecheck-test` reds): **zero** failures in this file. The nearby reds were `ctoEngine.overnight` (node:test, time-dependent), `demoCoverage`/`tailwindScale`/`ctoView`/`primitives` inventory drifts, and the duplication-gate. In failed `typecheck-test` logs, vitest prints `✓ src/renderer/CloneFromGitHub.test.tsx (10 tests)` immediately above the `Not implemented: HTMLCanvasElement.prototype.getContext` xterm noise — a plausible source of the misattribution.

## Changes (test file only, no skips/deletes)

1. `mountPicker` now assigns `root = h.root` so `unmount()` really unmounts — cleanup runs, poll loops die, in-flight clone jobs get `forgeCloneCancel`.
2. Test 1 resolves its poll `done` so the loop reaches a terminal state inside the test; a NOTE documents the file's no-leaked-async contract.
3. New pin test: unmount mid-clone stops polling and cancels the job (fake timers). **Verified it fails without the root-wiring fix** (cancel count 0) and passes with it.

## Verification results

**Files changed:** 1 file. `src/renderer/CloneFromGitHub.test.tsx` (+69 −1)

- PR branch (`multica/BET-1479-clonefromgithub-flaky-test` @ `8b23e800`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3885 vitest pass / 0 fail (198 files) + node:test 3775 pass / 0 fail. Failures: none. log sha256: `4e1bd959647b4826a92cbba101da65172ec84b352eb6abfaa4d0c6f9ca293be2`
- Base (`main` @ `626b1e39`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3884 vitest pass / 0 fail + node:test 3775 pass / 0 fail. Failures: none. log sha256: `dbbbabce605a62c7439cb410a8c9b9c536a57eb7cfa66a8c70bead7984ee2684`
- **Conclusion:** 0 new failures, 0 pre-existing failures; +1 test (the cancellation pin).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Base: origin/main @ 626b1e39
