### PR TITLE
BET-1478: dedupe ctoProbes 9-line self-clone (duplication-gate red)

### DIFF
--- a/src/server/ctoProbes.mjs
+++ b/src/server/ctoProbes.mjs
@@ -919,14 +919,28 @@ export function createProbes(deps = {}) {
    * Not thrifty-shed: a still-empty template is at most one paced nano call,
    * not a fan-out.
    */
-  async function authorSpecs({ ts = now(), todayKey = dayKeyOf(ts) } = {}) {
-    if (typeof runEphemeral !== "function") return { ran: 0, attempts: 0, skipped: "no-ephemeral" };
+  // Common prologue of the two paced nano passes (authorSpecs / relevanceScan):
+  // normalize `{ts, todayKey}` (the day-key defaults from ts), gate on the
+  // ephemeral seam, and load the spec'd tool list. Returns the pass's
+  // zero-work result via `.early`, or `{ts, todayKey, tools}` to proceed.
+  async function pacedPassPrologue(opts = {}) {
+    const { ts = now(), todayKey = dayKeyOf(ts) } = opts;
+    if (typeof runEphemeral !== "function") {
+      return { early: { ran: 0, attempts: 0, skipped: "no-ephemeral" } };
+    }
     let tools;
     try {
       tools = await probes.list();
     } catch {
-      return { ran: 0, attempts: 0 };
+      return { early: { ran: 0, attempts: 0 } };
     }
+    return { ts, todayKey, tools };
+  }
+
+  async function authorSpecs(opts = {}) {
+    const prologue = await pacedPassPrologue(opts);
+    if (prologue.early) return prologue.early;
+    const { ts, todayKey, tools } = prologue;
     let st;
     try {
       st = (await state.load("_authoring")) ?? {};
@@ -1268,14 +1282,10 @@ export function createProbes(deps = {}) {
    * indefinitely (review cycle 1, Question 1). Successful pairs then rest
    * for the week.
    */
-  async function relevanceScan({ ts = now(), todayKey = dayKeyOf(ts) } = {}) {
-    if (typeof runEphemeral !== "function") return { ran: 0, attempts: 0, skipped: "no-ephemeral" };
-    let tools;
-    try {
-      tools = await probes.list();
-    } catch {
-      return { ran: 0, attempts: 0 };
-    }
+  async function relevanceScan(opts = {}) {
+    const prologue = await pacedPassPrologue(opts);
+    if (prologue.early) return prologue.early;
+    const { ts, todayKey, tools } = prologue;
     let projects = [];
     try {
       projects = (await listProjects()) ?? [];


### PR DESCRIPTION
Closes the remaining scope of BET-1478: the 9-line jscpd self-clone in `src/server/ctoProbes.mjs` (lines 922-930 ↔ 1271-1279, 72 tokens) that the `duplication-gate` flagged on BET-1463's PR #1444.

The two `ctoCards.test.mjs` clones named in the issue were already deduped by BET-1481 (`9bdbf6a1`); this PR touches only `src/server/ctoProbes.mjs`.

## What changed

Extracted the shared prologue of the two paced nano passes (`authorSpecs` / `relevanceScan`) into a local `pacedPassPrologue(opts)` helper in the same file:

- normalizes `{ts, todayKey}` (day-key defaults from `ts`, identical to the old parameter destructuring),
- gates on the ephemeral seam (`{ran: 0, attempts: 0, skipped: "no-ephemeral"}` preserved 1:1),
- loads the spec'd tool list (`{ran: 0, attempts: 0}` on store failure, preserved 1:1),
- returns `{ts, todayKey, tools}` to proceed.

Pure refactor — zero behaviour change. No new files. `scripts/duplication-gate-ignore.txt` untouched (human-approval class per the issue).

**Base:** origin/main @ c7af081d

## Verification results

**Files changed:** 1 file. `src/server/ctoProbes.mjs` (+21/−11)

- PR branch (`multica/BET-1478-ctoprobes-dedupe` @ `7dcdf103`):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709
  - test: exit 0, 3775 pass / 0 fail / 0 skip. Failures: none. log sha256: d8e76ceded924bdeafed6564fcaf6bf1cc3c94c6cae0026baabe9bdb64f8b5a4
- Base (`origin/main` @ `c7af081d`, detached):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709
  - test: exit 0, 3775 pass / 0 fail / 0 skip. Failures: none. log sha256: d86dbd25e5d012eff7866fd26ee5dabcd4f313631ffff792ea84b67e17da4831
- **Conclusion:** 0 new failures, 0 pre-existing failures — both branches fully green.
- `scripts/check-duplication-gate.sh origin/main` (same script + `.jscpd.json` CI uses): `duplication-gate: scanning 1 changed file(s) (min-tokens 70, STRICT)` → **PASS — no clones**.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
