### PR TITLE
fix(server): per-process test sandbox home (BET-1493)

### DIFF
--- a/scripts/testSandbox.mjs
+++ b/scripts/testSandbox.mjs
@@ -24,27 +24,65 @@
 //                  result through `test.env`, which vitest injects into every
 //                  worker before the test module is evaluated.
 //
-// An already-set MANTA_STATE_HOME is respected, so a caller that wants a
-// specific sandbox (or a nested runner) keeps control.
+// PER-PROCESS ISOLATION (BET-1493). `node --test` runs each test file as its
+// own concurrent process, and the runner hands every child the coordinator's
+// full environment (`env: { ...process.env, … }` in the runner's spawn). When
+// the coordinator ran this preload first — the node 20 behavior, which is what
+// CI pins via setup-node — every child therefore saw the ALREADY-SET
+// MANTA_STATE_HOME and reused it, so all concurrent test-file processes shared
+// ONE sandbox and raced on the same stores (e.g. the cto ledger): a test
+// asserting exact ledger contents intermittently observed rows appended by a
+// different file's process. Newer runners (node ≥ 22) spawn children before
+// their own `--import` preload evaluates, so each child created a fresh root —
+// masking the race locally.
+//
+// So the home is per-process: the module marks the home it created with
+// MANTA_STATE_HOME_OWNER (the creating pid). A process that inherits a home
+// marked by a DIFFERENT pid subdivides it — `<inherited root>/proc-<pid>` —
+// so every test-file process gets its own slice of the throwaway tree while
+// the whole run stays under one inspectable root. A home with NO owner marker
+// is treated as an explicit external choice and shared as-is, so a caller that
+// wants a specific sandbox (or a nested runner, like vitest.config.ts
+// injecting one home into its workers) keeps control.
 
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+const HOME_VAR = "MANTA_STATE_HOME";
+const OWNER_VAR = "MANTA_STATE_HOME_OWNER";
+
 /**
- * Resolve the sandbox directory for this run, creating it on first call.
- * Idempotent: returns the already-chosen directory on subsequent calls, so the
- * two runners and any nested import agree on one location.
+ * Resolve the sandbox directory for this process, creating it on first call.
+ * Idempotent: returns the already-chosen directory on subsequent calls in the
+ * same process, so the two runners and any nested import agree on one location.
  *
- * The directory is intentionally NOT cleaned up: it lives under the OS temp
- * dir, holds only bytes a test wrote, and keeping it makes a failing test's
- * leftovers inspectable. The OS reclaims it.
+ * The directory tree is intentionally NOT cleaned up: it lives under the OS
+ * temp dir, holds only bytes a test wrote, and keeping it makes a failing
+ * test's leftovers inspectable. The OS reclaims it.
  */
 export function sandboxStateHome() {
-  const existing = process.env.MANTA_STATE_HOME;
-  if (typeof existing === "string" && existing.trim() !== "") return existing;
+  const existing = process.env[HOME_VAR];
+  const owner = process.env[OWNER_VAR];
+
+  if (typeof existing === "string" && existing.trim() !== "") {
+    const inheritedFromOther =
+      typeof owner === "string" && owner.trim() !== "" && owner !== String(process.pid);
+    if (!inheritedFromOther) return existing;
+
+    // Inherited from a parent sandbox process (the node:test coordinator) —
+    // carve out this process's own slice so concurrent test files never share
+    // stores (BET-1493). Stays under the run's throwaway root.
+    const dir = join(existing, `proc-${process.pid}`);
+    mkdirSync(dir, { recursive: true });
+    process.env[HOME_VAR] = dir;
+    process.env[OWNER_VAR] = String(process.pid);
+    return dir;
+  }
+
   const dir = mkdtempSync(join(tmpdir(), "manta-test-home-"));
-  process.env.MANTA_STATE_HOME = dir;
+  process.env[HOME_VAR] = dir;
+  process.env[OWNER_VAR] = String(process.pid);
   return dir;
 }
 

