### PR TITLE
refactor(server): drop persisted-but-unread deepAsk counters; fix connect-route comment (BET-1444)

### DIFF
--- a/src/server/ctoToolRegistry.mjs
+++ b/src/server/ctoToolRegistry.mjs
@@ -46,9 +46,7 @@ function payloadFrom(raw) {
     v: TOOL_REGISTRY_VERSION,
     tools: (Array.isArray(p?.tools) ? p.tools : []).map((t) => ({
       deepAskRound: 0,
-      deepAskAtUses: 0,
       deepReArmAt: null,
-      deepAskBarMet: false,
       lastDeepAskDay: null,
       asSourceDecayed: false,
       decayedAtUses: 0,
@@ -153,9 +151,7 @@ function baseTool(identity, ts) {
     unneverAtUses: null,
     // Deep-read ring ask bookkeeping (§7.4 ring semantics apply per ask).
     deepAskRound: 0,
-    deepAskAtUses: 0,
     deepReArmAt: null,
-    deepAskBarMet: false, // the deep bar's met-state snapshot at ask time
     lastDeepAskDay: null,
     // Dismissal decay chain (§7.6): the as_source trip's persisted state.
     asSourceDecayed: false,
@@ -660,9 +656,7 @@ export function createToolRegistry(deps = {}) {
           ts: nowMs,
         });
         t.deepAskRound = (t.deepAskRound ?? 0) + 1;
-        t.deepAskAtUses = t.uses ?? 0;
         t.deepReArmAt = null;
-        t.deepAskBarMet = bar.met;
         payload.lastDeepAskDay = today;
         changed = true;
         await ledgerLog({ kind: "cto.tool.deep_ask", tool: t.tool, project: bar.project, askRound: t.deepAskRound });
@@ -771,7 +765,6 @@ export function createToolRegistry(deps = {}) {
         if (ring === "deep_read") {
           t.consent.deep_read = "no";
           t.deepReArmAt = nowMs + NOT_NOW_REARM_MS;
-          t.deepAskAtUses = t.uses ?? 0;
           await ledgerLog({ kind: "cto.tool.consent", tool: id, ring: "deep_read", value: "no" });
         } else {
           t.consent.metadata = "no";

--- a/src/server/ctoToolRegistry.test.mjs
+++ b/src/server/ctoToolRegistry.test.mjs
@@ -752,7 +752,6 @@ test("deep-read ask: the bar crossing raises ONE concrete ask (ring deep_read, i
   assert.match(ask.body, /analyze GitHub's data about alpha overnight and report findings/);
   const row = registryStore._state().tools.find((x) => x.tool === "github");
   assert.equal(row.deepAskRound, 1);
-  assert.equal(row.deepAskBarMet, true);
   assert.equal(registryStore._state().lastDeepAskDay, new Date(W0 + DAY).toISOString().slice(0, 10));
   assert.ok(ledger.rows.some((r) => r.kind === "cto.tool.deep_ask" && r.project === "alpha"));
   // same day again → no second ask
@@ -760,7 +759,7 @@ test("deep-read ask: the bar crossing raises ONE concrete ask (ring deep_read, i
   assert.equal(cards.calls.upserts.length, 1);
   // next day → the gate re-opens (askRound < 3), one more ask
   const { registry: reg2, cards: cards2 } = seededRegistry(
-    [deepEligibleRow({ deepAskRound: 1, deepAskBarMet: true })],
+    [deepEligibleRow({ deepAskRound: 1 })],
     { nowMs: W0 + 2 * DAY },
   );
   await reg2.dailyScan();
@@ -783,11 +782,11 @@ test("deep-read ask: consented, rounds exhausted, and chain-tripped tools are sk
 });
 
 test("deep-read ask: a declined ask re-arms ONLY on the 30-day timer (vitality path)", async () => {
-  const row = deepEligibleRow({ consent: { metadata: "yes", deep_read: "no", write: null }, deepAskRound: 1, deepAskAtUses: 6, deepReArmAt: W0 + DAY + 10 * DAY });
+  const row = deepEligibleRow({ consent: { metadata: "yes", deep_read: "no", write: null }, deepAskRound: 1, deepReArmAt: W0 + DAY + 10 * DAY });
   const { registry, cards } = seededRegistry([row]);
   await registry.dailyScan();
   assert.equal(cards.calls.upserts.length, 0, "timer not elapsed — no ask");
-  const row2 = deepEligibleRow({ consent: { metadata: "yes", deep_read: "no", write: null }, deepAskRound: 1, deepAskAtUses: 6, deepReArmAt: W0 + DAY - 1000 });
+  const row2 = deepEligibleRow({ consent: { metadata: "yes", deep_read: "no", write: null }, deepAskRound: 1, deepReArmAt: W0 + DAY - 1000 });
   const { registry: r2, cards: c2, registryStore: s2 } = seededRegistry([row2]);
   await r2.dailyScan();
   assert.equal(c2.calls.upserts.length, 1);

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -4681,7 +4681,7 @@ const handleRequest = async (req, res) => {
   }
 
   // ---------- Tool discovery (BET-1395, §7) ----------
-  // POST /api/cto/tools/connect {tool, answer} — the connect-ask three-way
+  // POST /api/cto/tools/connect {tool, answer, ring} — the connect-ask three-way
   // (§7.4): "connect" grants the metadata consent ring, "not-now" declines
   // with a 30-day re-arm, "never" kills every ring for that tool. The
   // registry writes the consent + the §9.5 verdict and resolves the open


### PR DESCRIPTION
Opened automatically for `multica/BET-1444-hygiene` (branch push); body completed with the verification results.

---

## BET-1444 — BET-1404 follow-ups: stale connect-route comment + persisted-but-unread deepAsk counters

Base: origin/main @ a8094354

### Item 1 — stale route comment

`src/server/index.mjs` (`/api/cto/tools/connect`): the comment said the payload was `{tool, answer}`; the call passes `ring: body?.ring` too (`resolveConnect({ tool, answer, ring = "metadata" })`). Comment now reads `{tool, answer, ring}`. One-line change, nothing else.

### Item 2 — two persisted counters nobody reads

`deepAskBarMet` and `deepAskAtUses` were write-only. Removed from:

- `ctoToolRegistry.mjs` `payloadFrom` (persisted-shape back-fill defaults)
- `ctoToolRegistry.mjs` `baseTool` (creation defaults)
- the deep-ask write path (`t.deepAskAtUses`/`t.deepAskBarMet = bar.met`)
- the `not-now` deep-read re-arm write path (`t.deepAskAtUses`)

Verified first via `grep -rn "deepAskBarMet\|deepAskAtUses" src/` that no read sites exist (the sibling metadata-ring counter `askAtUses` IS read at the re-arm freshness gate and is untouched).

**Test-note:** the existing ask test asserted `row.deepAskBarMet === true` — removed that stale assertion and the removed counters from three test fixtures. Per the issue's own acceptance criterion the grep must return *nothing*, so I did not leave a tombstone assertion naming the removed fields (that would re-introduce the reference the criterion forbids). No new tests added for the deletion, per the issue.

### Verification results

- PR branch (`multica/BET-1444-hygiene` @ `caeff885`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3810 pass / 0 fail / 0 skip. Failures: none. log sha256: `370d80dde7840bc079e46afbbe8a4775ac6f0a0cbb0ef1856e96032bcf8be27e`
- Base (`main` @ `a8094354`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3810 pass / 0 fail / 0 skip. Failures: none. log sha256: `daf7d6c21f850a8d5219804b9c519d562e3ea16ca3dcde70bac41a51f110fc65`
- **Conclusion:** 0 new failures, 0 pre-existing failures. Both branches fully green.

### Acceptance criteria

- `npm run typecheck && npm test` green on both branches ✓
- `grep -rn "deepAskBarMet\|deepAskAtUses" src/` returns nothing (exit 1, zero matches) ✓
- Route comment matches the actual call ✓
- Net line count NEGATIVE: +4 / −12 = **net −8** ✓

Out of scope respected: experiment-first prompt-contract (scheduler seam) untouched.
