### PR TITLE
refactor(renderer): CTO drill-down reads throw on failure instead of empty renders (BET-1483)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -1739,13 +1739,8 @@ function ProfileView({
   const refresh = useCallback(async () => {
     try {
       const r = await window.api.ctoProfileGet();
-      // httpApi degrades a failed read to `emptyProfileRender()` (compiledAt
-      // 0 by construction; a server success always stamps a time). Treat that
-      // as the failure it is instead of claiming "nothing here yet".
-      if (r.compiledAt === 0) {
-        setLoadError("the profile read failed");
-        return;
-      }
+      // ctoProfileGet throws on a failed read (BET-1483) — the catch below
+      // surfaces it while the last good render stays on screen.
       setRender(r);
       setLoadError(null);
     } catch (e) {
@@ -2451,14 +2446,9 @@ function BlackboardView({
   const refresh = useCallback(async () => {
     try {
       const r = await window.api.ctoFactsGet({});
-      // httpApi degrades a failed read to `emptyFactsRender()` (compiledAt 0
-      // by construction; a server success always stamps a time). Treating it
-      // as success would swap the board — and the project chip row — for an
-      // empty render the user cannot switch back from (BET-1468 item 6).
-      if (r.compiledAt === 0) {
-        setLoadError("the blackboard read failed");
-        return;
-      }
+      // ctoFactsGet throws on a failed read (BET-1483) — the catch below keeps
+      // the board (and the project chip row) instead of swapping in an empty
+      // render the user cannot switch back from (BET-1468 item 6).
       setRender(r);
       setLoadError(null);
     } catch (e) {
@@ -2505,13 +2495,9 @@ function BlackboardView({
 
   const switchProject = async (project: string) => {
     try {
+      // ctoFactsGet throws on a failed read (BET-1483) — the catch keeps the
+      // currently displayed board and its chip row instead of wiping them.
       const r = await window.api.ctoFactsGet({ project });
-      if (r.compiledAt === 0) {
-        // Failed read (httpApi degrades to the empty render) — keep the
-        // currently displayed board and its chip row instead of wiping them.
-        pushToast({ id: `bb-switch-${Date.now()}`, message: `Couldn't switch to ${project}` });
-        return;
-      }
       setRender(r);
       setArchive([]);
       setArchiveTotal(0);
@@ -2749,13 +2735,8 @@ function ToolIntegrationsView({
   const refresh = useCallback(async () => {
     try {
       const r = await window.api.ctoToolsGet();
-      // httpApi degrades a failed read to `emptyToolsRender()` (compiledAt 0
-      // by construction; a server success always stamps a time) — treat it as
-      // the failure it is instead of claiming no tools are observed.
-      if (r.compiledAt === 0) {
-        setLoadError("the tool registry read failed");
-        return;
-      }
+      // ctoToolsGet throws on a failed read (BET-1483) — the catch below
+      // surfaces it instead of claiming no tools are observed.
       setRender(r);
       setLoadError(null);
     } catch (e) {

--- a/src/renderer/api/httpApi.test.ts
+++ b/src/renderer/api/httpApi.test.ts
@@ -56,6 +56,55 @@ beforeEach(() => {
 const HEX32 = "0123456789abcdef0123456789abcdef";
 
 // ---------------------------------------------------------------------------
+// CTO drill-down reads throw on failure (BET-1483)
+// ---------------------------------------------------------------------------
+//
+// ctoProfileGet / ctoFactsGet / ctoToolsGet used to swallow a failed read and
+// resolve with an all-empty render (compiledAt 0), which callers could only
+// detect by sniffing that sentinel. They now throw like ctoStateGet, so the
+// views' existing catch paths render the actual failure. These tests pin the
+// explicit contract: success resolves with the parsed body; 401 throws
+// AuthRequiredError; other HTTP errors and network failures reject.
+
+describe("httpApi CTO drill-down reads — explicit failure contract (BET-1483)", () => {
+  beforeEach(() => {
+    mockLocalStorage["manta_server"] = "https://example.com";
+    mockLocalStorage["manta_token"] = HEX32;
+  });
+
+  const drillDowns = [
+    { name: "ctoProfileGet", call: () => httpApi.ctoProfileGet(), path: "/api/cto/profile", okBody: { compiledAt: 42, skills: [] } },
+    { name: "ctoFactsGet", call: () => httpApi.ctoFactsGet({ project: "p" }), path: "/api/cto/facts?project=p", okBody: { compiledAt: 42, project: "p", active: [] } },
+    { name: "ctoToolsGet", call: () => httpApi.ctoToolsGet(), path: "/api/cto/tools", okBody: { compiledAt: 42, tools: [], never: [] } },
+  ] as const;
+
+  for (const d of drillDowns) {
+    it(`${d.name} resolves with the parsed body on success`, async () => {
+      stubFetch().mockImplementation(async () => new Response(JSON.stringify(d.okBody), { status: 200, headers: { "content-type": "application/json" } }));
+      const body = (await d.call()) as { compiledAt: number };
+      expect(body.compiledAt).toBe(42);
+    });
+
+    it(`${d.name} throws on an HTTP error instead of an empty render`, async () => {
+      stubFetch().mockImplementation(async () => new Response(JSON.stringify({ error: "no" }), { status: 503 }));
+      await expect(d.call()).rejects.toThrow("HTTP 503");
+    });
+
+    it(`${d.name} throws AuthRequiredError on 401`, async () => {
+      stubFetch().mockImplementation(async () => new Response("{}", { status: 401 }));
+      await expect(d.call()).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it(`${d.name} rejects on a network failure (no empty render)`, async () => {
+      const fetchMock = stubFetch().mockImplementation(async () => { throw new Error("fetch failed"); });
+      await expect(d.call()).rejects.toThrow("fetch failed");
+      expect((fetchMock.mock.calls[0][0] as string).includes(d.path)).toBe(true);
+    });
+  }
+});
+
+
+// ---------------------------------------------------------------------------
 // authHeaders — attach Bearer when a token is present
 // ---------------------------------------------------------------------------
 

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1914,21 +1914,14 @@ export const httpApi: Api = {
 
   // GET /api/cto/profile — the §8.5 profile & §3.2 journal drill-down render
   // model, composed server-side (Settings → Internals → Profile & rhythm).
-  // A rejection (engine off / server down) degrades to an empty model so the
-  // drill-down renders an "inert / no data yet" state rather than crashing.
+  // Throws on failure (engine off / server down / HTTP error), like ctoStateGet
+  // — the caller's catch renders the failure instead of a "no data yet" state.
   ctoProfileGet: async (): Promise<CtoProfileRender> => {
     const url = `${serverBase()}/api/cto/profile`;
-    let res: Response;
-    try {
-      res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
-    } catch {
-      return emptyProfileRender();
-    }
+    const res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
     if (res.status === 401) throw new AuthRequiredError();
-    if (!res.ok) return emptyProfileRender();
-    let json: CtoProfileRender = emptyProfileRender();
-    try { json = (await res.json()) as CtoProfileRender; } catch { /* non-JSON */ }
-    return json;
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return (await res.json()) as CtoProfileRender;
   },
 
   // POST /api/cto/profile/edit — inline profile edit (stated wins, §8.5).
@@ -1993,24 +1986,16 @@ export const httpApi: Api = {
   },
 
   // GET /api/cto/facts — the Blackboard drill-down render model (§10.5 row 1,
-  // BET-1399), composed server-side. A rejection degrades to an empty model
-  // so the drill-down renders an "inert / no data yet" state.
+  // BET-1399), composed server-side. Throws on failure, like ctoStateGet.
   ctoFactsGet: async (input?: { project?: string | null; asOf?: number | null }): Promise<CtoFactsRender> => {
     const qs = new URLSearchParams();
     if (input?.project) qs.set("project", input.project);
     if (input?.asOf != null && Number.isFinite(input.asOf)) qs.set("asOf", String(Math.floor(input.asOf)));
     const url = `${serverBase()}/api/cto/facts${qs.toString() ? `?${qs.toString()}` : ""}`;
-    let res: Response;
-    try {
-      res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
-    } catch {
-      return emptyFactsRender();
-    }
+    const res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
     if (res.status === 401) throw new AuthRequiredError();
-    if (!res.ok) return emptyFactsRender();
-    let json: CtoFactsRender = emptyFactsRender();
-    try { json = (await res.json()) as CtoFactsRender; } catch { /* non-JSON */ }
-    return json;
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return (await res.json()) as CtoFactsRender;
   },
 
   // GET /api/cto/facts/archive — read-only paginated archive browser (§6.3).
@@ -2075,19 +2060,13 @@ export const httpApi: Api = {
   },
 
   // GET /api/cto/tools — the tool-integrations drill-down render (§10.5 row 4).
+  // Throws on failure, like ctoStateGet.
   ctoToolsGet: async (): Promise<CtoToolsRender> => {
     const url = `${serverBase()}/api/cto/tools`;
-    let res: Response;
-    try {
-      res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
-    } catch {
-      return emptyToolsRender();
-    }
+    const res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
     if (res.status === 401) throw new AuthRequiredError();
-    if (!res.ok) return emptyToolsRender();
-    let json: CtoToolsRender = emptyToolsRender();
-    try { json = (await res.json()) as CtoToolsRender; } catch { /* non-JSON */ }
-    return json;
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return (await res.json()) as CtoToolsRender;
   },
 
   // POST /api/cto/tools/revoke — per-ring revoke (§10.5 row 4).
@@ -2127,8 +2106,8 @@ export const httpApi: Api = {
   },
 };
 
-// A safe all-empty default so the profile drill-down renders an inert state
-// (and never crashes) while the engine has no data or the box is offline.
+// A safe all-empty default so a failed profile edit/suppress still resolves
+// with the `{ok:false,error}` shape the caller checks explicitly.
 function emptyProfileRender(): CtoProfileRender {
   return {
     compiledAt: 0,
@@ -2155,17 +2134,6 @@ function emptyProfileRender(): CtoProfileRender {
     sensitive: [],
     journal: [],
   };
-}
-
-// Safe all-empty defaults for the BET-1399 drill-downs so the Blackboard and
-// tool-integrations panels render an inert state (never crash) while the
-// engine has no data or the box is offline.
-function emptyFactsRender(): CtoFactsRender {
-  return { compiledAt: 0, project: null, projects: [], asOf: null, active: [], superseded: [] };
-}
-
-function emptyToolsRender(): CtoToolsRender {
-  return { compiledAt: 0, tools: [], never: [] };
 }
 
 // Base64-encode an ArrayBuffer in chunks. `btoa(String.fromCharCode(...))`

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1380,6 +1380,7 @@ export interface Api {
   }): Promise<{ ok: boolean; error?: string; effects?: { success?: boolean; rejection?: boolean; access?: boolean; decay?: boolean } }>;
   // GET /api/cto/profile — the §8.5 profile & §3.2 journal drill-down render
   // model, composed server-side (Settings → Internals → Profile & rhythm).
+  // Throws on failure (like ctoStateGet) — callers render the error state.
   ctoProfileGet(): Promise<CtoProfileRender>;
   // POST /api/cto/profile/edit — inline profile edit: writes a `stated` value
   // that wins over inference for that dimension (§8.5) + a `correct` verdict.
@@ -1398,6 +1399,7 @@ export interface Api {
   // GET /api/cto/facts — the Blackboard drill-down render (§10.5 row 1):
   // facts per project, active + superseded struck-through, optional
   // bi-temporal asOf. A missing project selects the first known one.
+  // Throws on failure (like ctoStateGet) — callers render the error state.
   ctoFactsGet(input?: { project?: string | null; asOf?: number | null }): Promise<CtoFactsRender>;
   // GET /api/cto/facts/archive — read-only paginated archive browser (§6.3).
   ctoFactsArchiveGet(input?: { project?: string | null; before?: number | null; limit?: number }): Promise<CtoFactsArchivePage>;
@@ -1416,6 +1418,7 @@ export interface Api {
   ctoFactPin(input: { project: string; factId: string }): Promise<{ ok: boolean; error?: string; touched?: number }>;
   // GET /api/cto/tools — the tool-integrations drill-down render (§10.5
   // row 4): registry + probes joined, plus the never list.
+  // Throws on failure (like ctoStateGet) — callers render the error state.
   ctoToolsGet(): Promise<CtoToolsRender>;
   // POST /api/cto/tools/revoke — per-ring revoke (ring → "no"; metadata
   // revoke stops that tool's probes via the consent gate).


### PR DESCRIPTION
## Summary

Closes BET-1483. The three CTO drill-down read paths (`ctoProfileGet`, `ctoFactsGet`, `ctoToolsGet`) swallowed every failed read — network failure, HTTP error, even a non-JSON success body — and resolved with an all-empty render (`compiledAt: 0`). The views then smuggled the failure back out by sniffing that sentinel (`r.compiledAt === 0`), which is exactly the accidental convention BET-1468 items 6/7 were patched around.

This makes the failure explicit: the getters now **throw on failure like `ctoStateGet`** (BET-1468's chosen reference pattern), and the drill-downs' existing `catch` paths render the actual error. The views lose their `compiledAt === 0` sniffing entirely.

## Changes

- `src/renderer/api/httpApi.ts` — the three getters throw on `!res.ok` and let fetch/parse rejections propagate; 401 still throws `AuthRequiredError` (unchanged). Deleted the now-dead `emptyFactsRender`/`emptyToolsRender` factories; `emptyProfileRender` stays as the `{ok:false,error}` base for edit/suppress (which resolve with an explicit `ok` contract, not the sentinel).
- `src/renderer/CtoPanel.tsx` — dropped all four `compiledAt === 0` checks (profile refresh, blackboard refresh, `switchProject`, tools refresh). Failure semantics preserved and sharpened: last-good render stays on screen, `loadError` now carries the real cause (`HTTP 503`, `fetch failed`, …) instead of a generic "the profile read failed".
- `src/shared/api.ts` — documented the throw contract on the three `Api` declarations.
- `src/renderer/api/httpApi.test.ts` — pinned the contract: success resolves with the parsed body, HTTP error throws `HTTP <status>`, 401 throws `AuthRequiredError`, network failure rejects.

## Behavior notes

- `switchProject` previously toasted "Couldn't switch to X" on a sentinel hit; it now toasts via its catch with the actual error appended.
- The demo transport (`demoApi.ts`) is unaffected — always resolves fixture data, signatures unchanged.

Base: origin/main @ db42b722