--- a/scripts/testSandbox.test.mjs
+++ b/scripts/testSandbox.test.mjs
@@ -1,0 +1,94 @@
+// testSandbox.test.mjs — pins the per-process sandbox semantics (BET-1493).
+//
+// The sandbox must give every node:test file-process its OWN state home while
+// keeping the two contracts that predate it: an explicitly-set MANTA_STATE_HOME
+// (no owner marker — external caller or vitest.config.ts injection) is shared
+// as-is, and repeated calls in one process return the same directory. The
+// inherited-home case is what the runner creates on node 20 (the coordinator's
+// preload runs first, then every spawned test-file child inherits its env):
+// without the per-process split those children all raced on one ledger.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sandboxStateHome } from "./testSandbox.mjs";
+
+const HOME_VAR = "MANTA_STATE_HOME";
+const OWNER_VAR = "MANTA_STATE_HOME_OWNER";
+
+// The preload side effect already set real values in THIS process — save and
+// restore them around each scenario so the module's env reads are exercised
+// from a controlled state without disturbing anything that runs after us.
+function withEnv(home, owner, fn) {
+  const savedHome = process.env[HOME_VAR];
+  const savedOwner = process.env[OWNER_VAR];
+  try {
+    if (home === undefined) delete process.env[HOME_VAR];
+    else process.env[HOME_VAR] = home;
+    if (owner === undefined) delete process.env[OWNER_VAR];
+    else process.env[OWNER_VAR] = owner;
+    return fn();
+  } finally {
+    if (savedHome === undefined) delete process.env[HOME_VAR];
+    else process.env[HOME_VAR] = savedHome;
+    if (savedOwner === undefined) delete process.env[OWNER_VAR];
+    else process.env[OWNER_VAR] = savedOwner;
+  }
+}
+
+test("explicitly-set home with no owner marker is respected and shared as-is", () => {
+  withEnv("/tmp/external-caller-home", undefined, () => {
+    assert.equal(sandboxStateHome(), "/tmp/external-caller-home");
+    assert.equal(process.env[HOME_VAR], "/tmp/external-caller-home");
+    // The owner marker must stay unset — the external caller keeps control.
+    assert.equal(process.env[OWNER_VAR], undefined);
+  });
+});
+
+test("home created by this process is returned unchanged (idempotent)", () => {
+  const mine = String(process.pid);
+  withEnv("/tmp/already-mine-home", mine, () => {
+    assert.equal(sandboxStateHome(), "/tmp/already-mine-home");
+    assert.equal(process.env[OWNER_VAR], mine);
+  });
+});
+
+test("home inherited from a parent sandbox process is split per process", () => {
+  const root = "/tmp/inherited-root";
+  withEnv(root, "999999", () => {
+    const dir = sandboxStateHome();
+    assert.equal(dir, join(root, `proc-${process.pid}`));
+    assert.ok(existsSync(dir), "the per-process slice must be created");
+    assert.equal(process.env[HOME_VAR], dir);
+    assert.equal(process.env[OWNER_VAR], String(process.pid));
+    // Subsequent calls in the same process return the same slice.
+    assert.equal(sandboxStateHome(), dir);
+  });
+});
+
+test("unset home creates a fresh throwaway root owned by this process", () => {
+  withEnv(undefined, undefined, () => {
+    const dir = sandboxStateHome();
+    assert.ok(
+      dir.startsWith(join(tmpdir(), "manta-test-home-")),
+      `expected a fresh manta-test-home root under the OS temp dir, got ${dir}`,
+    );
+    assert.ok(existsSync(dir));
+    assert.equal(process.env[HOME_VAR], dir);
+    assert.equal(process.env[OWNER_VAR], String(process.pid));
+    // Idempotent within the process.
+    assert.equal(sandboxStateHome(), dir);
+  });
+});
+
+test("empty-string home is treated as unset; empty owner as no marker", () => {
+  withEnv("", "", () => {
+    const dir = sandboxStateHome();
+    assert.ok(dir.startsWith(join(tmpdir(), "manta-test-home-")));
+  });
+  withEnv("/tmp/external-empty-owner", "", () => {
+    assert.equal(sandboxStateHome(), "/tmp/external-empty-owner");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes BET-1493 — full server suite flaked because concurrent `node --test` file processes shared one sandboxed state home and raced on the same CTO ledger.

**Root cause** (verified, not theorized): the node:test runner spawns each test file as its own process with the coordinator's full environment (`env: { ...process.env, NODE_TEST_CONTEXT: 'child-v8' }` in the runner's spawn). On node 20 — the version CI pins via `setup-node` — the coordinator executes the `--import ./scripts/testSandbox.mjs` preload at bootstrap, so its `MANTA_STATE_HOME` is already set when children spawn; each child's preload then hits the "already-set is respected" early-return and **all concurrent test-file processes share one sandbox**. On node ≥ 22 the runner spawns children before its own `--import` preload evaluates, so each child created a fresh root — which is why the race reproduced in CI but not locally.

Reproduced deterministically (10/10 failures) by simulating the shared home the node 20 coordinator creates, using the exact shape of `ctoStores.test.mjs:251` ("sweepAllStores trims the ledger…"): a background writer appending ledger rows + the sweep test asserting exact contents. Same sharing confirmed on the real suite: all cto test files wrote into one forced-shared `cto/` root.

## Fix (issue option 1 — per-process sandbox home)

`scripts/testSandbox.mjs` now marks the home it creates with `MANTA_STATE_HOME_OWNER` (creator pid):

- **Inherited home owned by another pid** (the node:test coordinator case) → the child subdivides: `<run root>/proc-<pid>` — every test file gets its own slice of the throwaway tree; the whole run stays under one inspectable root.
- **Explicit external home** (no owner marker: `vitest.config.ts` worker injection, human callers) → shared as-is, documented contract unchanged.
- **Unset** → fresh `mkdtemp` root, as before (node ≥ 22 path unchanged in effect).

`stateHome()` (src/shared/paths.mjs) reads the env var at call time, so every store resolves inside the process's own slice with no other code change. The sandbox canaries (`stateSandbox.test.mjs` et al.) re-read `MANTA_STATE_HOME` at test runtime, so they stay green under the slice layout.

**After the fix, the same forced-shared harness: 0/10 failures** (was 10/10), with one `proc-<pid>` slice per test process created under the run root.

## Store-path helper audit (per the AGENTS.md invariant)

Every store a test writes routes through `statePath()`/`stateHome()` → lands in the process's slice. Two `homedir()`-based paths deliberately bypass the sandbox and are **read-only in tests** (verified: no test writes them in-process): `claudeAuth.mjs` `CREDENTIALS_PATH` (tests use a `HOME`-overridden child process, whose own `homedir()` then resolves inside the override) and `opencodeDb.mjs`'s opencode sqlite path (read-only access layer).

## Verification

- typecheck: exit 0 (both tsconfigs).
- New unit tests: `scripts/testSandbox.test.mjs` 5/5 — pins explicit-home respect, idempotency, per-process split (dir created + env rewritten), fresh-root creation, empty-string edge cases.
- Full-suite gate: **10× consecutive `npm test` runs on this branch — results appended below when the gate completes.**

Base: origin/main @ 287f4457
