### PR TITLE
CTO tests: full store injection + sandbox fail-fast (BET-1469)

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -55,7 +55,13 @@ import {
   verdictsStore,
   watchersStore,
   factsArchiveStore,
+  factsStore,
   probeStateStore,
+  profileStore,
+  journalStore,
+  toolRegistryStore,
+  toolUsageStore,
+  budgetStore,
   patchEngineState,
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
@@ -270,10 +276,13 @@ export function computeDot({ enabled, paused, thrifty }) {
 // cards schema (BET-1382): an open card (state === "open") is a needs-you item;
 // resolved/dismissed cards have already moved off cards.json into the ledger.
 // Defensive — a malformed or missing store yields zeros, never a throw.
-export async function defaultGetCounts() {
+// BET-1469: the cards store is injectable so a test can exercise the counting
+// logic without writing the real cards.json (the engine's own default passes
+// the bundle's cards store; the standalone default stays the real one).
+export async function defaultGetCounts(cardStore = cardsStore) {
   let needsYouCount = 0;
   try {
-    const cards = await cardsStore.load();
+    const cards = await cardStore.load();
     const arr = Array.isArray(cards?.cards) ? cards.cards : [];
     needsYouCount = arr.filter((c) => c && c.state === "open").length;
   } catch {
@@ -287,20 +296,53 @@ export async function defaultGetCounts() {
 // ---------------------------------------------------------------------------
 
 export function createCtoEngine(deps = {}) {
+  // BET-1469: the one-line store bundle for tests. Every key replaces that
+  // real store for the WHOLE engine — including every sub-engine constructed
+  // lazily below — so a test harness can go fully hermetic in one line
+  // (`stores: fakeStores()`) instead of threading ~13 individual deps (the
+  // gap that let fixtures leak into the live cards.json). Resolution order:
+  // an explicitly passed individual dep (ledger, engineState, …) wins, then a
+  // bundle entry, then the real store. Production passes nothing here and
+  // gets exactly the real bundle it always had. Note the bundle carries
+  // STORES, not engines: `rollups` is the rollup STORE (the top-level
+  // `rollups` dep remains the pre-built runner), and `cards` is the cards.json
+  // store (the top-level `cards` dep remains the cards manager).
+  const bundle = {
+    ledger: ledgerStore,
+    engineState: engineStateStore,
+    trust: trustStore,
+    cards: cardsStore,
+    inbox: inboxStore,
+    verdicts: verdictsStore,
+    budget: budgetStore,
+    watchers: watchersStore,
+    toolRegistry: toolRegistryStore,
+    toolUsage: toolUsageStore,
+    probeState: probeStateStore,
+    segments: segmentsStore,
+    rollups: rollupsStore,
+    facts: factsStore,
+    factsArchive: factsArchiveStore,
+    profile: profileStore,
+    journal: journalStore,
+    ...deps.stores,
+  };
   const {
     configGet = async () => ({}), // → { ctoEnabled?: boolean }
-    ledger = ledgerStore, // A1 ledger writer { append }
-    engineState = engineStateStore, // { load, save } (engine-state.json)
+    ledger = bundle.ledger, // A1 ledger writer { append }
+    engineState = bundle.engineState, // { load, save } (engine-state.json)
     // BET-1403: the trust ladder's own file — isolated from engine-state
     // writers so no snapshot-spread save can revert tiers/counters/pending.
-    trustStore: trustStoreDep = trustStore,
+    trustStore: trustStoreDep = bundle.trust,
     killSwitch = createKillSwitch(),
     publish = () => {}, // (evt: {kind:"ctoState", payload}) => void
     now = () => Date.now(),
     rates: rateLimits = RATE_LIMITS,
     tickIntervalMs = TICK_INTERVAL_MS,
     cardCheckIntervalMs = CARD_CHECK_INTERVAL_MS,
-    getCounts = defaultGetCounts,
+    // BET-1469: default counts read the BUNDLE's cards store, so a bundle-only
+    // harness never binds the real cards.json through this path either.
+    getCounts: getCountsDep = null,
     track = createRateTracker({ now }),
     // BET-1382 needs-you card machinery (blocker cards). Defaults to the real
     // stores; tests inject a fake. Cards are about the user's own blockers,
@@ -318,6 +360,7 @@ export function createCtoEngine(deps = {}) {
     // itself — same seam pattern as getSessionInfo/getDesktopPresence.
     cards = createCtoCards({
       fireNotify: cardFireNotify,
+      cardStore: bundle.cards,
       engineState,
       patchEngineState: (mutation) => patchEngineState(mutation, { engineState }),
     }),
@@ -365,13 +408,13 @@ export function createCtoEngine(deps = {}) {
     // BET-1391 verdict ledger (§9.5): optional pre-built verdicts store (else
     // the shared `verdicts.json` store). The verdict engine + facts sink are
     // constructed below from it.
-    verdicts = verdictsStore,
+    verdicts = bundle.verdicts,
     // BET-1388 economics (§10.6-6/§12.1/§12.2/§13.3): the ambient-spend budget
     // accessor (defaults to the real budget.json store via createCtoBudget).
     // beginEphemeral consults it for the independent HARD CAP before every
     // ambient model call; reportAmbientSpend records each run's spend and flips
     // thrifty when the cap is crossed. `tier` is the A12 dial (default low).
-    budget = createCtoBudget(),
+    budget = createCtoBudget({ store: bundle.budget }),
     tierGet = async () => "low",
     // BET-1398 standing-query watchers (§4.3/§13.4): optional pre-built
     // watcher engine (else one is constructed below from watchersStore/ledger/
@@ -404,6 +447,11 @@ export function createCtoEngine(deps = {}) {
     toolsRunEphemeral = null,
     toolsGetSurfaces = null,
   } = deps;
+
+  // BET-1469: the default counts producer binds the bundle's cards store (an
+  // injected `getCounts` dep still wins), so `getState()` in a bundle-only
+  // harness never reads the real cards.json.
+  const getCounts = getCountsDep ?? (() => defaultGetCounts(bundle.cards));
 
   let disposed = false;
   let thrifty = false;
@@ -959,7 +1007,7 @@ export function createCtoEngine(deps = {}) {
   // tick, and the segment-summary atom feed (via the segmenter's onSummary).
   function getProfile() {
     if (profileEngine) return profileEngine;
-    profileEngine = deps.profile ?? createCtoProfile({ now });
+    profileEngine = deps.profile ?? createCtoProfile({ now, store: bundle.profile });
     return profileEngine;
   }
 
@@ -969,7 +1017,7 @@ export function createCtoEngine(deps = {}) {
   // exposes it for the render-model read under Settings → Internals.
   function getJournal() {
     if (journalEngine) return journalEngine;
-    journalEngine = deps.journal ?? createCtoJournal({});
+    journalEngine = deps.journal ?? createCtoJournal({ store: bundle.journal });
     return journalEngine;
   }
 
@@ -988,6 +1036,8 @@ export function createCtoEngine(deps = {}) {
       ledger,
       runEphemeral: runEphemeral ? gatedRunEphemeral : null,
       now,
+      facts: bundle.facts,
+      archive: bundle.factsArchive,
       presenceCheck: () => engine.getPresence().state === "present",
       surfaceExists: factSurfaceExists,
       verify: factVerify,
@@ -1068,7 +1118,7 @@ export function createCtoEngine(deps = {}) {
   function getWatchers() {
     if (watcherEngine) return watcherEngine;
     watcherEngine = watchers ?? createStandingQueryEngine({
-      store: watchersStore,
+      store: bundle.watchers,
       ledger,
       engineState,
       now,
@@ -1103,6 +1153,8 @@ export function createCtoEngine(deps = {}) {
     toolEngine =
       tools ??
       createToolRegistry({
+        registryStore: bundle.toolRegistry,
+        usageStore: bundle.toolUsage,
         cards,
         ledger,
         now,
@@ -1131,7 +1183,7 @@ export function createCtoEngine(deps = {}) {
     if (!toolEngine) return null;
     probesEngine = createProbes({
       registry: toolEngine,
-      stateStore: probeStateStore,
+      stateStore: bundle.probeState,
       cards,
       ledger,
       now,
@@ -1153,7 +1205,7 @@ export function createCtoEngine(deps = {}) {
   // the facts-only fallback.
   async function resolveSegmentProject(id) {
     try {
-      const s = await segmentsStore.load(id);
+      const s = await bundle.segments.load(id);
       return s && s.project ? { project: s.project } : null;
     } catch {
       return null;
@@ -1213,7 +1265,7 @@ export function createCtoEngine(deps = {}) {
     const since = now() - windowDays * 24 * HOUR_MS;
     let names = [];
     try {
-      names = await fsp.readdir(rollupsStore.dirFor("day"));
+      names = await fsp.readdir(bundle.rollups.dirFor("day"));
     } catch {
       return [];
     }
@@ -1222,7 +1274,7 @@ export function createCtoEngine(deps = {}) {
       if (!name.endsWith(".json")) continue;
       let r;
       try {
-        r = await rollupsStore.load("day", name.slice(0, -5));
+        r = await bundle.rollups.load("day", name.slice(0, -5));
       } catch {
         continue;
       }
@@ -1240,7 +1292,7 @@ export function createCtoEngine(deps = {}) {
   async function archivedWatcherSignatures() {
     const out = new Set();
     try {
-      const dir = factsArchiveStore.dir;
+      const dir = bundle.factsArchive.dir;
       let names = [];
       if (typeof dir === "string" && dir) {
         names = (await fsp.readdir(dir).catch(() => [])) ?? [];
@@ -1249,7 +1301,7 @@ export function createCtoEngine(deps = {}) {
         const project = String(name).endsWith(".json") ? String(name).slice(0, -5) : String(name);
         let p;
         try {
-          p = await factsArchiveStore.load(project);
+          p = await bundle.factsArchive.load(project);
         } catch {
           continue;
         }
@@ -2004,8 +2056,8 @@ export function createCtoEngine(deps = {}) {
       configGet,
       engineState,
       ledger,
-      segments: segmentsStore,
-      rollups: rollupsStore,
+      segments: bundle.segments,
+      rollups: bundle.rollups,
       summarize, // raw seam — the backfill owns its own budget, no rate gate
       computeOneLiner,
       runEphemeral: backfillRunEphemeral,
@@ -2036,7 +2088,7 @@ export function createCtoEngine(deps = {}) {
   // expired entries are dropped (`purgeExpiredInbox`) with no trace.
   async function drainInbox() {
     try {
-      const store = inbox ?? inboxStore;
+      const store = inbox ?? bundle.inbox;
       const payload = await store.load();
       const entries = Array.isArray(payload?.entries) ? payload.entries : [];
       if (entries.length === 0) return { drained: 0 };

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
@@ -21,6 +35,64 @@ import { windowFor } from "./ctoRollups.mjs";
 // clock we can advance. Everything the engine touches goes through these
 // seams, so the tests assert pure behavior. `clock` is shared so the watchdog
 // and the engine observe the same time.
+//
+// BET-1469: the store bundle is injected too, so even the paths this harness
+// does not exercise bind memory instead of real files — an enabled tick
+// (watchers/tools/probes/rollups/backfill) can no longer reach the live box
+// state through a lazily-constructed sub-engine.
+// BET-1469: one in-memory replacement per real CTO store — the full `stores`
+// bundle createCtoEngine accepts. Shapes mirror the real stores: json stores
+// are single-payload { load, save }; dir stores are one-payload-per-id
+// { load(id), save(id, data) } over a Map; the rollups store namespaces by
+// level. No fs anywhere: `dir` is "" so the engine's readdir fall-throughs
+// short-circuit, and pathFor is identity.
+function makeMemoryStores() {
+  const jsonStore = (initial) => {
+    let payload = { ...initial };
+    return {
+      load: async () => ({ ...payload }),
+      save: async (p) => {
+        payload = { ...p };
+      },
+    };
+  };
+  const dirStore = () => {
+    const map = new Map();
+    return {
+      dir: "",
+      pathFor: (id) => id,
+      load: async (id) => map.get(id) ?? { v: 1 },
+      save: async (id, data) => {
+        map.set(id, data);
+      },
+    };
+  };
+  return {
+    ledger: { append: async () => true },
+    engineState: jsonStore({ v: 1 }),
+    trust: jsonStore({}),
+    cards: jsonStore({ v: 1, cards: [] }),
+    inbox: jsonStore({ v: 1, entries: [] }),
+    verdicts: jsonStore({ entries: [] }),
+    budget: jsonStore({}),
+    watchers: jsonStore({ watchers: [] }),
+    toolRegistry: jsonStore({ tools: [] }),
+    toolUsage: jsonStore({}),
+    probeState: dirStore(),
+    segments: dirStore(),
+    rollups: {
+      dir: "",
+      dirFor: (level) => `mem://rollups/${level}`,
+      load: async () => ({ v: 1 }),
+      save: async () => {},
+    },
+    facts: dirStore(),
+    factsArchive: dirStore(),
+    profile: jsonStore({}),
+    journal: jsonStore({ entries: [] }),
+  };
+}
+
 function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts } = {}) {
   const clock = { ms: 1_000_000 };
   const now = () => clock.ms;
@@ -32,10 +104,12 @@ function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts } = {}) {
   const cardCalls = [];
   const state = { v: 1, pendingBlockers: [] };
   const budgetCfg = { budgetIsHit: false, tier: "low" };
+  const memStores = makeMemoryStores();
+  memStores.ledger.append = async (row) => ledgerRows.push(row);
 
   const engine = createCtoEngine({
     configGet: async () => ({ ...currentConfig }),
-    ledger: { append: async (row) => ledgerRows.push(row) },
+    stores: memStores,
     cards: {
       onAskStart: (...a) => (cardCalls.push({ fn: "onAskStart", args: a }), Promise.resolve()),
       onAskResolved: (...a) => (
@@ -535,16 +609,25 @@ test("resume() clears health-escalation blocker cards (health recovered)", async
   assert.ok(h.cardCalls.some((c) => c.fn === "onHealthRecovered"));
 });
 
-test("defaultGetCounts counts open cards from the real cards store", async () => {
+test("defaultGetCounts counts open cards from an injected cards store (BET-1469)", async () => {
   const { defaultGetCounts } = await import("./ctoEngine.mjs");
-  const { cardsStore } = await import("./ctoStores.mjs");
-  // The real cards store resolves under the test-sandbox state home; write a
-  // card there and confirm it is counted only while open.
-  await cardsStore.save({ v: 1, cards: [
-    { id: "a", state: "open" },
-    { id: "b", state: "resolved" },
-  ] });
-  assert.deepEqual(await defaultGetCounts(), {
+  // The counting logic needs no real store: the cards store is injectable, so
+  // this test no longer writes cards.json (sandboxed or otherwise).
+  let payload = {
+    v: 1,
+    cards: [
+      { id: "a", state: "open" },
+      { id: "b", state: "resolved" },
+    ],
+  };
+  const cardStore = {
+    name: "cards",
+    load: async () => payload,
+    save: async (p) => {
+      payload = p;
+    },
+  };
+  assert.deepEqual(await defaultGetCounts(cardStore), {
     needsYouCount: 1,
     generationInFlight: false,
     tonightCount: 0,
@@ -589,6 +672,7 @@ function makeSegEngine({ owner } = {}) {
   });
   const engine = createCtoEngine({
     configGet: async () => ({ ctoEnabled: false }),
+    stores: makeMemoryStores(),
     ledger: { append: async () => {} },
     engineState: { load: async () => ({ v: 1, pendingBlockers: [] }), save: async () => {} },
     publish: () => {},
@@ -843,6 +927,7 @@ test("drainInbox folds unread notes into high-salience B1-weighted evidence and 
 
   const engine = createCtoEngine({
     configGet: async () => ({ ctoEnabled: true }),
+    stores: makeMemoryStores(),
     ledger: { append: async (row) => ledgerRows.push(row) },
     engineState: { load: async () => ({ v: 1, entries: [] }), save: async () => {} },
     cards: {},
@@ -893,6 +978,7 @@ test("overnightTick reads the ledger with a 24h lower bound instead of the whole
   const readCalls = [];
   const engine = createCtoEngine({
     configGet: async () => ({ ctoEnabled: true, ctoOvernight: true }),
+    stores: makeMemoryStores(),
     ledger: {
       append: async () => {},
       read: async (opts) => {
@@ -923,6 +1009,7 @@ test("dispose unregisters the verdict counter sinks (BET-1466 item 7)", async ()
   let verdictsState = { entries: [] };
   const engine = createCtoEngine({
     configGet: async () => ({ ctoEnabled: true }),
+    stores: makeMemoryStores(),
     ledger: { append: async () => {} },
     engineState: {
       load: async () => esState,

--- a/src/server/ctoEvidence.test.mjs
+++ b/src/server/ctoEvidence.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
@@ -10,14 +24,68 @@ import {
 } from "./ctoEvidence.mjs";
 import { createCtoEngine } from "./ctoEngine.mjs";
 
+// BET-1469: the in-memory `stores` bundle handed to the engine so its default
+// sub-engine constructions (cards/trust/verdicts/watchers/probes/segments/
+// rollups/facts/profile/journal/budget) all bind memory, never real files.
+// Shapes mirror ctoStores.mjs: json stores are { load, save }; dir stores are
+// { load(id), save(id, data) } over a Map; rollups namespaces by level.
+function makeMemoryStores() {
+  const jsonStore = (initial) => {
+    let payload = { ...initial };
+    return {
+      load: async () => ({ ...payload }),
+      save: async (p) => {
+        payload = { ...p };
+      },
+    };
+  };
+  const dirStore = () => {
+    const map = new Map();
+    return {
+      dir: "",
+      pathFor: (id) => id,
+      load: async (id) => map.get(id) ?? { v: 1 },
+      save: async (id, data) => {
+        map.set(id, data);
+      },
+    };
+  };
+  return {
+    ledger: { append: async () => true },
+    engineState: jsonStore({ v: 1 }),
+    trust: jsonStore({}),
+    cards: jsonStore({ v: 1, cards: [] }),
+    inbox: jsonStore({ v: 1, entries: [] }),
+    verdicts: jsonStore({ entries: [] }),
+    budget: jsonStore({}),
+    watchers: jsonStore({ watchers: [] }),
+    toolRegistry: jsonStore({ tools: [] }),
+    toolUsage: jsonStore({}),
+    probeState: dirStore(),
+    segments: dirStore(),
+    rollups: {
+      dir: "",
+      dirFor: (level) => `mem://rollups/${level}`,
+      load: async () => ({ v: 1 }),
+      save: async () => {},
+    },
+    facts: dirStore(),
+    factsArchive: dirStore(),
+    profile: jsonStore({}),
+    journal: jsonStore({ entries: [] }),
+  };
+}
+
 // A tiny engine harness for the ingestion-level tests (dedupe, cto-exclusion).
-// Fully injected: no fs, no stores, a fake clock, resolved owner/project.
+// Fully injected: no fs, no real stores (the in-memory `stores` bundle covers
+// every store the engine's defaults bind), a fake clock, resolved owner/project.
 function makeHarness({ owner = "user", project = "proj" } = {}) {
   const ledgerRows = [];
   const clock = { ms: 1_000_000 };
+  const stores = makeMemoryStores();
+  stores.ledger.append = async (r) => ledgerRows.push(r);
   const engine = createCtoEngine({
-    ledger: { append: async (r) => ledgerRows.push(r) },
-    engineState: { load: async () => ({}), save: async () => {} },
+    stores,
     killSwitch: { isPaused: async () => false, pause: async () => {}, resume: async () => {} },
     publish: () => {},
     now: () => clock.ms,

--- a/src/server/ctoStores.test.mjs
+++ b/src/server/ctoStores.test.mjs
@@ -5,6 +5,21 @@
 // tmux/opencode/network; the only I/O is real fs against grand the sandboxed
 // cto root (every path goes through ctoPath() → statePath()).
 
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. This file writes the real module-level CTO stores
+// (they resolve under MANTA_STATE_HOME when sandboxed); imported unsandboxed
+// those paths resolve against the LIVE box state (~/.manta) and the tests
+// would write production data. `npm test` / `npm run test:server` set
+// MANTA_STATE_HOME via scripts/testSandbox.mjs before any module is evaluated;
+// a bare `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO store tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { homedir } from "node:os";
@@ -225,6 +240,12 @@ test("probes store round-trips YAML through the sandbox", async () => {
 // Sweep wiring (sandboxed fs)
 // ---------------------------------------------------------------------------
 
+// BET-1469 note: this is the only caller of sweepAllStores, and it exercises
+// the real module-level stores (sweepAllStores resolves ctoPath() directly —
+// it has no injection surface). Every one of those writes therefore lands in
+// the sandboxed CTO root, never the live box state — and the MANTA_STATE_HOME
+// guard at the top of this file makes an unsandboxed direct run of this file
+// impossible, so the "not the real state home" property cannot regress here.
 test("sweepAllStores trims the ledger and caps the archive (integration)", async () => {
   const nowMs = NOW_MS;
   const cutoff = nowMs - RETENTION_MS.ledger;

--- a/src/server/stateSandbox.test.mjs
+++ b/src/server/stateSandbox.test.mjs
@@ -23,6 +23,7 @@ import { stateHome, statePath } from "../shared/paths.mjs";
 import { STORE_PATH as AUTH_STORE_PATH } from "./auth.mjs";
 import { STORE_PATH as USAGE_STOP_STORE_PATH } from "./stoppedStore.mjs";
 import { STORE_PATH as MODEL_PREFS_STORE_PATH } from "./modelPrefs.mjs";
+import { cardsStore, ledgerStore } from "./ctoStores.mjs";
 
 test("the test run has a sandboxed state home", () => {
   const sandbox = process.env.MANTA_STATE_HOME;
@@ -60,4 +61,18 @@ test("store paths resolve inside the sandbox, not the live box", () => {
     `model-prefs store resolved to ${MODEL_PREFS_STORE_PATH}, outside the sandbox ${sandbox}`,
   );
   assert.ok(!MODEL_PREFS_STORE_PATH.startsWith(homedir() + sep + ".manta"));
+  // The CTO stores (BET-1469) — cards.json is the file the engine tests used
+  // to write through `defaultGetCounts()`, so pin it (and the ledger) the same
+  // way: any store module resolving to the live ~/.manta/cto/ root from a test
+  // re-opens the production-write hole for the whole Adaptive CTO suite.
+  for (const [label, path] of [
+    ["cto cards", cardsStore.path],
+    ["cto ledger", ledgerStore.path],
+  ]) {
+    assert.ok(
+      path.startsWith(sandbox + sep),
+      `${label} store resolved to ${path}, outside the sandbox ${sandbox}`,
+    );
+    assert.ok(!path.startsWith(homedir() + sep + ".manta"));
+  }
 });


### PR DESCRIPTION
## Summary

BET-1469: every CTO test now binds injected stores, never the live box state — and a direct, unsandboxed `node --test <file>` run fails loudly instead of silently writing `~/.manta/`.

- **Item 1** — the only CTO test that wrote live (sandboxed) state via `defaultGetCounts()` now injects a cards store (the function takes one, default unchanged); the `sweepAllStores` integration test was confirmed to write only sandboxed module stores (`ctoPath()` → sandbox), with the guard making an unsandboxed run of that file impossible (comment added at the test).
- **Item 2** — both harnesses re-expressed: `makeHarness` in `ctoEngine.test.mjs` and `ctoEvidence.test.mjs` inject the full in-memory store bundle (closes the false "fully injected" comment), so enabled ticks (watchers/tools/probes/rollups/backfill) bind memory, never files. The directly-constructed engines in both files (`makeSegEngine`, drainInbox, BET-1466 overnight + dispose tests) get the bundle one-line too.
- **Item 3** — `createCtoEngine` accepts a one-line `stores` bundle swapping every store it and its lazily-built sub-engines bind (cards, inbox, verdicts, budget, watchers, tool registry/usage, probe state, segments, rollups, facts, facts archive, profile, journal, trust). Explicit individual deps still win; production passes nothing and gets exactly the real bundle it always had. Bundle keys are STORES (`rollups` = rollup store, not the runner; `cards` = cards.json store, not the manager) — documented at the constructor.
- **Item 4** — fail-fast guard at the top of the three CTO test files in scope: `MANTA_STATE_HOME` unset → module-evaluation throw naming the correct command, before any test body runs (verified: direct run fails, `~/.manta/cto` checksum unchanged). The `stateSandbox` canary now also pins the CTO cards/ledger store paths into the sandbox.

## Files changed (5)

- `src/server/ctoEngine.mjs` — the `stores` bundle + injectable `defaultGetCounts` (item 3's parameter change)
- `src/server/ctoEngine.test.mjs` — guard, `makeMemoryStores()`, harness re-expression, injected-store counts test
- `src/server/ctoEvidence.test.mjs` — guard, bundle-injected harness
- `src/server/ctoStores.test.mjs` — guard + sweep-test sandbox confirmation comment
- `src/server/stateSandbox.test.mjs` — CTO cards/ledger store path canaries

## Verification results

- typecheck: exit 0, no errors.
- tests (`npm test`): 3786 pass / 0 fail / 0 skip.
- Empirical live-state check: the box's own live CTO server writes `~/.manta/cto/*.json` continuously (checksum changed over a 25s idle window with no tests running); running the three CTO test files changed nothing beyond that baseline (checksum identical before/after).
- Direct unsandboxed run: `node --test src/server/ctoEngine.test.mjs` → immediate loud failure naming `npm test` / `npm run test:server`, zero writes to `~/.manta/cto/` (md5 unchanged).

Base: origin/main @ 87ef019f
