### PR TITLE
refactor(renderer): dedupe CloneFromGitHub test mount scaffolding (BET-1488)

### DIFF
--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -20,10 +20,9 @@
 
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { act } from "react";
-import { createRoot, type Root } from "react-dom/client";
+import type { Root } from "react-dom/client";
 import { CloneFromGitHub } from "./CloneFromGitHub";
 import { installMockApi, mount, clickCheckbox, type Harness, type MockApi } from "./testHarness";
-import type { ForgeCloneStatus } from "../shared/types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -58,6 +57,20 @@ const CLONE_IN_PROGRESS = {
   cancelled: false,
 };
 
+// The device-flow payload both sign-in tests share: no credential yet, so
+// the component shows the device-code panel (user code ABCD-1234).
+const NOT_CONNECTED_START = {
+  connected: false,
+  grant: {
+    grantId: "g1",
+    userCode: "ABCD-1234",
+    verificationUri: "https://github.com/login/device",
+    expiresIn: 900,
+    pollInterval: 5,
+  },
+  error: null,
+};
+
 let container: HTMLElement | null = null;
 let root: Root | null = null;
 let api: MockApi;
@@ -65,27 +78,34 @@ let api: MockApi;
 // (clickCheckbox) rather than poking the sr-only input.
 let h: Harness | null = null;
 
