### PR TITLE
fix(server): make the ctoBudget day-bucket prune aware of pending ROI month recomputes (BET-1486)

### DIFF
--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -158,15 +158,35 @@ export function recordSpend(payload, { now, usd, calls = 1 } = {}) {
   const prev = dayBucket(p, key);
   const days = { ...p.days, [key]: { usd: dollar(prev.usd) + dollar(usd), calls: num(prev.calls) + ((calls | 0) || 1) } };
   // BET-1466: bound the growth inside the only writer that adds buckets.
-  // Day buckets older than the burn-history window are read by nothing
-  // (the burn history reads exactly BURN_HISTORY_DAYS day-starts including
-  // today); ROI month accumulators older than the retention horizon are
-  // beyond the report's honest horizon and are dropped with the pending
-  // rows that feed them. budget.json is not covered by the store sweep.
+  // BET-1486: a day bucket is prunable only once no ROI recompute still
+  // reads it. The burn history reads exactly BURN_HISTORY_DAYS day-starts
+  // including today; the roll (refreshRoi) recomputes the CURRENT month's
+  // counters on every refresh and the PREVIOUS month's once more after it
+  // closes — the frozen figure the Health report renders. Buckets inside
+  // those two month windows therefore survive until the roll is done with
+  // them: pruning earlier froze an understated closed month (after a
+  // >7-day outage spanning the close, at $0, because the first post-boot
+  // spend pruned the closed month's buckets before the first roll ran).
+  // Once the roll freezes the previous month its buckets prune here on the
+  // next spend, so the keep-set stays bounded by the burn history plus at
+  // most two month windows. ROI month accumulators older than the
+  // retention horizon remain beyond the report's honest horizon and are
+  // dropped with the pending rows that feed them. budget.json is not
+  // covered by the store sweep.
   const oldestDay = startOfDay(t) - (BURN_HISTORY_DAYS - 1) * 24 * HOUR_MS;
+  const currentWindow = monthWindow(roiMonthKey(t));
+  const prevWindow = currentWindow ? monthWindow(roiMonthKey(currentWindow.startTs - 1)) : null;
+  const liveMonths = p.roi && typeof p.roi === "object" && p.roi.months && typeof p.roi.months === "object" ? p.roi.months : {};
+  // A missing entry means the post-close recompute has not run yet — the
+  // same predicate refreshRoi uses to include the previous month in
+  // toCompute. Unfrozen, unknown, or absent → the freeze is still pending.
+  const prevFrozen = !prevWindow || liveMonths[roiMonthKey(prevWindow.startTs)]?.frozen === true;
   for (const k of Object.keys(days)) {
     const ts = Number(k);
-    if (Number.isFinite(ts) && ts < oldestDay) delete days[k];
+    if (!Number.isFinite(ts) || ts >= oldestDay) continue; // the burn history still reads it
+    if (currentWindow && ts >= currentWindow.startTs) continue; // the current month — recomputed on every roll
+    if (!prevFrozen && ts >= prevWindow.startTs) continue; // the closed month — its freeze recompute still reads it
+    delete days[k];
   }
   let roi = p.roi;
   if (roi && typeof roi === "object" && roi.months && typeof roi.months === "object") {

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -803,25 +803,82 @@ test("pending retention keeps fresh probe-pending rows and counted fingerprints 
 
 // BET-1466 item 4: budget.json is not covered by the store sweep — the spend
 // recorder itself now bounds day-bucket and ROI-month growth.
-test("recordSpend prunes day buckets beyond the burn history and ROI months beyond the horizon", () => {
+// BET-1486: the prune keys on "no unfrozen month needs these buckets" — the
+// roll recomputes the current month on every refresh and the previous month
+// once more after it closes, so their buckets survive the burn-window prune.
+test("recordSpend prunes day buckets no live ROI recompute reads, and ROI months beyond the horizon", () => {
   const DAY = 86_400_000;
   let p = defaultBudgetPayload();
-  p.days[dayKey(MIDNIGHT - 10 * DAY)] = { usd: 9, calls: 9 }; // outside the 7-day burn history
+  p.days[dayKey(MIDNIGHT - 10 * DAY)] = { usd: 9, calls: 9 }; // Aug 18 — current month, outside the burn window → kept
   p.days[dayKey(MIDNIGHT - 6 * DAY)] = { usd: 1, calls: 1 }; // the oldest in-window day → kept
+  p.days[dayKey(MIDNIGHT - 40 * DAY)] = { usd: 3, calls: 3 }; // Jul 19 — the previous month, unfrozen → kept
+  p.days[dayKey(MIDNIGHT - 70 * DAY)] = { usd: 5, calls: 5 }; // Jun 19 — beyond every live window → dropped
   p.roi = {
     months: {
       [roiMonthKey(MIDNIGHT - 100 * DAY)]: { merged: 3 }, // past the 60d ROI horizon
-      [roiMonthKey(MIDNIGHT - 40 * DAY)]: { merged: 1 }, // recent → kept
+      [roiMonthKey(MIDNIGHT - 40 * DAY)]: { merged: 1 }, // recent → kept (and the unfrozen previous month)
     },
     pending: [],
   };
   const out = recordSpend(p, { now: MIDNIGHT + 60_000, usd: 0.25 });
-  assert.equal(out.days[dayKey(MIDNIGHT - 10 * DAY)], undefined, "a bucket older than the burn window is dropped");
+  assert.equal(out.days[dayKey(MIDNIGHT - 10 * DAY)].usd, 9, "a current-month bucket outside the burn window survives (the roll recomputes it every refresh)");
   assert.equal(out.days[dayKey(MIDNIGHT - 6 * DAY)].usd, 1, "the oldest in-window bucket survives");
+  assert.equal(out.days[dayKey(MIDNIGHT - 40 * DAY)].usd, 3, "the unfrozen previous month's bucket survives (its freeze recompute needs it)");
+  assert.equal(out.days[dayKey(MIDNIGHT - 70 * DAY)], undefined, "a bucket no live month recompute reads is dropped");
   assert.equal(out.days[dayKey(MIDNIGHT + 60_000)].usd, 0.25, "today's bucket is written");
   assert.equal(out.roi.months[roiMonthKey(MIDNIGHT - 100 * DAY)], undefined, "an ROI month past the horizon is dropped");
   assert.equal(out.roi.months[roiMonthKey(MIDNIGHT - 40 * DAY)].merged, 1, "a recent ROI month survives");
   assert.equal(out.roi.pending.length, 0, "pending rides along untouched");
+});
+
+// BET-1486: a missing/unfrozen entry for the previous month means its
+// post-close recompute (the freeze) has not run yet — its buckets must
+// survive the first post-outage spend so the roll freezes the real figure,
+// not $0. Once frozen, the buckets are dead weight and prune again.
+test("the closed month's buckets survive a post-outage prune until the roll freezes it, then prune (BET-1486)", () => {
+  const DAY = 86_400_000;
+  // >7-day outage spanning the close: the last pre-outage spend was Aug 20,
+  // the first post-boot spend is Sep 10 — the whole of August is outside
+  // the 7-day burn window and no roll has run since the close.
+  const SEP_10 = dayStart(13) + 3_600_000;
+  let p = defaultBudgetPayload();
+  p.days[dayKey(dayStart(-8))] = { usd: 7, calls: 7 }; // Aug 20 — the last pre-outage day
+  p.roi = { months: {}, pending: [] }; // no August entry → the freeze hasn't run
+  let out = recordSpend(p, { now: SEP_10, usd: 0.25 });
+  assert.equal(out.days[dayKey(dayStart(-8))].usd, 7, "the closed month's last bucket survives the first post-boot prune");
+  // The roll then freezes August (correctly, from the surviving buckets);
+  // the next spend prunes them.
+  out = { ...out, roi: { months: { "2026-08": { merged: 2, frozen: true } }, pending: [] } };
+  const out2 = recordSpend(out, { now: SEP_10 + 60_000, usd: 0.25 });
+  assert.equal(out2.days[dayKey(dayStart(-8))], undefined, "once the month is frozen its buckets no longer feed any recompute — pruned");
+});
+
+// BET-1486 end-to-end: the exact issue scenario — spends through Aug 20, a
+// >7-day outage spanning the close, the first post-boot spend (which prunes),
+// then the first roll. The August freeze must read the real spend, not $0.
+test("refreshRoi freezes the closed month at its real spend after a >7-day outage spanning the close (BET-1486)", async () => {
+  const DAY = 86_400_000;
+  const SEP_10 = dayStart(13) + 3_600_000;
+  let payload = defaultBudgetPayload();
+  payload = recordSpend(payload, { now: dayStart(-23), usd: 3 }); // Aug 5
+  payload = recordSpend(payload, { now: dayStart(-8), usd: 7 }); // Aug 20 — the last pre-outage day
+  payload = recordSpend(payload, { now: SEP_10, usd: 0.25 }); // Sep 10 — first post-boot spend
+  const store = { load: async () => payload, save: async (p) => (payload = p) };
+  const budget = createCtoBudget({
+    store,
+    jobsRead: async () => [],
+    gitProbe: async () => ({ exists: false, isAncestor: false }),
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now: () => SEP_10,
+  });
+  const r = await budget.refreshRoi();
+  const aug = r.months["2026-08"];
+  assert.ok(aug, "the closed month's roll exists");
+  assert.equal(aug.frozen, true, "the closed month is frozen on its first post-close recompute");
+  assert.ok(Math.abs(aug.spendUsd - 10) < 1e-9, `the freeze reads the real August spend (got ${aug.spendUsd})`);
+  assert.ok(Math.abs(r.months["2026-09"].spendUsd - 0.25) < 1e-9, "the current month's spend reads its own buckets");
 });
 
 test("overnightSpendUsd prices today's job_started estTokens at the model cost (§11.2)", () => {


### PR DESCRIPTION
## Problem

BET-1466's spend-recorder prune deletes any day bucket older than the 7-day burn window. But the ROI roll (`refreshRoi`) recomputes the **current** month's counters on every refresh and the **previous** month's once more after it closes — the frozen figure the Health report renders, sourced from `monthSpendUsd` over those same day buckets.

If the box is down (or idle) for >7 days spanning a month close, the first post-boot spend pruned the closed month's buckets **before** the first post-boot roll ran; the roll then froze the closed month at `spendUsd: 0`. Report-only (caps read today's bucket), but the rendered monthly figure was wrong forever.

The same mechanism also understated every closed month to its final ~7 days of spend even without an outage (the pre-close mid-month prunes had already deleted the month's older buckets).

## Fix

Key the day-bucket prune on "no unfrozen month needs these buckets" (the issue's prescribed option 1 — reorder was not viable: `recordSpend` cannot persist the freeze, since the freeze's `accepted`/`incidents`/`merged` counters come from stores the pure recorder can't read):

- buckets inside the **current month's** window survive (the roll recomputes it every refresh, and its close-freeze needs the whole month);
- buckets inside the **previous month's** window survive while that month is unfrozen — same predicate `refreshRoi` uses for `toCompute` (a missing entry = freeze not yet run);
- everything else prunes as before.

The keep-set stays bounded: burn history (7 buckets) + at most two month windows. Once the roll freezes the previous month, its buckets prune on the next spend. ROI-month retention prune is untouched.

Single site: `recordSpend` is the only day-bucket writer/pruner; `refreshRoi` needed no change (the freeze path was correct — it just needed the buckets to still exist).

## Tests

- Updated the BET-1466 prune test to the new contract (current-month and unfrozen-previous-month buckets survive; a bucket beyond every live window still drops; retention prune assertions unchanged).
- New unit test: post-outage replay — the closed month's last bucket survives the first post-boot prune, and prunes once the roll freezes the month.
- New integration test: the exact issue scenario (spends through Aug 20 → >7-day outage spanning the close → first post-boot spend → first roll) — `refreshRoi` freezes August at its real $10, not $0.

## Files changed

`src/server/ctoBudget.mjs` (+21/−4), `src/server/ctoBudget.test.mjs` (+62/−3).

**Verification results:**
- PR branch (`multica/BET-1486-budget-prune-outage` @ `a1b282be`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0` harness, 3788 pass / 1 fail / 0 skip. Failures: `src/server/ctoStores.test.mjs:249` "sweepAllStores trims the ledger and caps the archive (integration)". log sha256: `b24773ef98dd06e8cbd8f057c1c66b7c11c72cc12921ee60570599661f3407d3`
- Base (`main` @ `f7a9d899`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0` harness, 3786 pass / 1 fail / 0 skip. Failures: same test, `src/server/ctoStores.test.mjs:249`. log sha256: `a571112472b15d635db98cd6b2554ed1fd39a57c0a7e7a79944d0adbaf054f54`
- **Conclusion:** the 1 failure is pre-existing and identical between branches — a flaky cross-process ledger race when the full suite runs concurrently (passes in isolation on both branches; also reproduced on a bare `main` run). 0 new failures, 0 resolved. `ctoBudget.test.mjs` passes 48/48 in isolation; the two new tests pin the fix.

Follow-up filed: BET-1493 (flaky full-suite ledger race — pre-existing, out of scope here).

Base: origin/main @ f7a9d899