### PR TITLE
test(renderer): connect answer wiring routes tool+ring; no-tool asks never call (BET-1431)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -43,6 +43,7 @@ import {
   decisionCards,
   vetoCards,
   connectCards,
+  connectAnswerArgs,
   tonightVisible,
   executeSuggestionOption,
   tonightBudgetMode,
@@ -426,17 +427,15 @@ export function CtoPanel({
   // all three; the client toasts the outcome and refreshes the cards.
   const handleConnectAnswer = useCallback(
     (card: ConnectCardRow, answer: string) => {
-      const option = (card.options ?? []).find((o) => o.answer === answer);
-      const tool = option?.action?.payload?.tool;
-      const toolId = typeof tool === "string" ? tool : card.id;
-      const ring = option?.action?.payload?.ring;
-      const deepRead = ring === "deep_read";
+      // BET-1431: the {tool, answer, ring} argument-building lives in
+      // ctoView.connectAnswerArgs (pure + tested). A card whose option
+      // carries no `action.payload.tool` produces NO call — never a call
+      // with a bogus/undefined tool.
+      const args = connectAnswerArgs(card, answer);
+      if (!args) return;
+      const deepRead = args.ring === "deep_read";
       void window.api
-        ?.ctoToolConnect?.({
-          tool: toolId,
-          answer: answer as "connect" | "not-now" | "never",
-          ...(deepRead ? { ring: "deep_read" as const } : {}),
-        })
+        ?.ctoToolConnect?.(args)
         .then((r) => {
           if (r?.ok) {
             pushToast({

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -595,8 +595,9 @@ it("connectCards: selects connect-variant cards and drops a row with neither tit
 // ---------------------------------------------------------------------------
 
 // A card shaped exactly like the server's upsertConnect output (ctoCards.mjs):
-// every option binds the ask's tool identity + ring at generation time.
-const connectAskCard = (ring: string, tool: unknown = "github"): ConnectCardRow => ({
+// every option binds the ask's tool identity + ring at generation time. Omit
+// `tool` to build the defensive no-tool variant.
+const connectAskCard = (ring: string, tool?: unknown): ConnectCardRow => ({
   id: "cto:card:connect:github",
   title: "Connect GitHub (read-only)?",
   body: "used 6 times this week",
@@ -610,7 +611,7 @@ const connectAskCard = (ring: string, tool: unknown = "github"): ConnectCardRow 
 
 describe("connectAnswerArgs (BET-1431 — connect answer → ctoToolConnect wiring)", () => {
   it("each of the three answers routes its option's tool + answer; the metadata ask sends no ring", () => {
-    const card = connectAskCard("metadata");
+    const card = connectAskCard("metadata", "github");
     expect(connectAnswerArgs(card, "connect")).toEqual({ tool: "github", answer: "connect" });
     expect(connectAnswerArgs(card, "not-now")).toEqual({ tool: "github", answer: "not-now" });
     expect(connectAnswerArgs(card, "never")).toEqual({ tool: "github", answer: "never" });
@@ -618,23 +619,32 @@ describe("connectAnswerArgs (BET-1431 — connect answer → ctoToolConnect wiri
   });
 
   it("a deep-read ask forwards ring deep_read on every answer (the ring the ask was about)", () => {
-    const card = connectAskCard("deep_read");
+    const card = connectAskCard("deep_read", "github");
     expect(connectAnswerArgs(card, "connect")).toEqual({ tool: "github", answer: "connect", ring: "deep_read" });
     expect(connectAnswerArgs(card, "not-now")).toEqual({ tool: "github", answer: "not-now", ring: "deep_read" });
     expect(connectAnswerArgs(card, "never")).toEqual({ tool: "github", answer: "never", ring: "deep_read" });
   });
 
   it("an option carrying no action.payload.tool produces no call (null, never a bogus tool)", () => {
+    const noToolKey: ConnectCardRow = {
+      ...connectAskCard("metadata"),
+      options: (["connect", "not-now", "never"] as const).map((answer) => ({
+        label: answer,
+        answer,
+        action: { type: "tool-connect", payload: {} },
+      })),
+    };
     for (const answer of ["connect", "not-now", "never"]) {
-      expect(connectAnswerArgs(connectAskCard("metadata", undefined), answer)).toBeNull();
+      expect(connectAnswerArgs(connectAskCard("metadata"), answer)).toBeNull();
+      expect(connectAnswerArgs(noToolKey, answer)).toBeNull();
       expect(connectAnswerArgs(connectAskCard("metadata", 42), answer)).toBeNull();
       expect(connectAnswerArgs(connectAskCard("metadata", ""), answer)).toBeNull();
     }
   });
 
   it("an answer that is not one of the three registry verbs (or matches no option) is null", () => {
-    expect(connectAnswerArgs(connectAskCard("metadata"), "always")).toBeNull();
-    expect(connectAnswerArgs({ ...connectAskCard("metadata"), options: [] }, "connect")).toBeNull();
+    expect(connectAnswerArgs(connectAskCard("metadata", "github"), "always")).toBeNull();
+    expect(connectAnswerArgs({ ...connectAskCard("metadata", "github"), options: [] }, "connect")).toBeNull();
   });
 });
 

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -400,6 +400,7 @@ describe("nowRailMeta (§10.4 project · cost · elapsed)", () => {
 import {
   blockerCards,
   connectCards,
+  connectAnswerArgs,
   decisionCards,
   executeSuggestionOption,
   runnableSuggestionOption,
@@ -407,6 +408,7 @@ import {
   vetoCards,
   countdownRemaining,
   tonightVisible,
+  type ConnectCardRow,
 } from "./ctoView";
 
 it("decisionCards: selects decision-variant cards only", () => {
@@ -584,6 +586,56 @@ it("connectCards: selects connect-variant cards and drops a row with neither tit
   ];
   const out = connectCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
   expect(out.map((c) => c.id)).toEqual(["c2"]);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1431 — connect answer wiring (BET-1395 residue): the {tool, answer,
+// ring} argument set routed to ctoToolConnect. The card SELECTOR is covered
+// by the BET-1467 tests above; this pins the callback contract only.
+// ---------------------------------------------------------------------------
+
+// A card shaped exactly like the server's upsertConnect output (ctoCards.mjs):
+// every option binds the ask's tool identity + ring at generation time.
+const connectAskCard = (ring: string, tool: unknown = "github"): ConnectCardRow => ({
+  id: "cto:card:connect:github",
+  title: "Connect GitHub (read-only)?",
+  body: "used 6 times this week",
+  evidence: [],
+  options: (["connect", "not-now", "never"] as const).map((answer) => ({
+    label: answer,
+    answer,
+    action: { type: "tool-connect", payload: { tool, answer, ring } },
+  })),
+});
+
+describe("connectAnswerArgs (BET-1431 — connect answer → ctoToolConnect wiring)", () => {
+  it("each of the three answers routes its option's tool + answer; the metadata ask sends no ring", () => {
+    const card = connectAskCard("metadata");
+    expect(connectAnswerArgs(card, "connect")).toEqual({ tool: "github", answer: "connect" });
+    expect(connectAnswerArgs(card, "not-now")).toEqual({ tool: "github", answer: "not-now" });
+    expect(connectAnswerArgs(card, "never")).toEqual({ tool: "github", answer: "never" });
+    expect("ring" in (connectAnswerArgs(card, "connect") ?? {})).toBe(false);
+  });
+
+  it("a deep-read ask forwards ring deep_read on every answer (the ring the ask was about)", () => {
+    const card = connectAskCard("deep_read");
+    expect(connectAnswerArgs(card, "connect")).toEqual({ tool: "github", answer: "connect", ring: "deep_read" });
+    expect(connectAnswerArgs(card, "not-now")).toEqual({ tool: "github", answer: "not-now", ring: "deep_read" });
+    expect(connectAnswerArgs(card, "never")).toEqual({ tool: "github", answer: "never", ring: "deep_read" });
+  });
+
+  it("an option carrying no action.payload.tool produces no call (null, never a bogus tool)", () => {
+    for (const answer of ["connect", "not-now", "never"]) {
+      expect(connectAnswerArgs(connectAskCard("metadata", undefined), answer)).toBeNull();
+      expect(connectAnswerArgs(connectAskCard("metadata", 42), answer)).toBeNull();
+      expect(connectAnswerArgs(connectAskCard("metadata", ""), answer)).toBeNull();
+    }
+  });
+
+  it("an answer that is not one of the three registry verbs (or matches no option) is null", () => {
+    expect(connectAnswerArgs(connectAskCard("metadata"), "always")).toBeNull();
+    expect(connectAnswerArgs({ ...connectAskCard("metadata"), options: [] }, "connect")).toBeNull();
+  });
 });
 
 it("countdownRemaining: ms left, null once due or without a dueMs", () => {

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -588,6 +588,33 @@ export function connectCards(cards: ReadonlyArray<Record<string, unknown>>): Con
     .filter((c) => c.title || c.body);
 }
 
+// BET-1431 (BET-1395 residue): the connect answer's argument-building step,
+// extracted from CtoPanel's handleConnectAnswer so it is pure and testable
+// (the leaf stays a memoized callback shell). Returns the exact
+// `ctoToolConnect` argument set for the chosen answer, or null when there is
+// nothing valid to call: the answer is not one of the three registry verbs,
+// no option matches it, or the option's action carries no string
+// `payload.tool` — the caller must skip the call entirely rather than send a
+// bogus/undefined tool (the server's upsertConnect always binds the tool at
+// generation time, so null is a defensive contract, not an expected path).
+// `ring` is forwarded only for the deep-read ask; "metadata" is the route's
+// default and is omitted, matching the wire shape the server expects.
+export function connectAnswerArgs(
+  card: ConnectCardRow,
+  answer: string,
+): { tool: string; answer: "connect" | "not-now" | "never"; ring?: "deep_read" } | null {
+  if (answer !== "connect" && answer !== "not-now" && answer !== "never") return null;
+  const option = (card.options ?? []).find((o) => o.answer === answer);
+  const tool = option?.action?.payload?.tool;
+  if (typeof tool !== "string" || tool === "") return null;
+  const ring = option?.action?.payload?.ring;
+  return {
+    tool,
+    answer,
+    ...(ring === "deep_read" ? { ring: "deep_read" as const } : {}),
+  };
+}
+
 // Live countdown to a veto card's `dueMs`: the ms remaining (≥ 0), or null
 // when there is no due time or it already elapsed (the card resolves server-
 // side; the client just hides the countdown rather than reading negative).


### PR DESCRIPTION
## BET-1431 — renderer tests for the connect-card answer wiring (BET-1395 residue)

**Base: origin/main @ `103bb69b`**

### What

The connect leaf (`ConnectCard` → `handleConnectAnswer`) had no test coverage; both defects the 2026-08-31 review found (double-render, swallowed 401) lived at exactly this level. This PR pins the callback contract:

1. **Extraction (issue's preferred shape):** the `{tool, answer, ring}` argument-building moved out of the memoized `handleConnectAnswer` into a pure `connectAnswerArgs(card, answer)` in `src/renderer/ctoView.ts`, tested in `src/renderer/ctoView.test.ts` (`connectAnswerArgs (BET-1431 …)` describe block — 4 tests).
2. **No-tool → no call:** a card whose option carries no `action.payload.tool` returns `null` and the panel skips the call entirely.

### Behavior change (deliberate, issue-prescribed)

`handleConnectAnswer` previously fell back to `card.id` as the tool when `payload.tool` was missing — a call with a bogus tool id. Per the issue ("produces no call, rather than a call with `undefined`"), that fallback is removed: no string `payload.tool` → no `ctoToolConnect` call and no refresh. In practice dead-in-practice today — the server's `upsertConnect` always binds the tool at generation time — so no consumer regression is possible.

### Anti-spaghetti

- Single site: grep confirmed `CtoPanel.tsx:430` was the only place building connect args; no parallel copy added.
- `ctoView.ts` is the existing home for pure renderer CTO logic (as `executeSuggestionOption` already is for the sibling suggestion path) — extended, not duplicated.

### Anti-duplication (BET-1467)

Read BET-1467's tests first: they pin the **selectors** (`blockerCards` excludes connect, `connectCards` drops contentless rows). This PR pins the **callback argument contract** only — disjoint.

### Verification results

- PR branch (`multica/BET-1431-connect-callback-tests` @ `af4058c1`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3889` pass / `0` fail / `7` skip. Failures: none. log sha256: `12d15c0768cbc0a8f7188a544c697510f186a15cd85c9519e50170ca7547a71d`
- Base (`main` @ `103bb69b`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3885` pass / `0` fail / `7` skip. Failures: none. log sha256: `394665fe97dd042a3d2aabe11eced8f9b848c5bea37b9eaca180db13f1bca476`
- **Conclusion:** 0 new failures; +4 tests are this PR's own (3885 → 3889). 0 pre-existing failures on either branch.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

**Files changed:** 3 files, +98/−10 — `src/renderer/ctoView.ts`, `src/renderer/ctoView.test.ts`, `src/renderer/CtoPanel.tsx`.
