### PR TITLE
fix(server): de-flake usage poller re-poll count test — injectable retry timers (BET-1485)

### DIFF
--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -242,6 +242,10 @@ export function createUsagePoller({
   // direct users → no history recording.
   observe = null,
   staleRetryMs = STALE_RETRY_MS,
+  // Retry scheduling is injectable (BET-1485): tests queue armed retries and
+  // fire them manually, so the re-poll count doesn't depend on 5ms real
+  // timers surviving parallel test load.
+  timers = { setTimeout, clearTimeout },
 } = {}) {
   let snapshots = [];
   let lastContentKey = null;
@@ -370,15 +374,15 @@ export function createUsagePoller({
       }
       if (!anyStale) {
         staleRetries = 0;
-        clearTimeout(staleRetry);
+        timers.clearTimeout(staleRetry);
       } else if (staleRetries < MAX_STALE_RETRIES) {
         staleRetries += 1;
         console.log(
           `[usage] window past its reset instant — re-polling in ${staleRetryMs}ms ` +
             `(${staleRetries}/${MAX_STALE_RETRIES})`,
         );
-        clearTimeout(staleRetry);
-        staleRetry = setTimeout(() => void tick(), staleRetryMs);
+        timers.clearTimeout(staleRetry);
+        staleRetry = timers.setTimeout(() => void tick(), staleRetryMs);
         staleRetry?.unref?.();
       }
 
@@ -397,7 +401,7 @@ export function createUsagePoller({
   return {
     tick,
     stop() {
-      clearTimeout(staleRetry);
+      timers.clearTimeout(staleRetry);
       stopped = true;
     },
     get snapshots() {

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -946,6 +946,44 @@ test("poller: a window with no resetsAt is never marked stale", async () => {
   assert.equal("stale" in w, false);
 });
 
+// A deterministic replacement for the poller's real retry timers (BET-1485):
+// armed retries sit in a queue until the test fires them, so the re-poll
+// count no longer depends on 5ms real timers surviving parallel test load.
+function makeFakeRetryTimers() {
+  const queue = [];
+  const timers = {
+    setTimeout: (fn) => {
+      queue.push(fn);
+      return queue.length - 1;
+    },
+    clearTimeout: (id) => {
+      queue[id] = null;
+    },
+  };
+  // Fire every armed retry, let each resulting tick finish (its awaits are
+  // already-resolved promises, so microtasks drain before setImmediate), then
+  // repeat until nothing is armed. The guard turns a runaway re-arm loop
+  // (bound exceeded) into a failure instead of a hang.
+  const fireAll = async () => {
+    for (let rounds = 0; ; rounds++) {
+      if (rounds > 5) {
+        throw new Error("retry queue kept re-arming past the bound");
+      }
+      const due = [];
+      for (let i = 0; i < queue.length; i++) {
+        if (queue[i]) {
+          due.push(queue[i]);
+          queue[i] = null;
+        }
+      }
+      if (due.length === 0) return;
+      for (const fn of due) fn();
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  };
+  return { timers, fireAll };
+}
+
 test("poller: a waiting window re-polls a bounded number of times, then stops", async () => {
   let nowMs = 1000;
   let fetchCalls = 0;
@@ -958,17 +996,17 @@ test("poller: a waiting window re-polls a bounded number of times, then stops", 
       return { windows: [{ kind: "session", label: "s", pct: 78, resetsAt: 500 }] };
     },
   });
-  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-  const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs, staleRetryMs: 5 });
+  const { timers, fireAll } = makeFakeRetryTimers();
+  const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs, timers });
 
   await poller.tick(); // retry 1 armed
   assert.equal(fetchCalls, 1);
 
   // Each armed retry is itself a tick that arms the next, up to the cap of 3.
-  await sleep(60);
+  await fireAll();
   assert.equal(fetchCalls, 4, "the initial tick plus exactly MAX_STALE_RETRIES re-polls");
 
-  await sleep(60);
+  await fireAll(); // nothing is armed anymore — fireAll is a no-op
   assert.equal(fetchCalls, 4, "the budget is spent — no further re-poll while it stays stale");
 });
 
@@ -983,22 +1021,22 @@ test("poller: the retry budget re-arms once the window stops waiting", async () 
       return { windows: [{ kind: "session", label: "s", pct: 78, resetsAt }] };
     },
   });
