### PR TITLE
BET-1489: fix(server): extend MANTA_STATE_HOME fail-fast guard to remaining CTO test files

### DIFF
--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // cto.test.mjs — On-call CTO read gateway (BET-1164, issue 1/3).
 // Pure logic + injected I/O: registry integrity, dispatch (default-allow gate,
 // deny/confirm fail-closed, onNarrate boundaries), the tool reads (all

--- a/src/server/ctoAct.test.mjs
+++ b/src/server/ctoAct.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoBackfill.test.mjs
+++ b/src/server/ctoBackfill.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // Tests for ctoBackfill.mjs — the cold-start backfill (BET-1387, spec §10.6-4).
 // Pure + injectable: guardrails (watermark exclusivity, spend-bound stop with a
 // persisted reason, once-per-box marker, progress math) are tested against

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoBudgetWiring.test.mjs
+++ b/src/server/ctoBudgetWiring.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // ctoBudgetWiring.test.mjs — BET-1422 wiring gate. index.mjs cannot be
 // imported (it boots the server on import), so the singleton's deps are
 // asserted by a brace-balanced source scan: the two BET-1422 forge seams

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoDigest.test.mjs
+++ b/src/server/ctoDigest.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // src/server/ctoDigest.test.mjs
 // BET-1383 — digest engine (spec §5.4–5.5). Coverage per decomposition A9:
 //   - granularity table (Δ → reads/unit/rollup levels),

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // BET-1419 overnight wiring tests (§11): window open → plan dispatch through
 // the delegate seams; §11.6 preemption on the user's return; the §9.2 veto
 // card lifecycle; the tonight queue verbs. The overnight machine itself is

--- a/src/server/ctoFacts.test.mjs
+++ b/src/server/ctoFacts.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoForecast.test.mjs
+++ b/src/server/ctoForecast.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { computeHealthStats, HEALTH_STAT_MIN } from "./ctoHealth.mjs";

--- a/src/server/ctoInbound.test.mjs
+++ b/src/server/ctoInbound.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // ctoInbound.test.mjs — On-call CTO inbound feed (BET-1165, issue 2/3).
 // Pure logic + injected I/O, no live tmux / opencode / multica / push:
 //   - inbound routing (live flag off → park; live on → inject; dedupe via seenId)

--- a/src/server/ctoJournal.test.mjs
+++ b/src/server/ctoJournal.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // src/server/ctoJournal.test.mjs
 // BET-1394 — journal (§3.2) cap-50 eviction at admission, facts-style
 // retention, near-duplicate admission suppression, per-entry delete. Pure

--- a/src/server/ctoOvernight.test.mjs
+++ b/src/server/ctoOvernight.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // src/server/ctoOvernight.test.mjs
 // BET-1402 — pure-logic tests for the overnight scheduler CORE (node:test,
 // injected I/O only — no live tmux/opencode/network).

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // ctoProbes.test.mjs — BET-1396 (§7.5 probe runner, §7.3 vitality, §7.6
 // relevance, §10.6-7 escalation). Pure over injected fakes: no live network,
 // no secrets vault, no registry store (AGENTS.md server rule).

--- a/src/server/ctoProfile.test.mjs
+++ b/src/server/ctoProfile.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // src/server/ctoProfile.test.mjs
 // BET-1393 — profile engine (spec §8.1–8.4). Coverage per decomposition:
 //   - circular stats against fixtures (known mean hour / R̄),

--- a/src/server/ctoRollups.test.mjs
+++ b/src/server/ctoRollups.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoSegments.test.mjs
+++ b/src/server/ctoSegments.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // src/server/ctoSegments.test.mjs — BET-1380 work segmentation (§5.1), segment
 // summaries (§5.2), turn completion, and the G refit. Pure logic only —
 // injected stores/seams/now, no live tmux/opencode/network.

--- a/src/server/ctoSessions.test.mjs
+++ b/src/server/ctoSessions.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // src/server/ctoSessions.test.mjs — BET-1378 ephemeral session runner (§3.1),
 // task classes + cascade (§12.3), context budgets, active-set, reaper. Pure
 // logic only — injected oc/engineState, no live tmux/opencode/network.

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createCtoCards } from "./ctoCards.mjs";

