### PR TITLE
Persist the in-flight CTO ask registry across restarts (BET-1407)

### DIFF
--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -29,6 +29,13 @@
 // (2) health escalations — the watchdog's blocker-card requests that A2
 // (ctoEngine) already writes to `engine-state.json` `pendingBlockers`.
 //
+// BET-1407: the worker-ask registry is persisted (engine-state.json
+// `pendingAsks`, via the engine's bound patchEngineState — same single write
+// path as `pendingBlockers`) and seeded back on start, so a restart mid-ask
+// cannot drop an ask that had already crossed the 10-min card threshold.
+// Entries past the existing blocker retention window (INBOX_TTL_MS.blocker)
+// are dropped at seed; promoted asks are consumed from the registry.
+//
 // Determinism + testability: pure helpers are exported (stableCardId, ask
 // event classification, blocker copy); the stateful card manager is
 // `createCtoCards` with injected store/ledger/clock exactly like the other
@@ -37,8 +44,10 @@
 
 import { createHash } from "node:crypto";
 import {
+  INBOX_TTL_MS,
   cardsStore,
   engineStateStore,
+  isExpired,
   ledgerStore,
   patchStore,
 } from "./ctoStores.mjs";
@@ -171,6 +180,14 @@ export function askQuestionText(evt) {
   return "";
 }
 
+// BET-1407: the in-flight ask registry's key, shared by BOTH halves (the
+// in-memory map and the persisted `pendingAsks` array): the session when the
+// ask came from one, else the stable source id (sessionless inbox notes).
+// One derivation — memory and store can never disagree on identity.
+function askKeyOf(a) {
+  return (a && (a.sessionID || a.sourceId)) ?? null;
+}
+
 // BET-1463: the health-card grouping identity for one `pendingBlockers`
 // entry — every entry from the same underlying trip source (`recordBlocker`'s
 // `source` param, e.g. "watchdog" | "rate_limit") is the SAME ongoing
@@ -225,12 +242,19 @@ export function createCtoCards(deps = {}) {
     // `(fresh) => patch` function. Defaults to null (a no-op) so standalone/
     // test usage that doesn't care about pendingBlockers lifecycle keeps
     // working without wiring it.
-    patchEngineState: patchPendingBlockers = null,
+    // BET-1407: the SAME bound instance now also carries the worker-ask
+    // registry's persisted half (engine-state.json `pendingAsks`) — one
+    // writer, one mutex, one consume-and-prune shape for both queues.
+    patchEngineState: patchEngineStatePatch = null,
   } = deps;
 
-  // In-flight worker asks: sessionID -> { sourceKind, sourceId, sessionID,
-  // body, askedAt }. Kept in memory (derived from the live event stream); once
-  // promoted, the card itself is durable in cards.json.
+  // In-flight worker asks: key (sessionID, or sourceId for sessionless inbox
+  // notes) -> { sourceKind, sourceId, sessionID, body, askedAt, refs? }.
+  // BET-1407: no longer memory-only — every registration mirrors into
+  // engine-state.json `pendingAsks` (see registerAsk) and start() seeds this
+  // map back from it, so an ask that crossed the 10-min card threshold while
+  // the box was down still promotes instead of being lost. Once promoted, the
+  // card itself is durable in cards.json and the registry entry is consumed.
   const pendingAsks = new Map();
 
   // Source (3): a `blocker` inbox note (BET-1397 / spec §4.4). This is the ONE