-  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-  const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs, staleRetryMs: 5 });
+  const { timers, fireAll } = makeFakeRetryTimers();
+  const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs, timers });
 
   await poller.tick();
-  await sleep(60);
+  await fireAll();
   const spent = fetchCalls;
   assert.ok(spent >= 2, "budget was used while waiting");
 
   resetsAt = 99999; // provider published the new window
   await poller.tick();
-  await sleep(30);
+  await fireAll(); // a non-stale tick clears any armed retry and re-arms nothing
   const afterFresh = fetchCalls;
 
   resetsAt = 500; // a later boundary
   await poller.tick();
-  await sleep(60);
+  await fireAll();
   assert.ok(fetchCalls > afterFresh + 1, "a fresh boundary gets a fresh retry budget");
 });
 

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -24,6 +24,61 @@ function makeAdapter(id, { detect, fetch: doFetch }) {
   return { id, providerIDs: [id], detect, fetch: doFetch };
 }
 
+// The poller warns (console.warn) on every adapter failure it handles; tests
+// below silence it for the duration of a run and restore it afterwards.
+async function withSilencedWarnings(run) {
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    await run();
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+// An adapter whose every fetch throws a 429 — `retryAfterMs` undefined means
+// the header is absent entirely (the bare-429 floor case).
+function makeAlwaysRateLimited(id, retryAfterMs) {
+  let calls = 0;
+  const adapter = makeAdapter(id, {
+    detect: async () => true,
+    fetch: async () => {
+      calls++;
+      const err = new Error("rate limited");
+      err.status = 429;
+      if (retryAfterMs !== undefined) err.retryAfterMs = retryAfterMs;
+      throw err;
+    },
+  });
+  return { adapter, getCalls: () => calls };
+}
+
+// An adapter that succeeds on call 1 and throws `makeError()` on call 2 — the
+// "first poll ok, then the provider breaks" shape the carry-forward logic
+// exists for.
+function makeFlakyAdapter(makeError) {
+  let calls = 0;
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => {
+      calls++;
+      if (calls === 2) throw makeError();
+      return { windows: [{ kind: "session", label: "s", pct: 42 }] };
+    },
+  });
+  return { adapter, getCalls: () => calls };
+}
+
+// Codex adapter fetch with the standard injected deps, parameterized only by
+// the response sample.
+async function fetchCodexSample(sample) {
+  return codexAdapter.fetch({
+    fetchImpl: async () => fakeResponse(200, sample),
+    readToken: async () => "tok",
+    now: () => 0,
+  });
+}
+
 // ----------------------------------------------------------------------------
 // normalizeWindow — pure
 // ----------------------------------------------------------------------------
@@ -315,36 +370,29 @@ test("poller: a 429 with Retry-After backs off only that adapter, for exactly th
   }
 });
 