-type MountOverrides = {
-  forgeCloneStart?: () => Promise<{ id?: string; error?: string; message?: string }>;
-  forgeCloneStatus?: () => Promise<ForgeCloneStatus | null>;
+// Per-test overrides: any window.api forge stub, plus the component's
+// onCloned prop (which is not an api stub).
+type MountOverrides = Partial<MockApi> & {
   onCloned?: (paths: string[]) => void;
 };
 
-function mountPicker(overrides: MountOverrides = {}): void {
+// The one mount path every test in this file uses: installs the mock api
+// with picker defaults (live credential + the REPOS list + stubbed clone
+// calls), then mounts the real component through the shared harness. Per-test
+// stubs override any forge method — e.g. a pending forgeRepos, a
+// not_connected device flow, or a failing forgeCloneStart. (BET-1488:
+// extracted from four hand-rolled installMockApi + createRoot copies that
+// the duplication gate deterministically flagged as self-clones.)
+function mountPicker({ onCloned, ...stubs }: MountOverrides = {}): void {
   ({ api } = installMockApi({
     // Existing credential — the picker renders immediately, skipping the
     // device-connect screen.
     forgeDeviceStart: () => Promise.resolve({ connected: true, grant: null }),
     forgeRepos: () => Promise.resolve({ repos: REPOS, stale: false, error: null }),
-    forgeCloneStart: overrides.forgeCloneStart ?? (() => Promise.resolve({ id: "c1" })),
-    forgeCloneStatus:
-      overrides.forgeCloneStatus ?? (() => Promise.resolve(CLONE_IN_PROGRESS)),
+    forgeCloneStart: () => Promise.resolve({ id: "c1" }),
+    forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
+    ...stubs,
   }));
   h = mount(
     <CloneFromGitHub
       defaultRoot="/root"
       onCancel={() => {}}
-      onCloned={overrides.onCloned ?? (() => {})}
+      onCloned={onCloned ?? (() => {})}
     />,
   );
   container = h.container;
@@ -344,19 +364,8 @@ describe("CloneFromGitHub picker", () => {
     // `connected` on — so if the fetch ever ran pre-connect it would hit the
     // error branch (reproducing the old stuck state).
     let connected = false;
-    installMockApi({
-      forgeDeviceStart: () =>
-        Promise.resolve({
-          connected: false,
-          grant: {
-            grantId: "g1",
-            userCode: "ABCD-1234",
-            verificationUri: "https://github.com/login/device",
-            expiresIn: 900,
-            pollInterval: 5,
-          },
-          error: null,
-        }),
+    mountPicker({
+      forgeDeviceStart: () => Promise.resolve(NOT_CONNECTED_START),
       forgeDevicePoll: () => Promise.resolve({ status: "done" }),
       forgeRepos: () => {
         repoCallCount++;
@@ -366,16 +375,6 @@ describe("CloneFromGitHub picker", () => {
             : { repos: [], stale: false, error: "not_connected" },
         );
       },
-      forgeCloneStart: () => Promise.resolve({ id: "c1" }),
-      forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
-    });
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
-    act(() => {
-      root!.render(
-        <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
-      );
     });
 
     // Let forgeDeviceStart settle so the code panel mounts and schedules the
@@ -403,20 +402,7 @@ describe("CloneFromGitHub picker", () => {
     const reposPromise = new Promise((resolve) => {
       resolveRepos = resolve;
     });
-    installMockApi({
-      forgeDeviceStart: () => Promise.resolve({ connected: true, grant: null }),
-      forgeRepos: () => reposPromise,
-      forgeCloneStart: () => Promise.resolve({ id: "c1" }),
-      forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
-    });
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
-    act(() => {
-      root!.render(
-        <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
-      );
-    });
+    mountPicker({ forgeRepos: () => reposPromise });
     // The fetch is pending — the picker must show the loading state, not
     // "Search 0 repositories…" / "No repositories match.".
     await flushMicro();
@@ -440,36 +426,16 @@ describe("CloneFromGitHub picker", () => {
     // the box's behaviour after clearing a dead credential testable instead of
     // an infinite re-connect loop.
     let deviceStartCalls = 0;
-    installMockApi({
+    mountPicker({
       forgeDeviceStart: () => {
         deviceStartCalls++;
         return Promise.resolve(
           deviceStartCalls === 1
             ? { connected: true, grant: null }
-            : {
-                connected: false,
-                grant: {
-                  grantId: "g1",
-                  userCode: "ABCD-1234",
-                  verificationUri: "https://github.com/login/device",
-                  expiresIn: 900,
-                  pollInterval: 5,
-                },
-                error: null,
-              },
+            : NOT_CONNECTED_START,
         );
       },
       forgeRepos: () => Promise.resolve({ repos: [], stale: false, error: "rejected" }),
-      forgeCloneStart: () => Promise.resolve({ id: "c1" }),
-      forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
-    });
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
-    act(() => {
-      root!.render(
-        <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
-      );
     });
     await flushMicro();
     await flushMicro();
@@ -484,19 +450,8 @@ describe("CloneFromGitHub picker", () => {
   });
 
   it("renders an error message for a network failure and does NOT drop to the connect panel (BET-1059)", async () => {
-    installMockApi({
-      forgeDeviceStart: () => Promise.resolve({ connected: true, grant: null }),
+    mountPicker({
       forgeRepos: () => Promise.resolve({ repos: [], stale: false, error: "network" }),
-      forgeCloneStart: () => Promise.resolve({ id: "c1" }),
-      forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
-    });
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
-    act(() => {
-      root!.render(
-        <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
-      );
     });
     await flushMicro();
     await flushMicro();


### PR DESCRIPTION
## Summary

BET-1479 follow-up: `scripts/check-duplication-gate.sh` deterministically flagged 4 self-clones (16/16/14/11 lines, min-tokens 70) in `src/renderer/CloneFromGitHub.test.tsx`. The clones were four hand-rolled `installMockApi` + `container/createRoot/render` mount blocks in the device-flow/error tests, plus the `not_connected` device-grant payload repeated in two tests.

**Fix** — extract, don't configure:
- Generalized `mountPicker` to accept arbitrary `window.api` stub overrides (`Partial<MockApi>`), so all 11 tests mount through the one shared harness path; per-test stubs override any forge method.
- Extracted the shared `not_connected` device payload as `NOT_CONNECTED_START`.
- Net −81 lines (36 insertions, 81 deletions); file 527 → 483 lines.

Option 2 (policy/ignore-list change needing human sign-off) was **not** needed — the gate now scans this file clean.

## Gate re-run (synthetic changed-file scan, same invocation as the gate)

- Before: `lines=16 A[368] B[408]`, `lines=16 A[368] B[462]`, `lines=14 A[462] B[489]`, `lines=11 A[466] B[493]`
- After: **0 duplicates**

**Files changed:** 1. `src/renderer/CloneFromGitHub.test.tsx`

**Verification results:**
- PR branch (`multica/BET-1488-dedupe-clone-test-scaffolding` @ `c7ef15bf`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3803` pass / `0` fail / `0` skip. Failures: none. log sha256: `5a93be688541b22a1a6c8ca3906a02bd55a8428dd6ccf22a393d310c4508c575`
- Base (`main` @ `8f70b791`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3803` pass / `0` fail / `0` skip. Failures: none. log sha256: `e1e0f050856cb0121f9a4f98adb080bde8c851b05b97671667ed7f3e569cf429`
- **Conclusion:** 0 test failures on either branch; no behavior change — pure test-harness refactor.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
