### PR TITLE
BET-1490: make duplication-gate green for cto test files (shared fixtures + guard module)

### DIFF
--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -1,16 +1,6 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
+import { makeEngineDeps } from "./ctoTestEngineDeps.mjs";
 
 // cto.test.mjs — On-call CTO read gateway (BET-1164, issue 1/3).
 // Pure logic + injected I/O: registry integrity, dispatch (default-allow gate,
@@ -29,22 +19,7 @@ import {
 
 // Shared fakes so every engine test is deterministic and side-effect free.
 function makeEngine(overrides = {}) {
-  const engine = createCtoEngine({
-    listProjects: async () => [],
-    listSessions: async () => [],
-    listMessages: async () => [],
-    listModels: async () => [],
-    getSessionAgent: async () => null,
-    listSnapshots: () => [],
-    listStopped: async () => ({ records: [], lastLooked: null }),
-    searchMessages: async () => ({ supported: true, hits: [] }),
-    configGet: async () => ({}),
-    gitStatus: async () => "",
-    gitBranch: async () => null,
-    gitLog: async () => "",
-    ...overrides,
-  });
-  return engine;
+  return createCtoEngine(makeEngineDeps(overrides));
 }
 
 const TOOL_COUNT = 23; // 16 reads (BET-1164 + BET-1383 read_rollups/read_ledger) + read_inbox (BET-1397) + 3 watcher tools (BET-1165) + 3 drill-down read verbs (BET-1399)

--- a/src/server/ctoAct.test.mjs
+++ b/src/server/ctoAct.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoAct.test.mjs
+++ b/src/server/ctoAct.test.mjs
@@ -115,6 +115,16 @@ function makeDeps(overrides = {}) {
   return { deps, calls };
 }
 
+// The canonical §3.3 start-job probe: plain finding candidate, tracked cwd.
+async function runStartJobProbe(deps) {
+  const exec = createCtoActExecutor(deps);
+  return exec({
+    cls: "start-job",
+    action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } },
+    candidate: { finding: { text: "f", refs: [] } },
+  });
+}
+
 test("executor: record-decision proposes the gatekeeper-checked fact (behavior carried over from BET-1403)", async () => {
   const { deps, calls } = makeDeps();
   const exec = createCtoActExecutor(deps);
@@ -189,12 +199,7 @@ test("executor: start-job refuses at the §3.3 concurrent cto-delegate cap witho
       { id: "c", actor: "user", status: "running" },
     ],
   });
-  const exec = createCtoActExecutor(deps);
-  const out = await exec({
-    cls: "start-job",
-    action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } },
-    candidate: { finding: { text: "f", refs: [] } },
-  });
+  const out = await runStartJobProbe(deps);
   assert.equal(out.ok, false);
   assert.equal(out.reason, "rate_limit:concurrentDelegate");
   assert.equal(calls.beginDelegateJob, 0);
@@ -217,12 +222,7 @@ test("executor: start-job refusal from the delegate engine degrades with its err
   const { deps, calls } = makeDeps({
     startDelegateJob: async () => ({ ok: false, error: "at MAX_RUNNING_JOBS" }),
   });
-  const exec = createCtoActExecutor(deps);
-  const out = await exec({
-    cls: "start-job",
-    action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } },
-    candidate: { finding: { text: "f", refs: [] } },
-  });
+  const out = await runStartJobProbe(deps);
   assert.deepEqual(out, { ok: false, reason: "at MAX_RUNNING_JOBS" });
   assert.equal(calls.beginDelegateJob, 1);
   assert.equal(calls.gateReleased, 1);
