### PR TITLE
fix(server): upsertConnect invalid-args return gains ok:false (BET-1481)

### DIFF
--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -715,7 +715,7 @@ export function createCtoCards(deps = {}) {
   // resolveConnectCards. No notification path — like decision cards, this is
   // a resting needs-you surface.
   async function upsertConnect({ toolId, title, body, evidence = [], refs = [], ring = "metadata", ts = now() } = {}) {
-    if (!toolId || typeof toolId !== "string") return { changed: false, isNew: false };
+    if (!toolId || typeof toolId !== "string") return { ok: false, changed: false, isNew: false };
     const deep = ring === "deep_read";
     const sourceId = deep ? `${toolId}:deep` : toolId;
     return upsertOpenCard({

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -569,6 +569,21 @@ test("upsertConnect: re-raising the same tool upserts in place (no dup)", async 
   assert.equal(open[0].title, "second");
 });
 
+// BET-1481: the invalid-args early return carries the same { ok:false } shape
+// as the other three card writers — a future caller branching on ok (the
+// BET-1477 contract) must not read undefined as truthy-success here.
+test("upsertConnect: refuses a missing/non-string toolId with ok:false", async () => {
+  const h = makeHarness();
+  const r = await h.cards.upsertConnect({ title: "no toolId" });
+  assert.equal(r.ok, false);
+  assert.equal(r.changed, false);
+  assert.equal(r.isNew, false);
+  const r2 = await h.cards.upsertConnect({ toolId: 42 });
+  assert.equal(r2.ok, false);
+  assert.equal(openCardCount(h), 0);
+  assert.ok(!h.ledgerRows.some((row) => row.kind === CARD_CREATED && row.variant === "connect"));
+});
+
 test("resolveConnectCards: resolves the open card for the tool and writes the ledger row", async () => {
   const h = makeHarness();
   await h.cards.upsertConnect({ toolId: "vercel", title: "t", refs: ["vercel"] });

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -266,44 +266,44 @@ test("BET-1463 defect 1: ingesting a pending blocker stamps the entry consumed; 
   assert.equal(h.ledgerRows.filter((r) => r.kind === CARD_CREATED).length, 1, "no second card.created row");
 });
 
-test("BET-1463 defect 1: resolving a health card removes its pendingBlockers entry, and a subsequent ingest does not recreate it (Resume regression)", async () => {
+// BET-1463 defect 1 shared setup: one tripped watchdog blocker, escalated
+// into its single open health card.
+async function escalatedHealthHarness() {
   const h = makeHarness({
     pendingBlockers: [{ id: "b1", source: "watchdog", reason: "ambient spend", ts: 500, resolved: false }],
   });
-
   await h.cards.ingestHealthEscalations();
   const cardId = h.store().cards.find((c) => c.state === "open").id;
+  return { h, cardId };
+}
+
+// The invariant both defect-1 teardown paths must hold: the entry itself is
+// GONE (not just marked resolved — otherwise a later card tick's ingest has
+// something to resurrect from) and a subsequent ingest cannot bring the
+// card back.
+async function assertNoResurrection(h) {
+  assert.equal(h.engineStateSnapshot().pendingBlockers.length, 0);
+  const r = await h.cards.ingestHealthEscalations();
+  assert.equal(r.changed, false);
+  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 0, "no resurrection on a later card tick");
+}
+
+test("BET-1463 defect 1: resolving a health card removes its pendingBlockers entry, and a subsequent ingest does not recreate it (Resume regression)", async () => {
+  const { h, cardId } = await escalatedHealthHarness();
   assert.equal(h.engineStateSnapshot().pendingBlockers.length, 1, "entry still present, just stamped consumed");
 
   // User presses Resume -> onHealthRecovered resolves the open health card.
   await h.cards.onHealthRecovered();
   assert.equal(h.store().cards.filter((c) => c.state === "open").length, 0);
-  // The regression this test guards: the entry itself must be GONE, not just
-  // marked resolved — otherwise the next card tick's ingest (via a NEW
-  // watchdog trip reusing state, or a stale resolved:false somehow) has
-  // nothing to resurrect from.
-  assert.equal(h.engineStateSnapshot().pendingBlockers.length, 0);
-
-  // A card tick after Resume must not bring the card back.
-  const r = await h.cards.ingestHealthEscalations();
-  assert.equal(r.changed, false);
-  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 0, "Resume actually works — no resurrection");
+  await assertNoResurrection(h);
   assert.equal(h.store().cards.find((c) => c.id === cardId), undefined);
 });
 
 test("BET-1463 defect 1: dismissing a health card also drops its pendingBlockers entry", async () => {
-  const h = makeHarness({
-    pendingBlockers: [{ id: "b1", source: "watchdog", reason: "ambient spend", ts: 500, resolved: false }],
-  });
-  await h.cards.ingestHealthEscalations();
-  const cardId = h.store().cards.find((c) => c.state === "open").id;
+  const { h, cardId } = await escalatedHealthHarness();
 
   await h.cards.dismissById(cardId, { reason: "user dismissed" });
-  assert.equal(h.engineStateSnapshot().pendingBlockers.length, 0);
-
-  const r = await h.cards.ingestHealthEscalations();
-  assert.equal(r.changed, false);
-  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 0);
+  await assertNoResurrection(h);
 });
 
 test("BET-1463 defect 2: a no-op re-upsert returns changed:false and appends no ledger row", async () => {


### PR DESCRIPTION
## Summary

BET-1481 (follow-up nit from BET-1477 review): `upsertConnect`'s invalid-args early return was `{ changed: false, isNew: false }` — the only card writer not carrying the BET-1477 `{ ok, changed, isNew }` contract. A future caller branching on `ok` (the pattern introduced in `ctoSuggest.mjs`) would read `undefined` as truthy-success on this path.

- `src/server/ctoCards.mjs`: the guard now returns `{ ok: false, changed: false, isNew: false }`, matching the other writers' invalid-args shape. One-line change.
- `src/server/ctoCards.test.mjs`: new test pins the invalid-args return (`ok:false` for missing AND non-string `toolId`, no card, no `CARD_CREATED` row).

Out of scope per the issue: no caller changes (`ctoSuggest.mjs`, `ctoToolRegistry.mjs` untouched — no caller reads the value today); no ignore-list edits.

**Base: origin/main @ c176d8a**

## Verification results

**Files changed:** 2 files. `src/server/ctoCards.mjs` (+1 −1), `src/server/ctoCards.test.mjs` (+37 −22: the new pin + a test-only dedupe, below).

- PR branch (`multica/BET-1481-upsertconnect-ok-false` @ 9bdbf6a1):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3787 pass / 0 fail / 0 skip. Failures: none. log sha256: `7c4a9b08ed7bbbbc3c779fef4b2ad4d4a8cffb3e71a81fa85ae13f15f808d322`
- Base (`main` @ c176d8a):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709` (identical output: both clean)
  - test: exit 0, 3786 pass / 0 fail / 0 skip. Failures: none.
- **Conclusion:** 0 failures on either branch; the single net-new passing test is the new BET-1481 pin.

### Second commit: test-only dedupe required by the duplication gate

The first push's CI `duplication-gate` failed with 2 intra-file clones in `ctoCards.test.mjs` — both PRE-EXISTING on `main` (the two BET-1463 defect-1 tests share a ≥70-token setup and no-resurrection tail), so ANY PR touching this file trips the gate. Per the gate's own remedy I extracted `escalatedHealthHarness` + `assertNoResurrection`; assertions preserved 1:1, no behavior change, gate now passes locally (`bash scripts/check-duplication-gate.sh origin/main` → PASS).

### Shallow-clone note (not a product issue)

On a shallow clone (`git clone --depth N`), `scripts/conformance-freshness.test.mjs` reports 15 false "STALE" failures on BOTH branches — the "Last reviewed" shas aren't present in truncated history. `git fetch --unshallow origin` resolves it. Follow-up filed to make that failure mode self-explanatory.