@@ -256,8 +280,7 @@ export function createCtoCards(deps = {}) {
     // sending session when known, else by a stable hash of the tag/message;
     // the card id stays stable across re-reports of the same note (upsert).
     const sourceId = stableCardId(INBOX_SOURCE_KIND, tag || text);
-    const key = typeof sessionID === "string" && sessionID ? sessionID : sourceId;
-    pendingAsks.set(key, {
+    await registerAsk({
       sourceKind: INBOX_SOURCE_KIND,
       sourceId,
       sessionID: typeof sessionID === "string" ? sessionID : undefined,
@@ -266,6 +289,52 @@ export function createCtoCards(deps = {}) {
       askedAt: ts,
     });
     return { changed: true, notified: true };
+  }
+
+  // BET-1407: best-effort persist of one registry change through the engine's
+  // bound patchEngineState — the SAME sanctioned read-modify-write path
+  // recordBlocker and the pendingBlockers writers use (one process-wide
+  // mutex, no second write path, no bare save). A null writer (standalone/
+  // test usage without the engine) is a memory-only registry.
+  async function persistPendingAsks(mutation) {
+    if (typeof patchEngineStatePatch !== "function") return;
+    try {
+      await patchEngineStatePatch(mutation);
+    } catch {
+      /* best-effort — a registry write failure never takes the card path down */
+    }
+  }
+
+  // BET-1407: ONE registration idiom for BOTH ask sources (worker asks via
+  // onAskStart, inbox blocker notes via onInboxBlocker) — set the in-memory
+  // row, then mirror it into engine-state.json `pendingAsks` under the same
+  // key. Replace-in-place, never duplicate: re-registration is a no-op upsert
+  // in both halves.
+  async function registerAsk(ask) {
+    const key = askKeyOf(ask);
+    if (key == null) return;
+    pendingAsks.set(key, ask);
+    await persistPendingAsks((fresh) => {
+      const rows = Array.isArray(fresh?.pendingAsks) ? [...fresh.pendingAsks] : [];
+      const idx = rows.findIndex((r) => askKeyOf(r) === key);
+      if (idx >= 0) rows[idx] = ask;
+      else rows.push(ask);
+      return { pendingAsks: rows };
+    });
+  }
+
+  // BET-1407: remove registry rows by key from BOTH halves (the in-memory map
+  // and the persisted array). Best-effort; a pure no-op patch (no save) when
+  // no row matches. Malformed rows (unkeyable) are never matched.
+  async function removePendingAskRows(keys) {
+    const keySet = new Set((keys ?? []).filter((k) => k != null));
+    if (!keySet.size) return;
+    for (const k of keySet) pendingAsks.delete(k);
+    await persistPendingAsks((fresh) => {
+      const rows = Array.isArray(fresh?.pendingAsks) ? fresh.pendingAsks : [];
+      const next = rows.filter((r) => !keySet.has(askKeyOf(r)));
+      return next.length === rows.length ? {} : { pendingAsks: next };
+    });
   }
 
   async function ledgerAppend(entry) {
@@ -408,9 +477,9 @@ export function createCtoCards(deps = {}) {
   // when its health card closes — resolved or dismissed). Best-effort, and a
   // pure no-op patch (no save) when nothing in the group is left.
   async function dropPendingBlockersByGroup(group) {
-    if (!group || typeof patchPendingBlockers !== "function") return;
+    if (!group || typeof patchEngineStatePatch !== "function") return;
     try {
-      await patchPendingBlockers((fresh) => {
+      await patchEngineStatePatch((fresh) => {
         const pending = Array.isArray(fresh?.pendingBlockers) ? fresh.pendingBlockers : [];
         const next = pending.filter((b) => healthGroupKey(b) !== group);
         return next.length === pending.length ? {} : { pendingBlockers: next };
@@ -425,9 +494,9 @@ export function createCtoCards(deps = {}) {
   // Best-effort; a missed stamp just means the same entry (harmlessly)
   // upserts the same card again next tick — the upsert itself is idempotent.
   async function markPendingBlockersConsumed(ids) {
-    if (!ids.length || typeof patchPendingBlockers !== "function") return;
+    if (!ids.length || typeof patchEngineStatePatch !== "function") return;
     try {
-      await patchPendingBlockers((fresh) => {
+      await patchEngineStatePatch((fresh) => {
         const pending = Array.isArray(fresh?.pendingBlockers) ? fresh.pendingBlockers : [];
         const idSet = new Set(ids);
         let touched = false;
@@ -456,16 +525,19 @@ export function createCtoCards(deps = {}) {
   // Register a worker is now blocked on an ask. No card yet — the card appears
   // only once promoteDue sees the ask past BLOCKER_AFTER_MS (or via a health
   // escalation). Re-registration (global + scoped duplicate) is a no-op upsert.
+  // BET-1407: the ask also lands in engine-state.json `pendingAsks` so a
+  // restart mid-ask can seed it back.
   async function onAskStart({ sourceKind, sourceId, sessionID, body, ts = now() }) {
     if (!sessionID) return;
-    pendingAsks.set(sessionID, { sourceKind, sourceId, sessionID, body, askedAt: ts });
+    await registerAsk({ sourceKind, sourceId, sessionID, body, askedAt: ts });
   }
 
   // The ask was answered/rejected, or the owning session aborted → liveness
-  // predicate false: resolve any open blocker card for that session.
+  // predicate false: resolve any open blocker card for that session, and
+  // (BET-1407) prune the ask from both registry halves.
   async function onAskResolved({ sessionID, ts = now() } = {}) {
     if (!sessionID) return { changed: false };
-    pendingAsks.delete(sessionID);
+    await removePendingAskRows([sessionID]);
     return resolveForSession(sessionID, "ask answered", ts);
   }
 
@@ -481,9 +553,15 @@ export function createCtoCards(deps = {}) {
 
   // The 10-min card timer: promote every in-flight ask past BLOCKER_AFTER_MS
   // into its blocker card. `{changed, promoted}` for diagnostics/tests.
+  // BET-1407: each promoted ask is CONSUMED — removed from both registry
+  // halves — because the card is now the durable surface (cards.json survives
+  // restarts; the entry's job ends when the card machinery owns it). Removed
+  // AFTER the upsert so a crash in between can only re-add the entry, which
+  // converges on the next tick's byte-identical no-op upsert.
   async function promoteDue({ nowMs = now() } = {}) {
     let changed = false;
     let promoted = 0;
+    const consumedKeys = [];
     for (const ask of pendingAsks.values()) {
       if (nowMs - ask.askedAt < BLOCKER_AFTER_MS) continue;
       const r = await upsertBlocker({
@@ -498,8 +576,54 @@ export function createCtoCards(deps = {}) {
       });
       changed = changed || r.changed;
       if (r.isNew) promoted += 1;
+      consumedKeys.push(askKeyOf(ask));
     }
+    if (consumedKeys.length) await removePendingAskRows(consumedKeys);
     return { changed, promoted };
+  }
+
+  // BET-1407: restart resilience — rebuild the in-memory registry from its
+  // persisted half on engine start. An ask that crossed the 10-min card
+  // threshold while the box was down still promotes on the next card tick
+  // instead of being lost (the memory-only registry's "Resume doesn't work"
+  // gap — the same class of bug BET-1463 fixed for pendingBlockers).
+  //
+  // Bound: entries past the EXISTING blocker retention window
+  // (INBOX_TTL_MS.blocker — the week every blocker-class entry keeps, §4.4)
+  // are dropped from BOTH halves — the registry must not accumulate forever,
+  // and engine-state.json is not covered by the ctoStores retention sweeper.
+  // Boundary-exact via the shared isExpired helper (an entry exactly at the
+  // cutoff is kept). Rows that cannot be keyed or aged (no sessionID/sourceId,
+  // no numeric askedAt) are unreconstructable and dropped with the stale ones
+  // — a row with no askedAt would otherwise promote instantly on every
+  // restart (nowMs - undefined is NaN, which skips the threshold check).
+  // Pure no-op write when nothing is dropped. `{seeded, dropped}` for
+  // diagnostics/tests.
+  async function seedPendingAsks({ nowMs = now() } = {}) {
+    let payload;
+    try {
+      payload = await engineState.load();
+    } catch {
+      return { seeded: 0, dropped: 0 };
+    }
+    const rows = Array.isArray(payload?.pendingAsks) ? payload.pendingAsks : [];
+    const keep = [];
+    let dropped = 0;
+    for (const row of rows) {
+      const key = askKeyOf(row);
+      if (
+        key != null &&
+        typeof row?.askedAt === "number" &&
+        !isExpired(row.askedAt, { nowMs, retentionMs: INBOX_TTL_MS.blocker })
+      ) {
+        keep.push(row);
+        pendingAsks.set(key, row);
+      } else {
+        dropped += 1;
+      }
+    }
+    if (dropped) await persistPendingAsks(() => ({ pendingAsks: keep }));
+    return { seeded: keep.length, dropped };
   }
 
   // Source (2): read the watchdog's blocker-card requests that A2 already
@@ -782,6 +906,7 @@ export function createCtoCards(deps = {}) {
     onAskStart,
     onAskResolved,
     onInboxBlocker,
+    seedPendingAsks,
     promoteDue,
     ingestHealthEscalations,
     onHealthRecovered,

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -13,6 +13,7 @@ import {
   isAskStartEvent,
   stableCardId,
 } from "./ctoCards.mjs";
+import { INBOX_TTL_MS } from "./ctoStores.mjs";
 
 // A fully-injected card harness: real in-memory card store, engine-state,
 // ledger and a clock we control. No real fs — pure behavior. The
@@ -71,6 +72,11 @@ function makeHarness({ pendingBlockers = [], fireNotify = false } = {}) {
     },
     setPendingBlockers(b) {
       engineState = { v: 1, pendingBlockers: b };
+    },
+    // BET-1407: pre-load the persisted ask registry (engine-state.json
+    // `pendingAsks`) the way a previous boot would have left it.
+    setPendingAsks(rows) {
+      engineState = { v: 1, pendingBlockers: [], pendingAsks: [...rows] };
     },
     advance(ms) {
       clock.ms += ms;
@@ -597,4 +603,124 @@ test("resolveConnectCards: resolves the open card for the tool and writes the le
   // Resolving an absent tool changes nothing.
   const r2 = await h.cards.resolveConnectCards("ghost", "no-op");
   assert.equal(r2.changed, false);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1407: the in-flight ask registry is persisted (engine-state.json
+// `pendingAsks`) through the SAME patchEngineState seam the pendingBlockers
+// writers use, seeded back on start, bounded by the existing blocker
+// retention window, and consumed on promotion/resolution.
+// ---------------------------------------------------------------------------
+
+test("BET-1407: onAskStart persists the ask into engine-state pendingAsks; re-registration replaces, never duplicates", async () => {
+  const h = makeHarness();
+  await h.cards.onAskStart({ sourceKind: "question", sourceId: "que_1", sessionID: "s1", body: "Pick one?", ts: h.clock.ms });
+  let rows = h.engineStateSnapshot().pendingAsks;
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0], { sourceKind: "question", sourceId: "que_1", sessionID: "s1", body: "Pick one?", askedAt: h.clock.ms });
+  // Duplicate registration (global + scoped event) replaces the row — one
+  // entry per ask in both registry halves.
+  h.advance(1000);
+  await h.cards.onAskStart({ sourceKind: "question", sourceId: "que_1", sessionID: "s1", body: "Pick one?", ts: h.clock.ms });
+  rows = h.engineStateSnapshot().pendingAsks;
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].askedAt, h.clock.ms);
+  // Memory and store agree on the same key set.
+  assert.equal(h.engineStateSnapshot().pendingAsks.length, 1);
+});
+
+test("BET-1407: onInboxBlocker persists its registration under the same idiom (keyed by sessionID or sourceId)", async () => {
+  const h = makeHarness({ fireNotify: true });
+  await h.cards.onInboxBlocker({ message: "deploy failed", tag: "deploy", sessionID: "s7", ts: h.clock.ms });
+  let rows = h.engineStateSnapshot().pendingAsks;
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].sessionID, "s7");
+  assert.equal(rows[0].sourceKind, "inbox");
+  // A sessionless note keys by its stable source id.
+  await h.cards.onInboxBlocker({ message: "disk almost full", tag: "disk", ts: h.clock.ms });
+  rows = h.engineStateSnapshot().pendingAsks;
+  assert.equal(rows.length, 2);
+  assert.equal(rows[1].sessionID, undefined);
+  assert.ok(rows[1].sourceId);
+});
+
+test("BET-1407: promoteDue consumes the promoted ask — removed from the registry and engine-state, no re-promotion", async () => {
+  const h = makeHarness();
+  const t0 = h.clock.ms;
+  await h.cards.onAskStart({ sourceKind: "question", sourceId: "que_1", sessionID: "s1", body: "Pick one?", ts: t0 });
+  h.advance(BLOCKER_AFTER_MS + 60_000);
+  const r = await h.cards.promoteDue();
+  assert.equal(r.promoted, 1);
+  assert.equal(openCardCount(h), 1);
+  // The registry entry is gone from BOTH halves once the card owns the surface.
+  assert.equal(h.engineStateSnapshot().pendingAsks.length, 0);
+  // A second tick re-promotes nothing (no card dup, no registry resurrection).
+  const r2 = await h.cards.promoteDue();
+  assert.equal(r2.promoted, 0);
+  assert.equal(r2.changed, false);
+  assert.equal(openCardCount(h), 1);
+  assert.equal(h.engineStateSnapshot().pendingAsks.length, 0);
+});
+
+test("BET-1407: onAskResolved prunes the persisted registry row", async () => {
+  const h = makeHarness();
+  await h.cards.onAskStart({ sourceKind: "question", sourceId: "que_1", sessionID: "s1", body: "Pick one?", ts: h.clock.ms });
+  assert.equal(h.engineStateSnapshot().pendingAsks.length, 1);
+  await h.cards.onAskResolved({ sessionID: "s1", ts: h.clock.ms });
+  assert.equal(h.engineStateSnapshot().pendingAsks.length, 0);
+});
+
+test("BET-1407: seedPendingAsks restores in-flight asks — an ask past the 10-min threshold promotes on the next tick", async () => {
+  const h = makeHarness();
+  const t0 = h.clock.ms;
+  // What a previous boot persisted: one ask that crossed the threshold while
+  // the box was down, one young ask.
+  h.setPendingAsks([
+    { sourceKind: "question", sourceId: "que_old", sessionID: "s_old", body: "Old ask", askedAt: t0 - (BLOCKER_AFTER_MS + 60_000) },
+    { sourceKind: "question", sourceId: "que_new", sessionID: "s_new", body: "Young ask", askedAt: t0 - 60_000 },
+  ]);
+  const seeded = await h.cards.seedPendingAsks();
+  assert.equal(seeded.seeded, 2);
+  assert.equal(seeded.dropped, 0);
+  // The straddled ask promotes — the card is not lost to the restart.
+  const r = await h.cards.promoteDue();
+  assert.equal(r.promoted, 1);
+  const open = h.store().cards.filter((c) => c.variant === "blocker" && c.state === "open");
+  assert.equal(open.length, 1);
+  assert.equal(open[0].sessionID, "s_old");
+  // The consumed entry leaves the persisted registry; the young ask remains.
+  assert.deepEqual(h.engineStateSnapshot().pendingAsks.map((a) => a.sessionID), ["s_new"]);
+});
+
+test("BET-1407: seedPendingAsks drops asks past the existing blocker retention window (INBOX_TTL_MS.blocker) from both halves", async () => {
+  const h = makeHarness();
+  const t0 = h.clock.ms;
+  const cutoff = t0 - INBOX_TTL_MS.blocker;
+  h.setPendingAsks([
+    { sourceKind: "question", sourceId: "que_rot", sessionID: "s_rot", body: "rotted", askedAt: cutoff - 1 },
+    { sourceKind: "question", sourceId: "que_edge", sessionID: "s_edge", body: "at the cutoff is kept", askedAt: cutoff },
+    { sourceKind: "question", sourceId: "que_young", sessionID: "s_young", body: "young", askedAt: t0 - 60_000 },
+  ]);
+  const seeded = await h.cards.seedPendingAsks();
+  assert.equal(seeded.seeded, 2);
+  assert.equal(seeded.dropped, 1);
+  // Dropped from the persisted half too (the file must not accumulate).
+  assert.deepEqual(h.engineStateSnapshot().pendingAsks.map((a) => a.sessionID), ["s_edge", "s_young"]);
+  // Malformed rows (unkeyable / unageable) are unreconstructable — dropped.
+  h.setPendingAsks([
+    { sourceKind: "question", sourceId: "que_x", body: "no askedAt" },
+    { body: "no key", askedAt: t0 },
+  ]);
+  const seeded2 = await h.cards.seedPendingAsks();
+  assert.equal(seeded2.seeded, 0);
+  assert.equal(seeded2.dropped, 2);
+  assert.equal(h.engineStateSnapshot().pendingAsks.length, 0);
+});
+
+test("BET-1407: seedPendingAsks with no persisted registry is a pure no-op (no engine-state write)", async () => {
+  const h = makeHarness();
+  const patchesBefore = h.patchCalls.length;
+  const seeded = await h.cards.seedPendingAsks();
+  assert.deepEqual(seeded, { seeded: 0, dropped: 0 });
+  assert.equal(h.patchCalls.length, patchesBefore);
 });

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -363,6 +363,11 @@ export function createCtoEngine(deps = {}) {
       cardStore: bundle.cards,
       engineState,
       patchEngineState: (mutation) => patchEngineState(mutation, { engineState }),
+      // The engine's clock is authoritative for the cards module too — one
+      // now for promoteDue thresholds AND the BET-1407 seed's retention
+      // bound (a test's fake clock must not make every persisted ask look
+      // ancient against a real Date.now()).
+      now,
     }),
     // A5 evidence/presence seams (injected I/O — nothing here touches tmux /
     // push directly; index.mjs supplies the real resolvers).
@@ -2269,8 +2274,21 @@ export function createCtoEngine(deps = {}) {
     };
   }
 
-  function start() {
+  async function start() {
     if (disposed) throw new Error("cto engine already disposed");
+    // BET-1407: restart resilience — rebuild the in-flight ask registry from
+    // its persisted half (engine-state.json `pendingAsks`) BEFORE the first
+    // card tick, so an ask that crossed the 10-min card threshold while the
+    // box was down still promotes instead of being lost. Same seam guard as
+    // segmenter.boot — a test-injected cards fake without the seed stays
+    // valid. Best-effort: a failed seed degrades to a fresh registry.
+    if (typeof cards?.seedPendingAsks === "function") {
+      try {
+        await cards.seedPendingAsks();
+      } catch {
+        /* best-effort */
+      }
+    }
     // Load the persisted segmentation G (minutes) from engine-state (§5.1-d).
     if (segmenter && typeof segmenter.boot === "function") {
       void segmenter.boot().catch(() => {});

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -30,6 +30,7 @@ import { createSegmenter } from "./ctoSegments.mjs";
 import { startOfDay } from "./ctoRollups.mjs";
 import { createFactsEngine } from "./ctoFacts.mjs";
 import { windowFor } from "./ctoRollups.mjs";
+import { BLOCKER_AFTER_MS } from "./ctoCards.mjs";
 
 // Build a fully-injected engine harness: no real fs, no real stores, a fake
 // clock we can advance. Everything the engine touches goes through these
@@ -93,33 +94,50 @@ function makeMemoryStores() {
   };
 }
 
-function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts } = {}) {
+function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts, realCards = false, engineStateInit = {} } = {}) {
   const clock = { ms: 1_000_000 };
   const now = () => clock.ms;
   const ledgerRows = [];
   let pendingBlockers = [];
+  let pendingAsks = Array.isArray(engineStateInit?.pendingAsks) ? engineStateInit.pendingAsks : [];
   let killSwitchPaused = false;
   let published = [];
   let currentConfig = { ctoEnabled };
   const cardCalls = [];
-  const state = { v: 1, pendingBlockers: [] };
+  const state = { v: 1, pendingBlockers: [], ...(engineStateInit ?? {}) };
   const budgetCfg = { budgetIsHit: false, tier: "low" };
   const memStores = makeMemoryStores();
   memStores.ledger.append = async (row) => ledgerRows.push(row);
+  // BET-1407: with `realCards` the engine builds its REAL cards manager over
+  // the bundle's cards store — captured here so tests can assert cards.json
+  // contents without real fs.
+  let cardsPayload = { v: 1, cards: [] };
+  if (realCards) {
+    memStores.cards = {
+      load: async () => ({ ...cardsPayload }),
+      save: async (p) => {
+        cardsPayload = { ...p };
+      },
+    };
+  }
 
   const engine = createCtoEngine({
     configGet: async () => ({ ...currentConfig }),
     stores: memStores,
-    cards: {
-      onAskStart: (...a) => (cardCalls.push({ fn: "onAskStart", args: a }), Promise.resolve()),
-      onAskResolved: (...a) => (
-        cardCalls.push({ fn: "onAskResolved", args: a }),
-        Promise.resolve({ changed: false })
-      ),
-      onHealthRecovered: (...a) => (cardCalls.push({ fn: "onHealthRecovered", args: a }), Promise.resolve()),
-      promoteDue: async () => ({}),
-      ingestHealthEscalations: async () => ({}),
-    },
+    ...(realCards
+      ? {}
+      : {
+          cards: {
+            onAskStart: (...a) => (cardCalls.push({ fn: "onAskStart", args: a }), Promise.resolve()),
+            onAskResolved: (...a) => (
+              cardCalls.push({ fn: "onAskResolved", args: a }),
+              Promise.resolve({ changed: false })
+            ),
+            onHealthRecovered: (...a) => (cardCalls.push({ fn: "onHealthRecovered", args: a }), Promise.resolve()),
+            promoteDue: async () => ({}),
+            ingestHealthEscalations: async () => ({}),
+          },
+        }),
     engineState: {
       load: async () => ({ ...state }),
       save: async (payload) => {
@@ -127,6 +145,8 @@ function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts } = {}) {
           ? payload.pendingBlockers
           : [];
         state.pendingBlockers = pendingBlockers;
+        pendingAsks = Array.isArray(payload?.pendingAsks) ? payload.pendingAsks : [];
+        state.pendingAsks = pendingAsks;
         if (payload?.rollupCursor) state.rollupCursor = payload.rollupCursor;
         if (payload?.segmentGMinutes != null) state.segmentGMinutes = payload.segmentGMinutes;
       },
@@ -170,6 +190,10 @@ function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts } = {}) {
     get pendingBlockers() {
       return pendingBlockers;
     },
+    get pendingAsks() {
+      return pendingAsks;
+    },
+    cardsStore: () => cardsPayload,
     get killSwitchPaused() {
       return killSwitchPaused;
     },
@@ -1046,4 +1070,58 @@ test("the engine surface declares get cards() exactly once (BET-1466 item 7: dup
   const src = readFileSync(new URL("./ctoEngine.mjs", import.meta.url), "utf8");
   const count = src.split("get cards()").length - 1;
   assert.equal(count, 1, "a duplicated object-literal key silently shadows its twin");
+});
+
+// ---------------------------------------------------------------------------
+// BET-1407: the in-flight ask registry survives restarts. `start()` seeds it
+// from the persisted half (engine-state.json `pendingAsks`) so an ask that
+// crossed the 10-min card threshold while the box was down still promotes on
+// the next card tick, and a promoted ask is consumed from both halves.
+// ---------------------------------------------------------------------------
+
+test("BET-1407: engine start() seeds pendingAsks from the persisted registry and an ask past the 10-min threshold promotes on the next card tick", async () => {
+  // The harness clock starts at 1_000_000 — askedAt literals are relative to
+  // that. One ask crossed BLOCKER_AFTER_MS while the box was down; one is
+  // still young.
+  const h = makeHarness({
+    realCards: true,
+    engineStateInit: {
+      pendingAsks: [
+        { sourceKind: "question", sourceId: "que_old", sessionID: "s_old", body: "Old ask", askedAt: 1_000_000 - (BLOCKER_AFTER_MS + 60_000) },
+        { sourceKind: "question", sourceId: "que_new", sessionID: "s_new", body: "Young ask", askedAt: 1_000_000 - 60_000 },
+      ],
+    },
+  });
+  await h.engine.start();
+  // Seeded: both rows are live in memory, and the file kept them (nothing
+  // was stale — the seed write is a pure no-op).
+  assert.deepEqual(h.pendingAsks.map((a) => a.sessionID).sort(), ["s_new", "s_old"]);
+  // The straddled ask promotes on the next card tick (called directly —
+  // deterministic stand-in for the 60s poller) and is CONSUMED from both
+  // registry halves.
+  await h.engine.cards.promoteDue();
+  const open = h.cardsStore().cards.filter((c) => c.variant === "blocker" && c.state === "open");
+  assert.equal(open.length, 1);
+  assert.equal(open[0].sessionID, "s_old");
+  assert.equal(open[0].pendingSince, 1_000_000 - (BLOCKER_AFTER_MS + 60_000));
+  assert.deepEqual(h.pendingAsks.map((a) => a.sessionID), ["s_new"]);
+  assert.deepEqual(h.pendingAsks, h.state.pendingAsks, "memory and the persisted half agree");
+  h.engine.dispose();
+});
+
+test("BET-1407: engine start() drops a persisted ask past the blocker retention window", async () => {
+  const h = makeHarness({
+    realCards: true,
+    engineStateInit: {
+      pendingAsks: [
+        // 8 days old — past the existing blocker retention window.
+        { sourceKind: "question", sourceId: "que_rot", sessionID: "s_rot", body: "rotted", askedAt: 1_000_000 - 8 * 24 * 60 * 60_000 },
+        { sourceKind: "question", sourceId: "que_new", sessionID: "s_new", body: "Young ask", askedAt: 1_000_000 - 60_000 },
+      ],
+    },
+  });
+  await h.engine.start();
+  assert.deepEqual(h.pendingAsks.map((a) => a.sessionID), ["s_new"]);
+  assert.deepEqual(h.state.pendingAsks.map((a) => a.sessionID), ["s_new"], "the stale row is dropped from the persisted half too");
+  h.engine.dispose();
 });


### PR DESCRIPTION
## BET-1407 — persist `pendingAsks` across restart

**Base: origin/main @ 1ab9f19e**

The worker-ask registry (`pendingAsks` in `ctoCards.mjs`) was memory-only, derived from the live event stream: a box restart mid-ask lost every ask that had already crossed the 10-min card threshold — no card, no resolution, silence. Same class of bug BET-1463 fixed for `pendingBlockers`.

### What changed

- **`src/server/ctoCards.mjs`** — every registration (`onAskStart` worker asks + `onInboxBlocker` inbox notes, ONE idiom via `registerAsk`) mirrors the ask into `engine-state.json` `pendingAsks` through the **same bound `patchEngineState` seam** the `pendingBlockers` writers use (one process mutex, no second write path, no bare save). `onAskResolved` and `promoteDue` consume rows from both halves; promoted asks are consumed **after** the upsert so a crash in between can only re-add an entry that converges on the next tick's byte-identical no-op upsert. New `seedPendingAsks` rebuilds the in-memory registry and drops rows past the **existing blocker retention window** (`INBOX_TTL_MS.blocker` via the shared `isExpired` helper — engine-state is not covered by the ctoStores retention sweeper). Re-registration remains a no-op upsert. **No new store file, no new constant, no new config key.**
- **`src/server/ctoEngine.mjs`** — `start()` seeds the registry before the first card tick (async, best-effort, seam-guarded so injected cards fakes without the seed stay valid); the engine's `now` is passed into the cards manager so promoteDue thresholds and the seed's retention bound share one clock (previously cards silently used `Date.now()` — unobservable in prod, but it would have made a fake-clock test's persisted asks look 55 years stale).

### Cross-cutting

- Server-only (`src/server/`); no IPC, no renderer, no mobile.
- The cards manager's default `now` wiring changed from implicit `Date.now()` to the engine's injected `now` — behaviorally identical in production.

Verification results in the first comment.