### PR TITLE
CTO retention-sweep family writes through patchStore (BET-1482)

### DIFF
--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -580,12 +580,18 @@ export function purgeExpiredInbox(entries, { nowMs = Date.now(), expiresField = 
   return { keep, dropped };
 }
 
+// BET-1482: every sweep write is a patchStore read-filter-write section — the
+// whole-payload spread-save (`save({ ...payload, entries: keep })`) loaded its
+// snapshot OUTSIDE any mutex, so a sweep landing between another writer's load
+// and save (or racing a second sweep) could revert that writer's update. An
+// empty patch resolves to a pure no-op: no save fires when nothing expired.
 export async function sweepInbox(nowMs = Date.now()) {
-  const payload = await inboxStore.load();
-  const entries = Array.isArray(payload?.entries) ? payload.entries : [];
-  if (entries.length === 0) return;
-  const { keep } = purgeExpiredInbox(entries, { nowMs });
-  if (keep.length !== entries.length) await inboxStore.save({ ...payload, entries: keep });
+  await patchStore(inboxStore, (fresh) => {
+    const entries = Array.isArray(fresh?.entries) ? fresh.entries : [];
+    if (entries.length === 0) return {};
+    const { keep } = purgeExpiredInbox(entries, { nowMs });
+    return keep.length === entries.length ? {} : { entries: keep };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -622,11 +628,14 @@ async function sweepLedger(nowMs) {
 }
 
 async function sweepVerdicts(nowMs) {
-  const payload = await verdictsStore.load();
-  const entries = Array.isArray(payload?.entries) ? payload.entries : [];
-  if (entries.length === 0) return;
-  const { keep } = expireRows(entries, { nowMs, retentionMs: RETENTION_MS.verdicts });
-  if (keep.length !== entries.length) await verdictsStore.save({ ...payload, entries: keep });
+  // BET-1482: same patchStore discipline as sweepInbox — read-fresh-filter-
+  // write under the verdicts store's mutex.
+  await patchStore(verdictsStore, (fresh) => {
+    const entries = Array.isArray(fresh?.entries) ? fresh.entries : [];
+    if (entries.length === 0) return {};
+    const { keep } = expireRows(entries, { nowMs, retentionMs: RETENTION_MS.verdicts });
+    return keep.length === entries.length ? {} : { entries: keep };
+  });
 }
 
 async function sweepDirByFileTime(dir, nowMs, retentionMs) {
@@ -674,16 +683,33 @@ async function sweepArchiveCaps() {
   const dir = ctoPath("facts-archive");
   const files = await listJsonFiles(dir);
   for (const name of files) {
-    const filePath = join(dir, name);
-    const payload = await readJson(filePath, null);
-    if (!payload) continue;
-    const entries = Array.isArray(payload?.entries) ? payload.entries : [];
-    if (entries.length <= ARCHIVE_CAP) continue;
-    await writeJsonAtomic(
-      filePath,
-      JSON.stringify({ ...payload, entries: capArchive(entries, { cap: ARCHIVE_CAP }) }, null, 2),
-      { mode: MODE },
-    );
+    const id = name.slice(0, -".json".length);
+    if (!id) continue;
+    // BET-1482: the cap trim is a patchStore read-filter-write PER ARCHIVE
+    // FILE. The adapter reuses the dir store's own load/save (migration +
+    // v-stamp — the naked writeJsonAtomic spread-save bypassed both), and its
+    // `path` keys the mutex on the real file, so concurrent trims of the same
+    // archive serialize instead of racing their read/write windows.
+    try {
+      await patchStore(
+        {
+          name: factsArchiveStore.name,
+          path: factsArchiveStore.pathFor(id),
+          load: () => factsArchiveStore.load(id),
+          save: (data) => factsArchiveStore.save(id, data),
+        },
+        (fresh) => {
+          const entries = Array.isArray(fresh?.entries) ? fresh.entries : [];
+          return entries.length > ARCHIVE_CAP
+            ? { entries: capArchive(entries, { cap: ARCHIVE_CAP }) }
+            : {};
+        },
+      );
+    } catch {
+      // Per-file best-effort, as before: one unreadable (or too-new-versioned)
+      // archive must not take the whole sweep down — and a too-new payload is
+      // left untouched rather than rewritten by an older reader.
+    }
   }
 }
 

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -706,9 +706,14 @@ async function sweepArchiveCaps() {
         },
       );
     } catch {
-      // Per-file best-effort, as before: one unreadable (or too-new-versioned)
-      // archive must not take the whole sweep down — and a too-new payload is
-      // left untouched rather than rewritten by an older reader.
+      // Per-file best-effort — one unreadable or too-new-versioned archive
+      // must not take the whole sweep down (a too-new payload is left
+      // untouched rather than rewritten by an older reader). Note this is a
+      // deliberate delta from the old shape, not continuity: the naked
+      // readJson/writeJsonAtomic version only skipped READ failures, while a
+      // write failure propagated and aborted the remaining files. Here both
+      // are skipped, matching the sweep family's silent best-effort
+      // convention (every other catch in this module is silent too).
     }
   }
 }

--- a/src/server/ctoStores.test.mjs
+++ b/src/server/ctoStores.test.mjs
@@ -34,6 +34,7 @@ import {
   expireRows,
   capArchive,
   ctoPath,
+  inboxStore,
   verdictsStore,
   ledgerStore,
   factsArchiveStore,
@@ -41,6 +42,7 @@ import {
   rollupsStore,
   probesStore,
   sweepAllStores,
+  sweepInbox,
   INBOX_KINDS,
   INBOX_TTL_MS,
   inboxExpiresAt,
@@ -283,6 +285,84 @@ test("sweepAllStores trims the ledger and caps the archive (integration)", async
 
   const { rm } = await import("node:fs/promises");
   await rm(freshRollup);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1482 — the sweep family writes through patchStore (read-filter-write
+// under the per-store mutex), not the old unlocked load-spread-save.
+// ---------------------------------------------------------------------------
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test("sweepInbox is a patchStore section: a concurrent writer's patch and the sweep's expiry BOTH land", async () => {
+  await inboxStore.save({
+    entries: [
+      { id: "old", kind: "fyi", expires: NOW_MS - 1 },
+      { id: "new", kind: "finding", expires: NOW_MS + DAY },
+    ],
+  });
+  // The writer holds the inbox store's mutex mid-patch while the sweep runs;
+  // the sweep must queue behind it and re-derive from the writer's committed
+  // state (the old unlocked load-spread-save could clobber either side).
+  const writer = patchStore(inboxStore, async () => {
+    await delay(25);
+    return { marker: "w" };
+  });
+  await delay(5); // let the writer take the mutex
+  await sweepInbox(NOW_MS);
+  await writer;
+  const after = await inboxStore.load();
+  assert.equal(after.marker, "w", "the concurrent writer's key survived the sweep");
+  assert.deepEqual(
+    after.entries.map((e) => e.id),
+    ["new"],
+    "the sweep's expiry still landed on the writer's committed state",
+  );
+});
+
+test("sweepVerdicts (via sweepAllStores) is a patchStore section: a concurrent writer's patch and the expiry BOTH land", async () => {
+  const cutoff = NOW_MS - RETENTION_MS.verdicts;
+  await verdictsStore.save({
+    entries: [
+      { ts: cutoff - 1, verdict: "accept" },
+      { ts: NOW_MS, verdict: "accept" },
+    ],
+  });
+  const writer = patchStore(verdictsStore, async () => {
+    await delay(25);
+    return { marker: "w" };
+  });
+  await delay(5);
+  await sweepAllStores({ nowMs: NOW_MS });
+  await writer;
+  const after = await verdictsStore.load();
+  assert.equal(after.marker, "w", "the concurrent writer's key survived the sweep");
+  assert.equal(after.entries.length, 1, "only the fresh verdict survives");
+  assert.equal(after.entries[0].ts, NOW_MS);
+});
+
+test("sweepArchiveCaps trims through the store's own save: sibling keys survive and the payload stays versioned", async () => {
+  const many = Array.from({ length: ARCHIVE_CAP + 5 }, (_, i) => ({ id: i, ts: i }));
+  await factsArchiveStore.save("capproj", { entries: many, project: "capproj" });
+  await sweepAllStores({ nowMs: NOW_MS });
+  const after = await factsArchiveStore.load("capproj");
+  assert.equal(after.entries.length, ARCHIVE_CAP, "over-cap entries trimmed");
+  assert.equal(after.project, "capproj", "the keys the sweep does not own survive");
+  assert.equal(after.v, CURRENT_VERSION, "the write went through the store's versioned save");
+});
+
+test("sweepArchiveCaps is per-file best-effort: a too-new archive file is left untouched, the sweep survives", async () => {
+  const { writeFile, readFile } = await import("node:fs/promises");
+  const { join } = await import("node:path");
+  const futurePath = join(factsArchiveStore.dir, "future.json");
+  await writeFile(futurePath, JSON.stringify({ v: CURRENT_VERSION + 1 }), "utf-8");
+  const many = Array.from({ length: ARCHIVE_CAP + 5 }, (_, i) => ({ id: i, ts: i }));
+  await factsArchiveStore.save("goodproj", { entries: many });
+  await sweepAllStores({ nowMs: NOW_MS }); // must not throw
+  const after = await factsArchiveStore.load("goodproj");
+  assert.equal(after.entries.length, ARCHIVE_CAP, "the healthy archive is still capped");
+  const untouched = JSON.parse(await readFile(futurePath, "utf-8"));
+  assert.equal(untouched.v, CURRENT_VERSION + 1, "the too-new file was not rewritten by the older reader");
 });
 
 test("inboxExpiresAt: fyi is 48h, every other kind (and unknown) is 7 days", () => {

--- a/src/server/ctoTrust.mjs
+++ b/src/server/ctoTrust.mjs
@@ -186,7 +186,17 @@ export function createCtoTrust(deps = {}) {
     const derived = await stFromRaw(st);
     st = derived.st;
     if (derived.adopted) {
-      await store.save(st).catch(() => {});
+      // BET-1482: persist the one-time adoption through the store mutex. The
+      // naked whole-payload save sat OUTSIDE it — a writer landing between
+      // this load and the save would be clobbered by the adopted snapshot.
+      // Re-deriving INSIDE the mutex keeps the persist lose-update-free: if a
+      // writer already adopted and persisted, the fresh payload is no longer
+      // fresh, the adoption short-circuits, and the patch resolves empty
+      // (a pure no-op — no save, no resurrect of the legacy snapshot).
+      await patchStore(store, async (fresh) => {
+        const rederived = await stFromRaw(fresh);
+        return rederived.adopted ? rederived.st : {};
+      }).catch(() => {});
     }
     return {
       st,

--- a/src/server/ctoTrust.test.mjs
+++ b/src/server/ctoTrust.test.mjs
@@ -188,6 +188,11 @@ test("persistence: a legacy es.trust payload migrates into the dedicated store o
 // BET-1482: the one-time adoption persist rides the store's patchStore mutex.
 // The old shape — a naked whole-payload save outside any mutex — could clobber
 // a writer that committed between the read's outer load and the persist.
+// Sequenced with manually-resolved legacy-load promises (review cycle 1: a
+// load-count-based slowdown proved order-dependent — the read's outer store
+// load is issued synchronously before the writer starts, so the read takes
+// legacy load #1; slowing "call #2" slowed the WRITER and the old naked save
+// healed instead of clobbering).
 test("durability: the adoption persist cannot clobber a writer that committed first (BET-1482)", async () => {
   const legacyPayload = {
     v: 1,
@@ -196,19 +201,18 @@ test("durability: the adoption persist cannot clobber a writer that committed fi
       stats: { "start-job": { a: 40, b: 1, va: 3, vb: 0, recent: [] } },
     },
   };
-  // The SECOND legacy load (the concurrent read's adoption source) is slowed
-  // so the writer's full read-merge-save commits while that read is still
-  // deciding to adopt; later legacy loads resolve fast. The read's adoption
-  // persist must then re-derive INSIDE the mutex, see a no-longer-fresh
-  // store, and no-op — the old naked save would fire after the writer's
-  // commit and clobber it with the un-mutated legacy snapshot.
-  let legacyLoads = 0;
+  const copy = () => JSON.parse(JSON.stringify(legacyPayload));
+  // The FIRST legacy load is held unresolved until the test releases it; every
+  // later load auto-resolves on the next microtask. The read is the only
+  // consumer running when the first load fires, so "held" is deterministically
+  // the read's.
+  let held = null;
   const legacy = {
-    load: async () => {
-      legacyLoads += 1;
-      if (legacyLoads === 2) await new Promise((r) => setTimeout(r, 30));
-      return JSON.parse(JSON.stringify(legacyPayload));
-    },
+    load: () =>
+      new Promise((resolve) => {
+        if (held) queueMicrotask(() => resolve(copy()));
+        else held = resolve;
+      }),
     save: async () => {},
   };
   const store = memoryStore({});
@@ -220,15 +224,25 @@ test("durability: the adoption persist cannot clobber a writer that committed fi
     verdicts: memoryStore({ v: 1, entries: [] }),
     now: () => 1_000_000,
   });
-  // The writer adopts the same legacy payload inside the mutex, bumps the
-  // ask counter, and commits — all while the read's adoption decision is
-  // still pending on the slowed legacy load.
-  const writer = trust.noteVerdictEffects(
+  const tick = () => new Promise((r) => setImmediate(r));
+  // 1. The read runs first: its outer store load sees the still-empty
+  //    dedicated store and it parks on its HELD legacy load — adoption
+  //    undecided.
+  const read = trust.getState();
+  while (!held) await tick();
+  // 2. The writer adopts the same legacy payload inside the store mutex
+  //    (auto-resolving legacy load), bumps the ask counter, fully commits.
+  await trust.noteVerdictEffects(
     { success: true },
     { subject: { type: "suggestion", id: "x", class: "start-job" }, verdict: "accept" },
   );
-  await trust.getState(); // concurrent read: adopts in memory, persists via the mutex
-  await writer;
+  // 3. Only NOW does the read decide to adopt. Under the old naked save its
+  //    persist fires strictly AFTER the writer's commit and clobbers the
+  //    counter back to 40; under the patchStore persist it queues behind the
+  //    mutex, re-derives from the committed (no-longer-fresh) payload, and
+  //    no-ops.
+  held(copy());
+  await read;
   const st = await trust.getState();
   assert.equal(st.stats["start-job"]?.a, 41, "the writer's counter bump survived the adoption persist");
   assert.equal(st.tiers["start-job"], TIER_VETO_WINDOW, "the adopted tier survived");

--- a/src/server/ctoTrust.test.mjs
+++ b/src/server/ctoTrust.test.mjs
@@ -185,6 +185,55 @@ test("persistence: a legacy es.trust payload migrates into the dedicated store o
   assert.equal((await h.stores.legacy.load()).trust.stats["start-job"]?.va, 3);
 });
 
+// BET-1482: the one-time adoption persist rides the store's patchStore mutex.
+// The old shape — a naked whole-payload save outside any mutex — could clobber
+// a writer that committed between the read's outer load and the persist.
+test("durability: the adoption persist cannot clobber a writer that committed first (BET-1482)", async () => {
+  const legacyPayload = {
+    v: 1,
+    trust: {
+      tiers: { "start-job": TIER_VETO_WINDOW },
+      stats: { "start-job": { a: 40, b: 1, va: 3, vb: 0, recent: [] } },
+    },
+  };
+  // The SECOND legacy load (the concurrent read's adoption source) is slowed
+  // so the writer's full read-merge-save commits while that read is still
+  // deciding to adopt; later legacy loads resolve fast. The read's adoption
+  // persist must then re-derive INSIDE the mutex, see a no-longer-fresh
+  // store, and no-op — the old naked save would fire after the writer's
+  // commit and clobber it with the un-mutated legacy snapshot.
+  let legacyLoads = 0;
+  const legacy = {
+    load: async () => {
+      legacyLoads += 1;
+      if (legacyLoads === 2) await new Promise((r) => setTimeout(r, 30));
+      return JSON.parse(JSON.stringify(legacyPayload));
+    },
+    save: async () => {},
+  };
+  const store = memoryStore({});
+  const ledgerRows = [];
+  const trust = createCtoTrust({
+    store,
+    legacy,
+    ledger: { append: async (r) => ledgerRows.push(r), read: async () => ledgerRows },
+    verdicts: memoryStore({ v: 1, entries: [] }),
+    now: () => 1_000_000,
+  });
+  // The writer adopts the same legacy payload inside the mutex, bumps the
+  // ask counter, and commits — all while the read's adoption decision is
+  // still pending on the slowed legacy load.
+  const writer = trust.noteVerdictEffects(
+    { success: true },
+    { subject: { type: "suggestion", id: "x", class: "start-job" }, verdict: "accept" },
+  );
+  await trust.getState(); // concurrent read: adopts in memory, persists via the mutex
+  await writer;
+  const st = await trust.getState();
+  assert.equal(st.stats["start-job"]?.a, 41, "the writer's counter bump survived the adoption persist");
+  assert.equal(st.tiers["start-job"], TIER_VETO_WINDOW, "the adopted tier survived");
+});
+
 test("durability: a stale full-engine-state save cannot revert trust keys (the mirrored clobber direction)", async () => {
   const h = makeTrust({ verdictCount: VERDICT_MIN });
   await h.trust.noteVerdictEffects({ success: true }, { subject: { type: "suggestion", id: "x", class: "queue-tonight" }, verdict: "accept" });


### PR DESCRIPTION
Closes BET-1482.

## What

BET-1464 routed the five CTO writer files through `patchStore` but left the retention-sweep family on the pre-patchStore shape: an unlocked load-spread-save of the whole payload. This converts every remaining payload-rewriting sweep to a `patchStore` read-filter-write section:

- `sweepInbox` / `sweepVerdicts` — `patchStore(store, fresh => …)` under the store's own mutex; an empty patch is a pure no-op, so "nothing expired" still writes nothing.
- `sweepArchiveCaps` — per-file `patchStore` via an adapter over the dir store's own `load`/`save` (reuses migration + v-stamping that the naked `writeJsonAtomic` spread-save bypassed); the mutex keys on the real file path. Per-file failures stay best-effort: one unreadable / too-new-versioned archive cannot take the sweep down (a too-new file is left untouched rather than rewritten by an older reader).
- `sweepLedger` / rollups / segments / digests removals — already atomic (`sweepExpired`) or whole-file `rm()` (no payload rewrite), unchanged.
- `ctoTrust.loadState`'s one-time legacy-adoption persist now re-derives INSIDE the store mutex and no-ops when a writer already adopted and committed — the naked whole-payload save sat outside the mutex and could clobber a writer that committed between the outer load and the save.

## Tests

5 new tests: sweep/concurrent-writer composition for inbox + verdicts (both effects land regardless of order — the old unlocked shape could lose one), archive trim through the store's versioned save with sibling keys preserved, per-file best-effort on a too-new archive, and the trust adoption-persist clobber race (fails under the old naked save: the writer's counter bump is lost).

## Follow-up filed

**BET-1492** (PM, high): while grepping the pattern, found four sibling writers of `inbox.json`/`verdicts.json` still on the unlocked whole-payload shape TODAY (cto.mjs createCtoInbound append, ctoEngine drainInbox ×2, ctoVerdicts recordVerdict, ctoSuggest verdictHeld fallback) — i.e. the "second writer" this issue warns about already exists. Deferred from this PR with a per-site dispatch block in BET-1492; converting them here would have tripled the blast radius (cto.mjs/ctoEngine seams and their test injections) beyond this issue's scoped acceptance.

**Verification results:**
- PR branch (`multica/BET-1482-sweep-patchstore` @ `faccbd65`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3791 pass / 0 fail / 0 skip. Failures: none. log sha256: `23bdb78bc1e8112762f38018a096c0713ce563838993f33cb67e6a2136b81e0f`
- Base (`main` @ `e1e783a9`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3786 pass / 0 fail / 0 skip. Failures: none. log sha256: `44d49806862e8dff14a0615fe13786cac81657ac3e6c6936bfcc3308ed4cc43d`
- **Conclusion:** 0 pre-existing failures, 0 new failures; this PR adds 5 passing tests (3791 vs 3786).

Base: origin/main @ e1e783a9