-test("poller: a bare 429 with no Retry-After floors at 2 minutes", async () => {
+// Both 429-floor tests walk the same ladder: tick → still backed off one
+// minute later → retried once 2 minutes have passed in total. They differ
+// only in the 429's shape (no Retry-After header vs retry-after: 0).
+async function assert429FloorsAt2Minutes({ retryAfterMs }) {
   let nowMs = 0;
-  let calls = 0;
-  const rl = makeAdapter("rl", {
-    detect: async () => true,
-    fetch: async () => {
-      calls++;
-      const err = new Error("rate limited");
-      err.status = 429; // no retryAfterMs
-      throw err;
-    },
-  });
-  const originalWarn = console.warn;
-  console.warn = () => {};
-  try {
+  const { adapter: rl, getCalls } = makeAlwaysRateLimited("rl", retryAfterMs);
+  await withSilencedWarnings(async () => {
     const poller = createUsagePoller({ adapters: [rl], now: () => nowMs });
     await poller.tick();
-    assert.equal(calls, 1);
+    assert.equal(getCalls(), 1);
 
     nowMs += 1 * 60_000; // just under the 2-minute floor (even retry-after: 0 lands here)
     await poller.tick();
-    assert.equal(calls, 1);
+    assert.equal(getCalls(), 1);
 
-    nowMs += 2 * 60_000; // now past 2 minutes total — retried
+    nowMs += 2 * 60_000; // past 2 minutes total — retried
     await poller.tick();
-    assert.equal(calls, 2);
-  } finally {
-    console.warn = originalWarn;
-  }
-});
+    assert.equal(getCalls(), 2);
+  });
+}
+
+test("poller: a bare 429 with no Retry-After floors at 2 minutes", () =>
+  assert429FloorsAt2Minutes({ retryAfterMs: undefined }));
 
 test("rateLimitBackoffMs: clamps into the 2-15 minute band", () => {
   assert.equal(rateLimitBackoffMs(undefined), 120_000);
@@ -354,53 +402,14 @@ test("rateLimitBackoffMs: clamps into the 2-15 minute band", () => {
   assert.equal(rateLimitBackoffMs(3_600_000), 900_000); // above ceiling
 });
 
-test("poller: a 429 carrying retry-after: 0 backs off 2 minutes, not 15 (regression)", async () => {
-  let nowMs = 0;
-  let calls = 0;
-  const rl = makeAdapter("rl", {
-    detect: async () => true,
-    fetch: async () => {
-      calls++;
-      const err = new Error("rate limited");
-      err.status = 429;
-      err.retryAfterMs = 0; // Anthropic's literal retry-after: 0
-      throw err;
-    },
-  });
-  const originalWarn = console.warn;
-  console.warn = () => {};
-  try {
-    const poller = createUsagePoller({ adapters: [rl], now: () => nowMs });
-    await poller.tick();
-    assert.equal(calls, 1);
-
-    nowMs += 1 * 60_000; // before the 2-minute floor → still backed off
-    await poller.tick();
-    assert.equal(calls, 1);
-
-    nowMs += 2 * 60_000; // past 2 minutes → retried (NOT after 15)
-    await poller.tick();
-    assert.equal(calls, 2);
-  } finally {
-    console.warn = originalWarn;
-  }
-});
+test("poller: a 429 carrying retry-after: 0 backs off 2 minutes, not 15 (regression)", () =>
+  assert429FloorsAt2Minutes({ retryAfterMs: 0 }));
 
 test("poller: a failing adapter's snapshot is carried forward (same ref, unchanged fetchedAt, nothing republished)", async () => {
   let nowMs = 1_000_000;
-  let calls = 0;
-  const adapter = makeAdapter("a", {
-    detect: async () => true,
-    fetch: async () => {
-      calls++;
-      if (calls === 2) throw new Error("boom");
-      return { windows: [{ kind: "session", label: "s", pct: 42 }] };
-    },
-  });
+  const { adapter, getCalls } = makeFlakyAdapter(() => new Error("boom"));
   const published = [];
-  const originalWarn = console.warn;
-  console.warn = () => {};
-  try {
+  await withSilencedWarnings(async () => {
     const poller = createUsagePoller({
       adapters: [adapter],
       now: () => nowMs,
@@ -414,34 +423,22 @@ test("poller: a failing adapter's snapshot is carried forward (same ref, unchang
 
     nowMs += 60_000; // 1 minute later the adapter throws
     await poller.tick();
-    assert.equal(calls, 2);
+    assert.equal(getCalls(), 2);
     assert.equal(poller.snapshots.length, 1, "snapshot still present after the failed tick");
     assert.equal(poller.snapshots[0], first, "the SAME object reference is carried forward");
     assert.equal(poller.snapshots[0].fetchedAt, 1_000_000, "fetchedAt untouched");
     assert.equal(published.length, 1, "the failed tick put nothing on the bus");
-  } finally {
-    console.warn = originalWarn;
-  }
+  });
 });
 
 test("poller: carry-forward across the backoff window keeps the snapshot present", async () => {
   let nowMs = 1_000_000;
-  let calls = 0;
-  const adapter = makeAdapter("a", {
-    detect: async () => true,
-    fetch: async () => {
-      calls++;
-      if (calls === 2) {
-        const err = new Error("rate limited");
-        err.status = 429;
-        throw err;
-      }
-      return { windows: [{ kind: "session", label: "s", pct: 42 }] };
-    },
+  const { adapter, getCalls } = makeFlakyAdapter(() => {
+    const err = new Error("rate limited");
+    err.status = 429;
+    return err;
   });
-  const originalWarn = console.warn;
-  console.warn = () => {};
-  try {
+  await withSilencedWarnings(async () => {
     const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs });
     await poller.tick(); // success
     assert.equal(poller.snapshots.length, 1);
@@ -449,44 +446,30 @@ test("poller: carry-forward across the backoff window keeps the snapshot present
 
     nowMs += 1 * 60_000; // 1 min later — bare 429 sets the 2-minute floor backoff
     await poller.tick();
-    assert.equal(calls, 2, "adapter was called on the failing tick");
+    assert.equal(getCalls(), 2, "adapter was called on the failing tick");
     assert.equal(poller.snapshots.length, 1, "snapshot present after the 429");
 
     nowMs += 30_000; // still inside the 2-min backoff — adapter not even called
     await poller.tick();
-    assert.equal(calls, 2, "adapter not called while backed off");
+    assert.equal(getCalls(), 2, "adapter not called while backed off");
     assert.equal(poller.snapshots.length, 1, "snapshot carried across the backoff window");
     assert.equal(poller.snapshots[0], first, "same reference carried");
-  } finally {
-    console.warn = originalWarn;
-  }
+  });
 });
 
 test("poller: carry-forward expires after 30 minutes with no successful fetch", async () => {
   let nowMs = 1_000_000;
-  let calls = 0;
-  const adapter = makeAdapter("a", {
-    detect: async () => true,
-    fetch: async () => {
-      calls++;
-      if (calls === 2) throw new Error("boom");
-      return { windows: [{ kind: "session", label: "s", pct: 42 }] };
-    },
-  });
-  const originalWarn = console.warn;
-  console.warn = () => {};
-  try {
+  const { adapter, getCalls } = makeFlakyAdapter(() => new Error("boom"));
+  await withSilencedWarnings(async () => {
     const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs });
     await poller.tick(); // success
     assert.equal(poller.snapshots.length, 1);
 
     nowMs += 31 * 60_000; // past the 30-minute carry-forward cap
     await poller.tick(); // fails again
-    assert.equal(calls, 2);
+    assert.equal(getCalls(), 2);
     assert.equal(poller.snapshots.length, 0, "snapshot dropped once older than the carry cap");
-  } finally {
-    console.warn = originalWarn;
-  }
+  });
 });
 
 test("poller: detect() flips to false → snapshot dropped on the very next tick, no carry-forward", async () => {
@@ -767,11 +750,7 @@ test("codex adapter: a 100% window reports exhausted even with a positive balanc
 
 test("codex adapter: absent credits balance stays undefined, never 0", async () => {
   const sample = { rate_limit: { primary_window: { used_percent: 5, reset_after_seconds: 60 } } };
-  const snap = await codexAdapter.fetch({
-    fetchImpl: async () => fakeResponse(200, sample),
-    readToken: async () => "tok",
-    now: () => 0,
-  });
+  const snap = await fetchCodexSample(sample);
   assert.equal("balance" in snap, false, "no credits field → no balance key at all");
   assert.equal(snap.balance, undefined, "absent balance is undefined, not 0");
   assert.equal("exhausted" in snap, false);
@@ -779,11 +758,7 @@ test("codex adapter: absent credits balance stays undefined, never 0", async () 
 
 test("codex adapter: no credits, no plan_type — extras/planLabel omitted, not fabricated", async () => {
   const sample = { rate_limit: { primary_window: { used_percent: 5, reset_after_seconds: 60 } } };
-  const snap = await codexAdapter.fetch({
-    fetchImpl: async () => fakeResponse(200, sample),
-    readToken: async () => "tok",
-    now: () => 0,
-  });
+  const snap = await fetchCodexSample(sample);
   assert.equal("planLabel" in snap, false);
   assert.equal("extras" in snap, false);
 });


### PR DESCRIPTION
## Summary

`src/server/usage.test.mjs` — "poller: a waiting window re-polls a bounded number of times, then stops" — asserted an exact fetch count (`1 + MAX_STALE_RETRIES` = 4) but counted **real 5ms timer firings** inside a 60ms wall-clock window. Under full `npm test` parallel load the event loop starves, chained `setTimeout`s fire late, and the count comes up one short (`3 !== 4`). Observed 2026-08-31: failed 2/2 full-suite runs on a BET-1474 branch and 1/2 on `origin/main`, while passing 5/5 standalone (BET-1485).

**Fix (usage.mjs):** `createUsagePoller` gains an injectable `timers` dep (`{ setTimeout, clearTimeout }`, defaults to the globals) used for the stale-retry scheduling — one production line changed per call site, no behavior change.

**Fix (usage.test.mjs):** the two re-poll tests (`:949` and its sibling `:975`, which shares the same flaky mechanism) now inject a fake retry-timer queue: armed retries are pumped explicitly via `fireAll()`, so the exact `1 + MAX_STALE_RETRIES = 4` budget is asserted with zero real-timer dependency. A runaway re-arm (budget not enforced) would throw instead of hang.

**Also in this PR — pre-existing duplication-gate clones:** the STRICT `duplication-gate` re-scans every *changed* file whole, and this file already carried 4 self-clones on `origin/main` (verified byte-identical before/after my change) — the same false-positive class as the parent issue BET-1474 fixed for `ctoSuggest.test.mjs`. Since this PR necessarily touches the file, the gate would have gone red on pre-existing clones. De-cloned per the BET-1474 precedent: shared `withSilencedWarnings` / `makeAlwaysRateLimited` / `makeFlakyAdapter` / `fetchCodexSample` / `assert429FloorsAt2Minutes` builders, test bodies ported 1:1. `check-duplication-gate.sh origin/main` now reports **PASS — no clones**.

Base: origin/main @ `8f70b791`

**Files changed:** 2 files. `src/server/usage.mjs` (+12/−2), `src/server/usage.test.mjs` (+133/−126)

**Verification results:**
- PR branch (`multica/BET-1485-poller-flake` @ `bacc4f2c`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3803 pass / 0 fail / 0 skip (run twice — the flaking suite was 2/2-red before the fix). Failures: none. log sha256: `00a4c4d66b88bacf147c24fc751772b25645d84bded98e53c749599ecc767ee9`
  - duplication-gate: exit 0, "PASS — no clones"
- Base (`main` @ `8f70b791`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3803 pass / 0 fail / 0 skip. Failures: none. log sha256: `17db744080b2da73a4f0e473ca8e5fe1c331504b07c27932614202fb344750b9`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved — both branches fully green. The flake itself is not reproducible by test failure anymore (its real-timer dependency is gone); full-suite determinism evidenced by 2/2 green PR-branch runs under the same parallel load that was 2/2-red on 2026-08-31.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