@@ -230,12 +230,7 @@ test("executor: start-job refusal from the delegate engine degrades with its err
 
 test("executor: a §3.3 gate refusal (kill switch / pause) refuses the act before any start", async () => {
   const { deps, calls } = makeDeps({ beginDelegateJob: async () => ({ ok: false, error: "cto_paused" }) });
-  const exec = createCtoActExecutor(deps);
-  const out = await exec({
-    cls: "start-job",
-    action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } },
-    candidate: { finding: { text: "f", refs: [] } },
-  });
+  const out = await runStartJobProbe(deps);
   assert.deepEqual(out, { ok: false, reason: "cto_paused" });
   assert.equal(calls.startDelegateJob.length, 0);
   assert.equal(calls.gateReleased, 0);

--- a/src/server/ctoBackfill.test.mjs
+++ b/src/server/ctoBackfill.test.mjs
@@ -115,6 +115,28 @@ function validSummarize() {
 const PRESENT = async () => true;
 const AWAY = async () => false;
 
+// The standard replay backfill over the fixture db: cto enabled, quiet
+// ledger/rollups, away-presence, in-memory engine state + segment files,
+// `oneLiner` as the fake segmenter's one-liner.
+function makeReplayBackfill(fx, { NOW, oneLiner }) {
+  const engineState = memStore();
+  const segments = memFileStore();
+  const backfill = createCtoBackfill({
+    configGet: async () => ({ ctoEnabled: true }),
+    engineState,
+    ledger: noopLedger,
+    segments,
+    rollups: { save: async () => {}, load: async () => null, dir: "/tmp/none" },
+    summarize: validSummarize(),
+    computeOneLiner: async () => oneLiner,
+    getDb: async () => fx.db,
+    presenceCheck: AWAY,
+    now: () => NOW,
+    maxSessionsPerStep: 100,
+  });
+  return { engineState, segments, backfill };
+}
+
 // ---------------------------------------------------------------------------
 // Pure guardrail tests
 // ---------------------------------------------------------------------------
@@ -243,21 +265,7 @@ test("segments phase replays a session into a persisted segment and advances pro
   fx.insMessage("u1", "s1", { role: "user", ts: NOW - 2000, text: "debug the login flow" });
   fx.insMessage("a1", "s1", { role: "assistant", ts: NOW - 1000, cost: 0 });
 
-  const engineState = memStore();
-  const segments = memFileStore();
-  const backfill = createCtoBackfill({
-    configGet: async () => ({ ctoEnabled: true }),
-    engineState,
-    ledger: noopLedger,
-    segments,
-    rollups: { save: async () => {}, load: async () => null, dir: "/tmp/none" },
-    summarize: validSummarize(),
-    computeOneLiner: async () => "debug the login flow",
-    getDb: async () => fx.db,
-    presenceCheck: AWAY,
-    now: () => NOW,
-    maxSessionsPerStep: 100,
-  });
+  const { engineState, segments, backfill } = makeReplayBackfill(fx, { NOW, oneLiner: "debug the login flow" });
 
   const res = await backfill.step();
   assert.equal(res.ok, true);
@@ -283,21 +291,7 @@ test("watermark enforced during replay: a message at/after the watermark is NOT 
   fx.insMessage("u1", "s1", { role: "user", ts: NOW - 2000, text: "old work" });
   fx.insMessage("w1", "s1", { role: "user", ts: NOW + 1000, text: "LIVE work after the watermark" });
 
-  const engineState = memStore();
-  const segments = memFileStore();
-  const backfill = createCtoBackfill({
-    configGet: async () => ({ ctoEnabled: true }),
-    engineState,
-    ledger: noopLedger,
-    segments,
-    rollups: { save: async () => {}, load: async () => null, dir: "/tmp/none" },
-    summarize: validSummarize(),
-    computeOneLiner: async () => "old work",
-    getDb: async () => fx.db,
-    presenceCheck: AWAY,
-    now: () => NOW,
-    maxSessionsPerStep: 100,
-  });
+  const { segments, backfill } = makeReplayBackfill(fx, { NOW, oneLiner: "old work" });
 
   await backfill.step();
   const seg = [...segments._data.values()][0];

--- a/src/server/ctoBackfill.test.mjs
+++ b/src/server/ctoBackfill.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // Tests for ctoBackfill.mjs — the cold-start backfill (BET-1387, spec §10.6-4).
 // Pure + injectable: guardrails (watermark exclusivity, spend-bound stop with a

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -42,6 +42,22 @@ function dayStart(offsetDays = 0) {
 const MIDNIGHT = dayStart(0);
 const NOON = MIDNIGHT + 12 * 3_600_000;
 
+// A budget over a given payload snapshot with all external reads quiet (no
+// jobs, no git probes, no ledger/verdict/segment rows); `now` pins the clock.
+function makeQuietBudget(payload, now) {
+  let current = payload;
+  const store = { load: async () => current, save: async (p) => (current = p) };
+  return createCtoBudget({
+    store,
+    jobsRead: async () => [],
+    gitProbe: async () => ({ exists: false, isAncestor: false }),
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now,
+  });
+}
+
 test("cap defaults to $2.50 and honors ctoAmbientCap", () => {
   assert.equal(ambientCapUsd({}), DEFAULT_AMBIENT_CAP_USD);
   assert.equal(ambientCapUsd({ ctoAmbientCap: 1.25 }), 1.25);
@@ -734,17 +750,10 @@ test("refreshRoi: store and probe failures degrade without throwing (no frozen z
 });
 
 test("roiSnapshot: collectingUntil is the first month's end from the day buckets", async () => {
-  let payload = recordSpend(defaultBudgetPayload(), { now: dayStart(-40), usd: 0.5 });
-  const store = { load: async () => payload, save: async (p) => (payload = p) };
-  const budget = createCtoBudget({
-    store,
-    jobsRead: async () => [],
-    gitProbe: async () => ({ exists: false, isAncestor: false }),
-    ledgerRead: async () => [],
-    verdictsRead: async () => [],
-    segmentsRead: async () => [],
-    now: () => MIDNIGHT,
-  });
+  const budget = makeQuietBudget(
+    recordSpend(defaultBudgetPayload(), { now: dayStart(-40), usd: 0.5 }),
+    () => MIDNIGHT,
+  );
   const snap = await budget.roiSnapshot();
   assert.equal(snap.roll, null); // no refresh ran → no roll stored
   assert.equal(snap.collectingUntil, monthWindow(JUL_KEY).endTs);
@@ -866,16 +875,7 @@ test("refreshRoi freezes the closed month at its real spend after a >7-day outag
   payload = recordSpend(payload, { now: dayStart(-23), usd: 3 }); // Aug 5
   payload = recordSpend(payload, { now: dayStart(-8), usd: 7 }); // Aug 20 — the last pre-outage day
   payload = recordSpend(payload, { now: SEP_10, usd: 0.25 }); // Sep 10 — first post-boot spend
-  const store = { load: async () => payload, save: async (p) => (payload = p) };
-  const budget = createCtoBudget({
-    store,
-    jobsRead: async () => [],
-    gitProbe: async () => ({ exists: false, isAncestor: false }),
-    ledgerRead: async () => [],
-    verdictsRead: async () => [],
-    segmentsRead: async () => [],
-    now: () => SEP_10,
-  });
+  const budget = makeQuietBudget(payload, () => SEP_10);
   const r = await budget.refreshRoi();
   const aug = r.months["2026-08"];
   assert.ok(aug, "the closed month's roll exists");

--- a/src/server/ctoBudgetWiring.test.mjs
+++ b/src/server/ctoBudgetWiring.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // ctoBudgetWiring.test.mjs — BET-1422 wiring gate. index.mjs cannot be
 // imported (it boots the server on import), so the singleton's deps are

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoDigest.test.mjs
+++ b/src/server/ctoDigest.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // src/server/ctoDigest.test.mjs
 // BET-1383 — digest engine (spec §5.4–5.5). Coverage per decomposition A9:

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // BET-1419 overnight wiring tests (§11): window open → plan dispatch through
 // the delegate seams; §11.6 preemption on the user's return; the §9.2 veto

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -437,10 +437,7 @@ test("overnight: user prompt preempts — running cto jobs paused and the window
 
 test("overnight: veto card arms 30 min before the trough, cancels on the veto verdict, resolves once open", async () => {
   // Inside the pre-window: 20 min before the trough's start.
-  const due = h0().startMs;
-  const h = makeHarness({ trough: { startMs: due, endMs: due + 6 * HOUR }, queue: [QUEUE_TASK], projects: [] });
-  h.clock.ms = due - 20 * 60_000;
-  await h.engine.tick();
+  const { due, h } = await armVetoCard();
 
   assert.equal(h.overnightStoreObj.window?.countdown?.dueMs, due, "countdown armed at the trough start");
   assert.equal(h.vetoCards.length, 1);
@@ -506,12 +503,7 @@ test("overnight: veto card arms 30 min before the trough, cancels on the veto ve
 });
 
 test("overnight: an executed window feeds the veto record's acceptance (BET-1403 §9.4 veto→act bar)", async () => {
-  const due = h0().startMs;
-  const h = makeHarness({ trough: { startMs: due, endMs: due + 6 * HOUR }, queue: [QUEUE_TASK], projects: [] });
-
-  // Arm the veto card in the pre-window (no cancel this time).
-  h.clock.ms = due - 20 * 60_000;
-  await h.engine.tick();
+  const { due, h } = await armVetoCard();
   assert.equal(h.vetoCards.length, 1);
 
   // The clock enters the trough while the user is absent: the window opens
@@ -699,6 +691,16 @@ test("durability: a trust fold survives a queue-edit save landing after it (mirr
 });
 
 // Fixed trough helper for the veto-card test (a window that starts "now").
+// Arm a veto card: a harness with the canonical trough, the clock placed
+// 20 min inside the pre-window, one tick. Returns { due, h }.
+async function armVetoCard() {
+  const due = h0().startMs;
+  const h = makeHarness({ trough: { startMs: due, endMs: due + 6 * HOUR }, queue: [QUEUE_TASK], projects: [] });
+  h.clock.ms = due - 20 * 60_000;
+  await h.engine.tick();
+  return { due, h };
+}
+
 function h0() {
   return { startMs: 1_700_000_000_000 + 6 * HOUR, endMs: 1_700_000_000_000 + 12 * HOUR };
 }

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -1,16 +1,6 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
+import { makeMemoryStores } from "./ctoTestStores.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -40,63 +30,6 @@ const delay = (ms) => new Promise((r) => setTimeout(r, ms));
 // clock we can advance. Everything the engine touches goes through these
 // seams, so the tests assert pure behavior. `clock` is shared so the watchdog
 // and the engine observe the same time.
-//
-// BET-1469: the store bundle is injected too, so even the paths this harness
-// does not exercise bind memory instead of real files — an enabled tick
-// (watchers/tools/probes/rollups/backfill) can no longer reach the live box
-// state through a lazily-constructed sub-engine.
-// BET-1469: one in-memory replacement per real CTO store — the full `stores`
-// bundle createCtoEngine accepts. Shapes mirror the real stores: json stores
-// are single-payload { load, save }; dir stores are one-payload-per-id
-// { load(id), save(id, data) } over a Map; the rollups store namespaces by
-// level. No fs anywhere: `dir` is "" so the engine's readdir fall-throughs
-// short-circuit, and pathFor is identity.
-function makeMemoryStores() {
-  const jsonStore = (initial) => {
-    let payload = { ...initial };
-    return {
-      load: async () => ({ ...payload }),
-      save: async (p) => {
-        payload = { ...p };
-      },
-    };
-  };
-  const dirStore = () => {
-    const map = new Map();
-    return {
-      dir: "",
-      pathFor: (id) => id,
-      load: async (id) => map.get(id) ?? { v: 1 },
-      save: async (id, data) => {
-        map.set(id, data);
-      },
-    };
-  };
-  return {
-    ledger: { append: async () => true },
-    engineState: jsonStore({ v: 1 }),
-    trust: jsonStore({}),
-    cards: jsonStore({ v: 1, cards: [] }),
-    inbox: jsonStore({ v: 1, entries: [] }),
-    verdicts: jsonStore({ entries: [] }),
-    budget: jsonStore({}),
-    watchers: jsonStore({ watchers: [] }),
-    toolRegistry: jsonStore({ tools: [] }),
-    toolUsage: jsonStore({}),
-    probeState: dirStore(),
-    segments: dirStore(),
-    rollups: {
-      dir: "",
-      dirFor: (level) => `mem://rollups/${level}`,
-      load: async () => ({ v: 1 }),
-      save: async () => {},
-    },
-    facts: dirStore(),
-    factsArchive: dirStore(),
-    profile: jsonStore({}),
-    journal: jsonStore({ entries: [] }),
-  };
-}
 
 function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts, realCards = false, engineStateInit = {} } = {}) {
   const clock = { ms: 1_000_000 };

--- a/src/server/ctoEvidence.test.mjs
+++ b/src/server/ctoEvidence.test.mjs
@@ -1,16 +1,6 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
+import { makeMemoryStores } from "./ctoTestStores.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -23,58 +13,6 @@ import {
   PRESENT_PROOF_MS,
 } from "./ctoEvidence.mjs";
 import { createCtoEngine } from "./ctoEngine.mjs";
-
-// BET-1469: the in-memory `stores` bundle handed to the engine so its default
-// sub-engine constructions (cards/trust/verdicts/watchers/probes/segments/
-// rollups/facts/profile/journal/budget) all bind memory, never real files.
-// Shapes mirror ctoStores.mjs: json stores are { load, save }; dir stores are
-// { load(id), save(id, data) } over a Map; rollups namespaces by level.
-function makeMemoryStores() {
-  const jsonStore = (initial) => {
-    let payload = { ...initial };
-    return {
-      load: async () => ({ ...payload }),
-      save: async (p) => {
-        payload = { ...p };
-      },
-    };
-  };
-  const dirStore = () => {
-    const map = new Map();
-    return {
-      dir: "",
-      pathFor: (id) => id,
-      load: async (id) => map.get(id) ?? { v: 1 },
-      save: async (id, data) => {
-        map.set(id, data);
-      },
-    };
-  };
-  return {
-    ledger: { append: async () => true },
-    engineState: jsonStore({ v: 1 }),
-    trust: jsonStore({}),
-    cards: jsonStore({ v: 1, cards: [] }),
-    inbox: jsonStore({ v: 1, entries: [] }),
-    verdicts: jsonStore({ entries: [] }),
-    budget: jsonStore({}),
-    watchers: jsonStore({ watchers: [] }),
-    toolRegistry: jsonStore({ tools: [] }),
-    toolUsage: jsonStore({}),
-    probeState: dirStore(),
-    segments: dirStore(),
-    rollups: {
-      dir: "",
-      dirFor: (level) => `mem://rollups/${level}`,
-      load: async () => ({ v: 1 }),
-      save: async () => {},
-    },
-    facts: dirStore(),
-    factsArchive: dirStore(),
-    profile: jsonStore({}),
-    journal: jsonStore({ entries: [] }),
-  };
-}
 
 // A tiny engine harness for the ingestion-level tests (dedupe, cto-exclusion).
 // Fully injected: no fs, no real stores (the in-memory `stores` bundle covers

--- a/src/server/ctoFacts.test.mjs
+++ b/src/server/ctoFacts.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoForecast.test.mjs
+++ b/src/server/ctoForecast.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -150,10 +150,15 @@ function verdict(verdict, never, tsOffsetDays) {
   return { ts: NOW - (tsOffsetDays ?? 0) * DAY, verdict, ...(never ? { never: true } : {}) };
 }
 
+// The suggestionAcceptance health stat computed over the given verdicts.
+async function acceptanceStat(verdicts) {
+  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => verdicts });
+  return stats.find((x) => x.id === "suggestionAcceptance");
+}
+
 test("suggestion acceptance: collecting (n/10) until 10 acceptance-deciding verdicts", async () => {
   const verdicts = Array.from({ length: 5 }, (_, i) => verdict("accept", false, i));
-  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => verdicts });
-  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  const s = await acceptanceStat(verdicts);
   assert.equal(s.min, HEALTH_STAT_MIN.suggestionAcceptance);
   assert.equal(s.n, 5);
   assert.equal(s.value, null);
@@ -166,8 +171,7 @@ test("suggestion acceptance: open/expire never enter the acceptance counters", a
     verdict("expire", false, 0),
     verdict("accept", false, 0),
   ];
-  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => verdicts });
-  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  const s = await acceptanceStat(verdicts);
   assert.equal(s.n, 2); // only the two accept verdicts decide acceptance
   assert.equal(s.value, null); // still collecting
 });
@@ -177,8 +181,7 @@ test("suggestion acceptance: ≥10 verdicts renders accepted % (accept/edit succ
     ...Array.from({ length: 7 }, () => verdict("accept", false, 0)),
     ...Array.from({ length: 3 }, () => verdict("dismiss", false, 0)),
   ];
-  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => verdicts });
-  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  const s = await acceptanceStat(verdicts);
   assert.equal(s.n, 10);
   assert.equal(s.value, "70% accepted");
 });