--- a/src/server/ctoSweeperWiring.test.mjs
+++ b/src/server/ctoSweeperWiring.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // ctoSweeperWiring.test.mjs — BET-1464 defect 1 wiring gate. index.mjs cannot
 // be imported (it boots the server on import), so the sweeper's startup
 // wiring is asserted by a source scan: the poller must be imported from

--- a/src/server/ctoTier.test.mjs
+++ b/src/server/ctoTier.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { tierChangeLedgerEntry, TIER_CHANGE_KIND } from "./ctoTier.mjs";

--- a/src/server/ctoToolCatalog.test.mjs
+++ b/src/server/ctoToolCatalog.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoToolRegistry.test.mjs
+++ b/src/server/ctoToolRegistry.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoToolScan.test.mjs
+++ b/src/server/ctoToolScan.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoTrust.test.mjs
+++ b/src/server/ctoTrust.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/src/server/ctoVerdicts.test.mjs
+++ b/src/server/ctoVerdicts.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // src/server/ctoVerdicts.test.mjs
 // BET-1391 — verdict ledger + §9.5 counter mapping + estimator helpers.
 import { test } from "node:test";

--- a/src/server/ctoWatchers.test.mjs
+++ b/src/server/ctoWatchers.test.mjs
@@ -1,3 +1,17 @@
+// BET-1469: fail fast, before ANY test body runs, when this file is executed
+// outside the state sandbox. A CTO store module imported unsandboxed resolves
+// its paths against the LIVE box state (~/.manta) and a test would write
+// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}
+
 // ctoWatchers.test.mjs — standing-query watcher engine (BET-1398 / §4.3, §13.4).
 // Pure logic + injected I/O (fake store/ledger/engineState), no live services:
 //   - predicate validation (closed set of 3 kinds; unknown/bad params rejected)


### PR DESCRIPTION
## Summary

BET-1489 follow-up to BET-1469: copies the module-level `MANTA_STATE_HOME` fail-fast guard verbatim from `src/server/ctoEngine.test.mjs` (lines 1–13, byte-identical, no adjustments) to the top of all 28 remaining `src/server/cto*.test.mjs` files.

- Globbed `src/server/cto*.test.mjs` → 31 files; skipped the 3 already guarded (`ctoEngine`, `ctoEvidence`, `ctoStores`); guarded the remaining 28.
- The issue's illustrative list named 16 files, but the operative dispatch is "glob `src/server/cto*.test.mjs` and skip the three already guarded", so the additional files that exist on `main` today are also covered: `ctoAct`, `ctoBudgetWiring`, `ctoEngine.overnight`, `ctoForecast`, `ctoHealth`, `ctoInbound`, `ctoSuggest`, `ctoSweeperWiring`, `cto`, `ctoTier`, `ctoToolCatalog`, `ctoToolScan`.
- Defense-in-depth only: `npm test` / `npm run test:server` already sandbox via `--import ./scripts/testSandbox.mjs`; this protects direct single-file invocations (`node --test src/server/ctoX.test.mjs`).
- Note (anti-spaghetti): 31 textual copies of the same guard is deliberate, per the issue's explicit "copy verbatim, adjust nothing" dispatch — a shared guard module would itself have to be imported, and BET-1469 chose the in-file form. Not re-litigated.

**Files changed:** 28 files, +392 lines (13 guard lines + 1 blank line each). All under `src/server/cto*.test.mjs`.

**Verification results:**
- PR branch (`multica/BET-1489-cto-test-guard` @ `982e4cfc`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, 3810 pass / 0 fail / 0 skip. Failures: none. log sha256: `da960ba227baa7d04b9c87b3f242e51855a1e3b12c3ae686d18fc7187f0c2b94`
- Base (`main` @ `2965e852`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, 3810 pass / 0 fail / 0 skip. Failures: none. log sha256: `eb3cd32f19176d2e8fab9173002660b5e63bf8e09fbdcfaa1855a44322e12e6f`
- **Conclusion:** 0 new failures, 0 pre-existing, 0 resolved — both branches fully green.
- Issue-specific check: `node --test src/server/ctoCards.test.mjs` → exit 1, aborts at import with the exact guard message ("MANTA_STATE_HOME is not set — refusing to run CTO tests…"), and a recursive mtime snapshot of `~/.manta` before/after is byte-identical (nothing written). The same fail-fast was confirmed for **all 31** CTO test files individually.

Base: origin/main @ 2965e852