@@ -188,8 +191,7 @@ test("suggestion acceptance: a `never` flag counts as a rejection", async () => 
     ...Array.from({ length: 6 }, () => verdict("accept", false, 0)),
     ...Array.from({ length: 4 }, () => verdict("accept", true, 0)), // never-flagged accept → rejection
   ];
-  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => verdicts });
-  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  const s = await acceptanceStat(verdicts);
   assert.equal(s.n, 10);
   assert.equal(s.value, "60% accepted");
 });
@@ -197,8 +199,7 @@ test("suggestion acceptance: a `never` flag counts as a rejection", async () => 
 test("suggestion acceptance: verdicts older than 30d are excluded", async () => {
   const old = verdict("accept", false, 40);
   const fresh = Array.from({ length: 10 }, () => verdict("accept", false, 1));
-  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => [old, ...fresh] });
-  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  const s = await acceptanceStat([old, ...fresh]);
   assert.equal(s.n, 10);
 });
 

--- a/src/server/ctoInbound.test.mjs
+++ b/src/server/ctoInbound.test.mjs
@@ -1,16 +1,6 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
+import { makeEngineDeps } from "./ctoTestEngineDeps.mjs";
 
 // ctoInbound.test.mjs — On-call CTO inbound feed (BET-1165, issue 2/3).
 // Pure logic + injected I/O, no live tmux / opencode / multica / push:
@@ -260,22 +250,7 @@ test("normalizeInboxKind maps unknown/bare to blocker; coalesceInboxEntry unions
 // ---------------------------------------------------------------------------
 
 function makeEngine(overrides = {}) {
-  return createCtoEngine({
-    listProjects: async () => [],
-    listSessions: async () => [],
-    listMessages: async () => [],
-    listModels: async () => [],
-    getSessionAgent: async () => null,
-    listSnapshots: () => [],
-    listStopped: async () => ({ records: [], lastLooked: null }),
-    searchMessages: async () => ({ supported: true, hits: [] }),
-    configGet: async () => ({}),
-    gitStatus: async () => "",
-    gitBranch: async () => null,
-    gitLog: async () => "",
-    queryMultica: async () => ({ ok: true }),
-    ...overrides,
-  });
+  return createCtoEngine(makeEngineDeps({ queryMultiba: async () => ({ ok: true }), ...overrides }));
 }
 
 // Gate that reports confirm only for `watch` (the confirm-mode tool).

--- a/src/server/ctoJournal.test.mjs
+++ b/src/server/ctoJournal.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // src/server/ctoJournal.test.mjs
 // BET-1394 — journal (§3.2) cap-50 eviction at admission, facts-style

--- a/src/server/ctoOvernight.test.mjs
+++ b/src/server/ctoOvernight.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // src/server/ctoOvernight.test.mjs
 // BET-1402 — pure-logic tests for the overnight scheduler CORE (node:test,

--- a/src/server/ctoProbes.test.mjs
+++ b/src/server/ctoProbes.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // ctoProbes.test.mjs — BET-1396 (§7.5 probe runner, §7.3 vitality, §7.6
 // relevance, §10.6-7 escalation). Pure over injected fakes: no live network,

--- a/src/server/ctoProfile.test.mjs
+++ b/src/server/ctoProfile.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // src/server/ctoProfile.test.mjs
 // BET-1393 — profile engine (spec §8.1–8.4). Coverage per decomposition:

--- a/src/server/ctoProfile.test.mjs
+++ b/src/server/ctoProfile.test.mjs
@@ -362,7 +362,8 @@ test("offHoursDeviation: 3am for a midday worker → flagged; midday → null", 
 // Engine integration (injected store)
 // ---------------------------------------------------------------------------
 
-test("engine: observable deterministic layer builds temporal stats", async () => {
+// An initialized profile over a capturing in-memory store.
+async function makeProfile() {
   const store = {
     saved: null,
     load: async () => ({}),
@@ -372,6 +373,11 @@ test("engine: observable deterministic layer builds temporal stats", async () =>
   };
   const p = createCtoProfile({ store, now: () => 0 });
   await p.init();
+  return { store, p };
+}
+
+test("engine: observable deterministic layer builds temporal stats", async () => {
+  const { p } = await makeProfile();
   const DAY = 86_400_000;
   // midday activity (epoch → Date shift is platform-dependent; use now()=0 offset)
   for (let i = 0; i < 5; i++) {
@@ -383,15 +389,7 @@ test("engine: observable deterministic layer builds temporal stats", async () =>
 });
 
 test("engine: atoms + session length apply through applySegmentSummary", async () => {
-  const store = {
-    saved: null,
-    load: async () => ({}),
-    save: async (d) => {
-      store.saved = d;
-    },
-  };
-  const p = createCtoProfile({ store, now: () => 0 });
-  await p.init();
+  const { p } = await makeProfile();
   await p.applySegmentSummary({
     project: "manta",
     atoms: [{ dimension: "swift", direction: "up", weight: 1, ref: "s1" }],
@@ -404,15 +402,7 @@ test("engine: atoms + session length apply through applySegmentSummary", async (
 });
 
 test("engine: weekly decay erodes repo familiarity from others' edits", async () => {
-  const store = {
-    saved: null,
-    load: async () => ({}),
-    save: async (d) => {
-      store.saved = d;
-    },
-  };
-  const p = createCtoProfile({ store, now: () => 0 });
-  await p.init();
+  const { store, p } = await makeProfile();
   await p.recordRepoEdit({ repo: "manta", own: true }); // 0.2 → ~0.28
   await p.recordRepoEdit({ repo: "manta", own: false });
   await p.recordRepoEdit({ repo: "manta", own: false }); // 2 others' edits pending

--- a/src/server/ctoRollups.test.mjs
+++ b/src/server/ctoRollups.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoSegments.test.mjs
+++ b/src/server/ctoSegments.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // src/server/ctoSegments.test.mjs — BET-1380 work segmentation (§5.1), segment
 // summaries (§5.2), turn completion, and the G refit. Pure logic only —

--- a/src/server/ctoSegments.test.mjs
+++ b/src/server/ctoSegments.test.mjs
@@ -222,6 +222,31 @@ test("user abort (queued-drain) never caches a one-liner or flags a completion",
 });
 
 // ---------------------------------------------------------------------------
+// Two prompts 30s apart in session s1 (both within a 1-minute gap G).
+function seedTwoPrompts(h) {
+  h.set(0);
+  h.seg.observe(prompt("a"), { sessionID: "s1", project: "p", ts: h.now() });
+  h.set(30_000);
+  h.seg.observe(prompt("b"), { sessionID: "s1", ts: h.now() });
+}
+
+// A busy event then idle (turn completion), 1s apart, then the turn flush.
+async function observeTurnClose(h) {
+  h.set(1000);
+  h.seg.observe(busy(), { sessionID: "s1", ts: h.now() });
+  h.set(2000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
+  await flushTurns(h.seg);
+}
+
+// Close session s1 with idle at 1s and return the persisted segment file.
+async function closeWithIdle(h) {
+  h.set(1000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
+  await flushClose(h.seg);
+  return [...h.stores.segmentsStore.peek().values()][0];
+}
+
 // Segmentation: gap close, idle close (§5.1-a,b)
 // ---------------------------------------------------------------------------
 
@@ -231,10 +256,7 @@ test("events closer than G stay in one segment; idle closes it", async () => {
     g: 1, // G = 1 minute
     summarize: async (data) => { calls.push(data); return { ok: true, summary: validSummary({ window: data.start ? [0, 0] : [0, 0] }) }; },
   });
-  h.set(0);
-  h.seg.observe(prompt("a"), { sessionID: "s1", project: "p", ts: h.now() });
-  h.set(30_000);
-  h.seg.observe(prompt("b"), { sessionID: "s1", ts: h.now() }); // within G
+  seedTwoPrompts(h); // within G
   h.set(60_000);
   h.seg.observe(idle(), { sessionID: "s1", ts: h.now() }); // idle closes
   await flushClose(h.seg);
@@ -251,10 +273,7 @@ test("an inter-event gap exceeding G closes the segment and opens a new one", as
     g: 1, // G = 60000 ms
     summarize: async () => ({ ok: true, summary: validSummary() }),
   });
-  h.set(0);
-  h.seg.observe(prompt("a"), { sessionID: "s1", project: "p", ts: h.now() });
-  h.set(30_000);
-  h.seg.observe(prompt("b"), { sessionID: "s1", ts: h.now() }); // gap 30s < G
+  seedTwoPrompts(h); // gap 30s < G
   h.set(200_000);
   h.seg.observe(prompt("c"), { sessionID: "s1", ts: h.now() }); // gap 170s > G → closes seg1, opens seg2
   h.set(250_000);
@@ -316,11 +335,7 @@ test("one-liner computed at turn completion is cached and reused at segment clos
   });
   h.set(0);
   h.seg.observe(prompt("a"), { sessionID: "s1", project: "p", ts: h.now() });
-  h.set(1000);
-  h.seg.observe(busy(), { sessionID: "s1", ts: h.now() });
-  h.set(2000);
-  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() }); // turn completion → one-liner
-  await flushTurns(h.seg);
+  await observeTurnClose(h);
   await flushClose(h.seg);
   assert.equal(oneLinerSeen.length, 1, "one-liner computed exactly once, at turn completion");
   assert.equal(h.seg.getOneLiner("s1"), "Fixed the login redirect", "cached");
@@ -333,11 +348,7 @@ test("a failed/absent one-liner degrades to the truncated last user prompt", asy
   const h = makeSeg({ computeOneLiner: async () => null });
   h.set(0);
   h.seg.observe(prompt("do the thing now"), { sessionID: "s1", ts: h.now() });
-  h.set(1000);
-  h.seg.observe(busy(), { sessionID: "s1", ts: h.now() });
-  h.set(2000);
-  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
-  await flushTurns(h.seg);
+  await observeTurnClose(h);
   assert.equal(h.seg.getOneLiner("s1"), "do the thing now", "fallback is the truncated prompt");
 });
 
@@ -396,10 +407,7 @@ test("a non-gated validation failure persists a degraded summary and records the
   const h = makeSeg({ summarize: async () => ({ ok: false, gated: false }) });
   h.set(0);
   h.seg.observe(prompt("fix the bug please"), { sessionID: "s1", project: "p", ts: h.now() });
-  h.set(1000);
-  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
-  await flushClose(h.seg);
-  const file = [...h.stores.segmentsStore.peek().values()][0];
+  const file = await closeWithIdle(h);
   assert.equal(file.summary.outcome, "in-progress");
   assert.equal(file.summary.one_liner, "fix the bug please");
   assert.ok(
@@ -412,10 +420,7 @@ test("a gated summary (disabled/paused) degrades without recording a failure", a
   const h = makeSeg({ summarize: async () => ({ ok: false, gated: true }) });
   h.set(0);
   h.seg.observe(prompt("work"), { sessionID: "s1", ts: h.now() });
-  h.set(1000);
-  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
-  await flushClose(h.seg);
-  const file = [...h.stores.segmentsStore.peek().values()][0];
+  const file = await closeWithIdle(h);
   assert.equal(file.summary.outcome, "in-progress");
   assert.ok(
     !h.stores.ledgerStore.peek().some((r) => r.kind === "cto.segment_summary_failed"),

--- a/src/server/ctoSessions.test.mjs
+++ b/src/server/ctoSessions.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // src/server/ctoSessions.test.mjs — BET-1378 ephemeral session runner (§3.1),
 // task classes + cascade (§12.3), context budgets, active-set, reaper. Pure

--- a/src/server/ctoStores.test.mjs
+++ b/src/server/ctoStores.test.mjs
@@ -5,20 +5,9 @@
 // tmux/opencode/network; the only I/O is real fs against grand the sandboxed
 // cto root (every path goes through ctoPath() → statePath()).
 
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. This file writes the real module-level CTO stores
-// (they resolve under MANTA_STATE_HOME when sandboxed); imported unsandboxed
-// those paths resolve against the LIVE box state (~/.manta) and the tests
-// would write production data. `npm test` / `npm run test:server` set
-// MANTA_STATE_HOME via scripts/testSandbox.mjs before any module is evaluated;
-// a bare `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO store tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
+import { memoryStore } from "./ctoTestStores.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -407,18 +396,6 @@ test("purgeExpiredInbox drops only expired entries, silently (no trace)", () => 
 // standing-query engine's migration marker).
 // ---------------------------------------------------------------------------
 
-// Deep-copy at the boundary like the real jsonStore (a parsed clone per
-// load/save) — aliasing the live object would fake both stale snapshots and
-// clobbers. Same shape as the memoryStore fixture in ctoTrust.test.mjs.
-function memoryStore(initial = {}) {
-  let data = JSON.parse(JSON.stringify(initial ?? {}));
-  return {
-    load: async () => JSON.parse(JSON.stringify(data)),
-    save: async (p) => {
-      data = JSON.parse(JSON.stringify(p));
-    },
-  };
-}
 
 async function seedEngineState(payload) {
   await engineStateStore.save({ v: 1, ...payload });

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoSweeperWiring.test.mjs
+++ b/src/server/ctoSweeperWiring.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // ctoSweeperWiring.test.mjs — BET-1464 defect 1 wiring gate. index.mjs cannot
 // be imported (it boots the server on import), so the sweeper's startup

--- a/src/server/ctoTestEngineDeps.mjs
+++ b/src/server/ctoTestEngineDeps.mjs
@@ -1,0 +1,21 @@
+// BET-1490: the no-op engine-deps stub shared by the cto.test.mjs and
+// ctoInbound.test.mjs engine tests — every list/read seam returns empty so
+// the tests stay deterministic and side-effect free. Callers spread their
+// own overrides on top.
+export function makeEngineDeps(overrides = {}) {
+  return {
+    listProjects: async () => [],
+    listSessions: async () => [],
+    listMessages: async () => [],
+    listModels: async () => [],
+    getSessionAgent: async () => null,
+    listSnapshots: () => [],
+    listStopped: async () => ({ records: [], lastLooked: null }),
+    searchMessages: async () => ({ supported: true, hits: [] }),
+    configGet: async () => ({}),
+    gitStatus: async () => "",
+    gitBranch: async () => null,
+    gitLog: async () => "",
+    ...overrides,
+  };
+}

--- a/src/server/ctoTestGuard.mjs
+++ b/src/server/ctoTestGuard.mjs
@@ -1,0 +1,19 @@
+// BET-1490: shared fail-fast MANTA_STATE_HOME guard for every
+// src/server/cto*.test.mjs file. BET-1469/1489 mandated the guard be copied
+// verbatim into each test file; that byte-identical mirror is what the
+// duplication-gate flags, so this module replaces the mirror. Importing it
+// as the FIRST import of a test file preserves (and tightens) the fail-fast
+// semantics: with no MANTA_STATE_HOME set, module evaluation aborts HERE,
+// before any store module in the importing file is evaluated, and nothing is
+// written to the live box state (~/.manta).
+//
+// `npm test` / `npm run test:server` set MANTA_STATE_HOME via
+// scripts/testSandbox.mjs before any module is evaluated; a bare
+// `node --test <file>` does not.
+if (!process.env.MANTA_STATE_HOME) {
+  throw new Error(
+    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
+      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
+      "or set MANTA_STATE_HOME to a throwaway directory first.",
+  );
+}

--- a/src/server/ctoTestStores.mjs
+++ b/src/server/ctoTestStores.mjs
@@ -1,0 +1,73 @@
+// Shared in-memory store fixtures for the src/server/cto*.test.mjs files.
+//
+// BET-1490: extracted from byte-identical copies that the duplication-gate's
+// strict policy flags as soon as two of the owning files land in one PR
+// (BET-1469 deliberately mirrored the fixtures; this shared module replaces
+// the mirror without changing any shape).
+
+// BET-1469: the in-memory `stores` bundle handed to the engine so its default
+// sub-engine constructions (cards/trust/verdicts/watchers/probes/segments/
+// rollups/facts/profile/journal/budget) all bind memory, never real files.
+// Shapes mirror ctoStores.mjs: json stores are single-payload { load, save };
+// dir stores are one-payload-per-id { load(id), save(id, data) } over a Map;
+// the rollups store namespaces by level. No fs anywhere: `dir` is "" so the
+// engine's readdir fall-throughs short-circuit, and pathFor is identity.
+export function makeMemoryStores() {
+  const jsonStore = (initial) => {
+    let payload = { ...initial };
+    return {
+      load: async () => ({ ...payload }),
+      save: async (p) => {
+        payload = { ...p };
+      },
+    };
+  };
+  const dirStore = () => {
+    const map = new Map();
+    return {
+      dir: "",
+      pathFor: (id) => id,
+      load: async (id) => map.get(id) ?? { v: 1 },
+      save: async (id, data) => {
+        map.set(id, data);
+      },
+    };
+  };
+  return {
+    ledger: { append: async () => true },
+    engineState: jsonStore({ v: 1 }),
+    trust: jsonStore({}),
+    cards: jsonStore({ v: 1, cards: [] }),
+    inbox: jsonStore({ v: 1, entries: [] }),
+    verdicts: jsonStore({ entries: [] }),
+    budget: jsonStore({}),
+    watchers: jsonStore({ watchers: [] }),
+    toolRegistry: jsonStore({ tools: [] }),
+    toolUsage: jsonStore({}),
+    probeState: dirStore(),
+    segments: dirStore(),
+    rollups: {
+      dir: "",
+      dirFor: (level) => `mem://rollups/${level}`,
+      load: async () => ({ v: 1 }),
+      save: async () => {},
+    },
+    facts: dirStore(),
+    factsArchive: dirStore(),
+    profile: jsonStore({}),
+    journal: jsonStore({ entries: [] }),
+  };
+}
+
+// Deep-copy at the boundary like the real jsonStore (a parsed clone per
+// load/save) — aliasing the live object would fake both stale snapshots and
+// clobbers.
+export function memoryStore(initial = {}) {
+  let data = JSON.parse(JSON.stringify(initial ?? {}));
+  return {
+    load: async () => JSON.parse(JSON.stringify(data)),
+    save: async (p) => {
+      data = JSON.parse(JSON.stringify(p));
+    },
+  };
+}

--- a/src/server/ctoTier.test.mjs
+++ b/src/server/ctoTier.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoToolCatalog.test.mjs
+++ b/src/server/ctoToolCatalog.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoToolRegistry.test.mjs
+++ b/src/server/ctoToolRegistry.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoToolScan.test.mjs
+++ b/src/server/ctoToolScan.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/server/ctoTrust.test.mjs
+++ b/src/server/ctoTrust.test.mjs
@@ -42,6 +42,16 @@ function makeTrust({ engineState = {}, verdictCount = 0 } = {}) {
   return { trust, stores, ledgerRows, verdictEntries };
 }
 
+// Record `accepts` successful verdicts then one dismissal for `subject`,
+// returning the post-drive state.
+async function driveVerdicts(h, subject, accepts) {
+  for (let i = 0; i < accepts; i++) {
+    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
+  }
+  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
+  return h.trust.getState();
+}
+
 // ---------------------------------------------------------------------------
 // §9.3 eligibility map
 // ---------------------------------------------------------------------------
@@ -293,11 +303,7 @@ test("promotion: accepts past the bar promote ask → veto-window, ledger + dige
   const subject = { type: "suggestion", id: "s1", class: "start-job" };
   // 31 accepts + 1 dismiss: the tail clears (a degenerate b=0 record never
   // passes — the estimator refuses zero-variance records).
-  for (let i = 0; i < 31; i++) {
-    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
-  }
-  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
-  const st = await h.trust.getState();
+  const st = await driveVerdicts(h, subject, 31);
   assert.equal(st.tiers["start-job"], TIER_VETO_WINDOW);
   assert.ok(h.ledgerRows.some((r) => r.kind === "trust.promoted" && r.cls === "start-job" && r.to === TIER_VETO_WINDOW));
   assert.equal(st.pending, 1);
@@ -312,11 +318,7 @@ test("promotion never fires under the cold-start gate, whatever the counters say
   const h = makeTrust({ verdictCount: 0 }); // cold start: < VERDICT_MIN verdicts
   const subject = { type: "suggestion", id: "s1", class: "start-job" };
   // A record that would pass the tail outside cold start.
-  for (let i = 0; i < 40; i++) {
-    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
-  }
-  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
-  const st = await h.trust.getState();
+  const st = await driveVerdicts(h, subject, 40);
   assert.equal(st.pending, 0);
   // And consult reports the ask cap while the global gate holds.
   const c = await h.trust.consult("start-job", { coldStart: true });
@@ -326,11 +328,7 @@ test("promotion never fires under the cold-start gate, whatever the counters say
 test("capped class never promotes even with a stellar record", async () => {
   const h = makeTrust({ verdictCount: VERDICT_MIN });
   const subject = { type: "suggestion", id: "c1", class: "config-change" };
-  for (let i = 0; i < 40; i++) {
-    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
-  }
-  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
-  const st = await h.trust.getState();
+  const st = await driveVerdicts(h, subject, 40);
   assert.equal(st.tiers["config-change"] ?? TIER_ASK, TIER_ASK);
   assert.equal(st.pending, 0); // no announcement either
   const c = await h.trust.consult("config-change", { coldStart: false });
@@ -395,11 +393,7 @@ test("act-and-report bookkeeping: ledger row + pending announcement, exactly-onc
 test("rolling window is capped and consumed by a tier change", async () => {
   const h = makeTrust({ verdictCount: VERDICT_MIN });
   const subject = { type: "suggestion", id: "s1", class: "start-job" };
-  for (let i = 0; i < 31; i++) {
-    await h.trust.noteVerdictEffects({ success: true }, { subject, verdict: "accept" });
-  }
-  await h.trust.noteVerdictEffects({ rejection: true }, { subject, verdict: "dismiss" });
-  let st = await h.trust.getState();
+  let st = await driveVerdicts(h, subject, 31);
   assert.equal(st.tiers["start-job"], TIER_VETO_WINDOW);
   assert.equal(st.stats["start-job"].recent.length, 0); // consumed by promotion
   // Keep recording: the window caps at REJECT_WINDOW entries.

--- a/src/server/ctoTrust.test.mjs
+++ b/src/server/ctoTrust.test.mjs
@@ -1,16 +1,6 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
+import { memoryStore } from "./ctoTestStores.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -36,18 +26,6 @@ import {
 // Fixtures
 // ---------------------------------------------------------------------------
 
-function memoryStore(initial = {}) {
-  // Deep-copy at the boundary like the real jsonStore (a parsed clone per
-  // load/save) — aliasing the live object would fake both migrations and
-  // clobbers.
-  let data = JSON.parse(JSON.stringify(initial ?? {}));
-  return {
-    load: async () => JSON.parse(JSON.stringify(data)),
-    save: async (p) => {
-      data = JSON.parse(JSON.stringify(p));
-    },
-  };
-}
 
 function makeTrust({ engineState = {}, verdictCount = 0 } = {}) {
   const ledgerRows = [];

--- a/src/server/ctoVerdicts.test.mjs
+++ b/src/server/ctoVerdicts.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // src/server/ctoVerdicts.test.mjs
 // BET-1391 — verdict ledger + §9.5 counter mapping + estimator helpers.

--- a/src/server/ctoWatchers.test.mjs
+++ b/src/server/ctoWatchers.test.mjs
@@ -133,15 +133,21 @@ test("rate-threshold honors an eventKind filter (other kinds don't count)", asyn
   assert.equal(deps.ledgerRows.filter((r) => r.kind === "watcher.hit").length, 0);
 });
 
+// A usage-burn standing-query engine over `deps` with the canonical
+// registered predicate (windowMs 6000, capFraction 0.5), ticked once.
+async function makeBurnEngine(deps) {
+  const eng = createStandingQueryEngine(deps);
+  await eng.register({ predicate: { kind: USAGE_BURN, params: { windowMs: 6000, capFraction: 0.5 } } });
+  await eng.runTick();
+  return eng;
+}
+
 test("usage-burn fires when burst spend is at/above the cap fraction (once per window)", async () => {
   const deps = makeEngineDeps({
     getSpendInWindow: async () => 60, // windowMs 6000 of a day = huge share
     getCapUsd: async () => 100,
   });
-  const eng = createStandingQueryEngine(deps);
-  await eng.register({ predicate: { kind: USAGE_BURN, params: { windowMs: 6000, capFraction: 0.5 } } });
-  // 60 >= 0.5 * (100 * 6000 / 86400000)=0.0035 → true
-  await eng.runTick();
+  await makeBurnEngine(deps);
   assert.equal(deps.ledgerRows.filter((r) => r.kind === "watcher.hit").length, 1);
 });
 
@@ -150,9 +156,7 @@ test("usage-burn does not fire when spend is below the cap share", async () => {
     getSpendInWindow: async () => 0,
     getCapUsd: async () => 100,
   });
-  const eng = createStandingQueryEngine(deps);
-  await eng.register({ predicate: { kind: USAGE_BURN, params: { windowMs: 6000, capFraction: 0.5 } } });
-  await eng.runTick();
+  await makeBurnEngine(deps);
   assert.equal(deps.ledgerRows.filter((r) => r.kind === "watcher.hit").length, 0);
 });
 

--- a/src/server/ctoWatchers.test.mjs
+++ b/src/server/ctoWatchers.test.mjs
@@ -1,16 +1,5 @@
-// BET-1469: fail fast, before ANY test body runs, when this file is executed
-// outside the state sandbox. A CTO store module imported unsandboxed resolves
-// its paths against the LIVE box state (~/.manta) and a test would write
-// production data. `npm test` / `npm run test:server` set MANTA_STATE_HOME via
-// scripts/testSandbox.mjs before any module is evaluated; a bare
-// `node --test <file>` does not.
-if (!process.env.MANTA_STATE_HOME) {
-  throw new Error(
-    "MANTA_STATE_HOME is not set — refusing to run CTO tests against the live box state. " +
-      "Run via `npm test` or `npm run test:server` (both --import ./scripts/testSandbox.mjs), " +
-      "or set MANTA_STATE_HOME to a throwaway directory first.",
-  );
-}
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
 
 // ctoWatchers.test.mjs — standing-query watcher engine (BET-1398 / §4.3, §13.4).
 // Pure logic + injected I/O (fake store/ledger/engineState), no live services:


### PR DESCRIPTION
## Summary

Makes the strict duplication-gate green for cto test files (BET-1490). Two named clone sets, plus the rest of the inventory the gate actually flags once all 31 `src/server/cto*.test.mjs` files land in one diff — the gate scans every changed file pairwise AND against itself, so a PR touching cto test files is red until **all** clones among them are gone (jscpd over the 31 files on `main`: 16 clones, not 2).

**Set 1 — shared fixtures (extracted, per the issue's preferred route):**
- `makeMemoryStores()` (byte-identical in `ctoEngine.test.mjs` + `ctoEvidence.test.mjs`) → `src/server/ctoTestStores.mjs`
- `memoryStore()` deep-copy fixture (identical in `ctoStores.test.mjs` + `ctoTrust.test.mjs` — the comment even said "Same shape as the memoryStore fixture in ctoTrust.test.mjs") → same module
- The 12-key no-op `createCtoEngine` deps stub (near-identical `makeEngine` in `cto.test.mjs` + `ctoInbound.test.mjs`) → `src/server/ctoTestEngineDeps.mjs`

**Set 2 — the `MANTA_STATE_HOME` guard mirror (extracted, route 1 of the issue):**
- All 31 files' verbatim guard → `src/server/ctoTestGuard.mjs`, imported as the **first import** of every cto test file. Semantics preserved and tightened: same "MANTA_STATE_HOME is not set — refusing to run CTO tests…" message; because the guard module is now first in the import graph it aborts **before** any store module is evaluated (the old inline form ran after import hoisting), and nothing is written to `~/.manta`. Verified: `node --test src/server/ctoCards.test.mjs` (no `--import`) aborts at import from `ctoTestGuard.mjs:14` with the exact message. One wording normalization: `ctoStores.test.mjs`'s copy said "CTO **store** tests" — all files now share the canonical 30-file message. This intentionally supersedes BET-1469/1489's "copy verbatim inline" pattern (which is what made the mirror); fail-fast intent is unchanged.

**The other 14 clones the gate would still flag (intra-file self-clones, 9 files):** each repeated ≥70-token scaffolding block extracted into a local helper in the same file — `runStartJobProbe` (ctoAct ×3), `makeReplayBackfill` (ctoBackfill), `makeQuietBudget` (ctoBudget), `armVetoCard` (ctoEngine.overnight), `acceptanceStat` (ctoHealth ×5), `makeProfile` (ctoProfile ×3), `seedTwoPrompts`/`observeTurnClose`/`closeWithIdle` (ctoSegments), `driveVerdicts` (ctoTrust ×4), `makeBurnEngine` (ctoWatchers). No ignore-list entries added — the human-approval route was not needed.

**Gate evidence:** `scripts/check-duplication-gate.sh origin/main` → `scanning 34 changed file(s) … PASS — no clones`. jscpd over the 31 test files: 16 clones → 0.

**Base:** origin/main @ `a8094354`

**Verification results:**
- PR branch (`multica/BET-1490-dup-gate-cto-tests` @ `3b0f3aa8`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0. vitest: 3901 pass / 0 fail / 7 skip (198 files); node:test: 3810 pass / 0 fail. Failures: none. log sha256: `0d4e68ed6504092ed40e9663ec4f407de4dafa2553ea56ea24a63a13a2458f09`
- Base (`main` @ `a8094354`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0. vitest: 3901 pass / 0 fail / 7 skip; node:test: 3810 pass / 0 fail. Failures: none. log sha256: `18fb0feb4cfed66b3537cae213c4dfa1ddc4ed16710be4e69a0c2b8936d2fb01`
- **Conclusion:** 0 new failures, 0 pre-existing failures — both branches fully green. Duplication-gate: PASS on the PR branch (red inventory it fixes: 16 clones on base).

Reviewer note: the diff is dominated by deletions (730−/329+ across 31 test files); the interesting review surface is the three new shared modules and the ten local helpers.
