### PR TITLE
fix(server): ROI pending cap spares counted fingerprints that can still re-sample (BET-1487)

### DIFF
--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -668,6 +668,38 @@ function monthAccumulator(months, key) {
 // surfaced 60 days late is beyond the report's honest horizon).
 export const ROI_PENDING_RETENTION_MS = 60 * 24 * HOUR_MS;
 
+/**
+ * The count-aware trailing cap on `roi.pending` (BET-1487). The old blind
+ * `.slice(-200)` could evict a COUNTED row — a dedupe fingerprint — while its
+ * delegate job was still inside the jobs store's terminal-retention window:
+ * the sampling step would re-snapshot the job and the probe step would count
+ * it into its month accumulator a second time. So the cap evicts
+ * oldest-first, but only rows that are safe to re-sample:
+ *   - an uncounted row is always evictable (re-sampling it merely re-probes
+ *     a job that has never been counted — no double count), and
+ *   - a counted row only once its job record is provably gone from the jobs
+ *     store — absent from the same refresh's snapshot. Job ids are minted
+ *     once and the store's sweeper only removes records, so absence is
+ *     final. The store's own retention (7 days, a 50-terminal-record cap,
+ *     or forever for a dirty-worktree record) is irrelevant here: the
+ *     snapshot IS the ground truth.
+ * `liveIds` is the set of job ids the store actually returned this refresh,
+ * or null when the read failed (liveness unknowable → no counted row is
+ * evictable). When protection leaves more than `cap` rows, the list exceeds
+ * the cap until the store retires the records.
+ */
+export function trimPendingCap(rows, { cap = 200, liveIds = null } = {}) {
+  if (rows.length <= cap) return rows;
+  let toDrop = rows.length - cap;
+  const kept = [];
+  for (const row of rows) {
+    const evictable = row.counted !== true || (liveIds !== null && !liveIds.has(row.id));
+    if (evictable && toDrop > 0) toDrop -= 1;
+    else kept.push(row);
+  }
+  return kept;
+}
+
 // ---------------------------------------------------------------------------
 // The I/O accessor the engine consumes (injected store + seams).
 // ---------------------------------------------------------------------------
@@ -1038,9 +1070,13 @@ function validPrRef(ref) {
         return (async () => {
           // 1. Sample terminal CTO-actor jobs not yet snapshotted.
           let jobs = [];
+          let jobsReadOk = true;
           try {
             jobs = (await jobsRead()) ?? [];
           } catch {
+            // Liveness is unknowable this refresh — the step-4 cap must then
+            // treat every counted row as still-at-risk (BET-1487).
+            jobsReadOk = false;
             jobs = [];
           }
           // Every pending id — counted or not — is a dedupe fingerprint: a job
@@ -1132,7 +1168,17 @@ function validPrRef(ref) {
               ? typeof j.finishedAt === "number" ? j.finishedAt >= cutoff : true
               : typeof j.finishedAt === "number" && j.finishedAt >= cutoff,
           );
-          const trimmed = kept.slice(-200);
+          // The trailing cap is count-aware (BET-1487): a counted row is a
+          // dedupe fingerprint while its delegate job could still re-sample —
+          // i.e. while its record is still in the store snapshot read in
+          // step 1. The cap evicts only fingerprints that snapshot proves
+          // dead, so on a chatty box (>200 counted jobs inside the store's
+          // terminal-retention window) the list exceeds the cap instead of
+          // losing a fingerprint.
+          const liveIds = jobsReadOk
+            ? new Set(jobs.map((j) => (j && typeof j.id === "string" ? j.id : null)).filter((id) => id !== null))
+            : null;
+          const trimmed = trimPendingCap(kept, { liveIds });
           pending = trimmed;
 
           return { ...payload, roi: { months, pending: trimmed } };

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -889,19 +889,20 @@ test("refreshRoi: the pending cap never evicts a counted fingerprint whose job i
     now: () => MIDNIGHT,
   });
   await budget.refreshRoi();
-  // The 150 probe-counted rows + the 50 originals = 200 merged, and the cap
-  // trimmed its 1 surplus from an UNCOUNTED row — the old blind slice would
-  // have evicted counted `c0` (the oldest position) instead.
-  assert.equal(payload.roi.months[AUG_KEY].merged, COUNTED + 150);
+  // The 151 probe-counted rows (150 u-rows + fresh) + the 50 originals
+  // already counted = 201 merged, and the cap trimmed its 1 surplus from an
+  // UNCOUNTED-position row — the old blind slice would have evicted counted
+  // `c0` (the oldest position) instead.
+  assert.equal(payload.roi.months[AUG_KEY].merged, COUNTED + 151);
   assert.equal(payload.roi.pending.length, 200);
   const ids1 = new Set(payload.roi.pending.map((j) => j.id));
   for (const id of countedIds) assert.equal(ids1.has(id), true, `counted fingerprint ${id} survived the cap`);
   assert.equal(ids1.has("u0"), false, "the oldest uncounted row paid the cap");
   // Refresh 2: nothing re-samples (every store id is still snapshotted) and
   // nothing re-counts — under the old code the evicted `c0` fingerprint
-  // would re-sample here and double-count to COUNTED + 151.
+  // would re-sample here and double-count once more.
   await budget.refreshRoi();
-  assert.equal(payload.roi.months[AUG_KEY].merged, COUNTED + 150);
+  assert.equal(payload.roi.months[AUG_KEY].merged, COUNTED + 151);
   assert.equal(payload.roi.pending.length, 200);
 });
 
@@ -935,7 +936,7 @@ test("refreshRoi: a failed jobs read protects every counted fingerprint from the
   assert.equal(payload.roi.pending.length, 200);
   assert.equal(payload.roi.pending.some((j) => j.id === "counted"), true);
   assert.equal(payload.roi.pending.some((j) => j.id === "u0"), false);
-  assert.equal(payload.roi.pending.some((j) => j.id === "u201"), true);
+  assert.equal(payload.roi.pending.some((j) => j.id === "u200"), true);
 });
 
 // BET-1466 item 4: budget.json is not covered by the store sweep — the spend

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -477,6 +477,7 @@ import {
   preSurfacedIncidents,
   isJobMerged,
   roiRecommendation,
+  trimPendingCap,
 } from "./ctoBudget.mjs";
 
 const AUG_KEY = roiMonthKey(MIDNIGHT); // 2026-08 local
@@ -813,6 +814,128 @@ test("pending retention keeps fresh probe-pending rows and counted fingerprints 
   await budget.refreshRoi();
   const ids = payload.roi.pending.map((j) => j.id).sort();
   assert.deepEqual(ids, ["countedNoFinish", "fresh"]);
+});
+
+// BET-1487: the pending cap is count-aware — a counted row is a dedupe
+// fingerprint while its delegate job can still re-sample (its record is still
+// in the jobs store), so the cap evicts only provably-dead fingerprints.
+test("trimPendingCap evicts oldest-first but spares counted fingerprints that can still re-sample (BET-1487)", () => {
+  const row = (id, counted, finishedAt = MIDNIGHT - 1000) => ({ id, counted, finishedAt });
+  // At or under the cap: unchanged.
+  assert.deepEqual(
+    trimPendingCap([row("a", false), row("b", true)], { liveIds: new Set() }).map((j) => j.id),
+    ["a", "b"],
+  );
+  // Over the cap with everything evictable: the oldest rows drop, the newest
+  // `cap` survive — the old blind `.slice(-200)` behavior.
+  const allUncounted = Array.from({ length: 205 }, (_, i) => row(`u${i}`, false));
+  const t1 = trimPendingCap(allUncounted, { liveIds: new Set() });
+  assert.equal(t1.length, 200);
+  assert.deepEqual([t1[0].id, t1[199].id], ["u5", "u204"]);
+  // A counted row whose job is STILL in the store (id present in the
+  // snapshot) is protected even at the oldest position; an uncounted row
+  // further back pays instead.
+  const mixed = [row("c0", true), row("u0", false), ...Array.from({ length: 199 }, (_, i) => row(`u${i + 1}`, false))];
+  const t2 = trimPendingCap(mixed, { liveIds: new Set(["c0"]) });
+  assert.equal(t2.length, 200);
+  assert.equal(t2.some((j) => j.id === "c0"), true, "a live fingerprint survives");
+  assert.equal(t2.some((j) => j.id === "u0"), false, "an uncounted row is evicted first");
+  // The same list with the record swept (id absent from the snapshot): the
+  // fingerprint is dead and evictable like any other row.
+  const t3 = trimPendingCap(mixed, { liveIds: new Set() });
+  assert.equal(t3.some((j) => j.id === "c0"), false);
+  assert.equal(t3.some((j) => j.id === "u0"), true);
+  // The cap never keys on finishedAt — a counted row without a timestamp is
+  // protected by the same liveness rule.
+  const noTs = [row("cn", true, null), ...Array.from({ length: 200 }, (_, i) => row(`u${i}`, false))];
+  assert.equal(trimPendingCap(noTs, { liveIds: new Set(["cn"]) }).some((j) => j.id === "cn"), true);
+  assert.equal(trimPendingCap(noTs, { liveIds: new Set() }).some((j) => j.id === "cn"), false);
+  // A failed store read (liveIds null) protects every counted row — the cap
+  // trims only uncounted rows.
+  const heavy = [row("c0", true), row("c1", true), ...Array.from({ length: 200 }, (_, i) => row(`u${i}`, false))];
+  const t4 = trimPendingCap(heavy, { liveIds: null });
+  assert.equal(t4.length, 200);
+  assert.deepEqual(t4.filter((j) => j.counted === true).map((j) => j.id), ["c0", "c1"]);
+  // Fully protected: nothing evictable → the list exceeds the cap rather
+  // than lose a fingerprint.
+  const allCounted = Array.from({ length: 205 }, (_, i) => row(`c${i}`, true));
+  const t5 = trimPendingCap(allCounted, { liveIds: new Set(allCounted.map((j) => j.id)) });
+  assert.equal(t5.length, 205);
+});
+
+test("refreshRoi: the pending cap never evicts a counted fingerprint whose job is still in the store (BET-1487)", async () => {
+  let payload = defaultBudgetPayload();
+  const COUNTED = 50;
+  const countedIds = Array.from({ length: COUNTED }, (_, i) => `c${i}`);
+  // The 50 counted rows' delegate jobs are STILL in the jobs store (inside
+  // its terminal-retention window) — every one is a live dedupe fingerprint.
+  const jobs = countedIds.map((id) => ({ id, actor: "cto", status: "done", branch: `cto/${id}`, cwd: "/p", finishedAt: MIDNIGHT - 1000 }));
+  payload.roi = {
+    months: { [AUG_KEY]: { merged: COUNTED } }, // as if all 50 were already counted
+    pending: [
+      ...countedIds.map((id) => ({ id, branch: `cto/${id}`, cwd: "/p", finishedAt: MIDNIGHT - 1000, counted: true })), // oldest positions
+      ...Array.from({ length: 150 }, (_, i) => ({ id: `u${i}`, branch: `cto/u${i}`, cwd: "/p", finishedAt: MIDNIGHT - 500, counted: false })),
+      { id: "fresh", branch: "cto/fresh", cwd: "/p", finishedAt: MIDNIGHT - 10, counted: false },
+    ], // 201 rows → the cap is over by 1
+  };
+  const store = { load: async () => payload, save: async (p) => (payload = p) };
+  const budget = createCtoBudget({
+    store,
+    jobsRead: async () => jobs,
+    gitProbe: async () => ({ exists: false, isAncestor: false }), // every probe reads "merged"
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now: () => MIDNIGHT,
+  });
+  await budget.refreshRoi();
+  // The 150 probe-counted rows + the 50 originals = 200 merged, and the cap
+  // trimmed its 1 surplus from an UNCOUNTED row — the old blind slice would
+  // have evicted counted `c0` (the oldest position) instead.
+  assert.equal(payload.roi.months[AUG_KEY].merged, COUNTED + 150);
+  assert.equal(payload.roi.pending.length, 200);
+  const ids1 = new Set(payload.roi.pending.map((j) => j.id));
+  for (const id of countedIds) assert.equal(ids1.has(id), true, `counted fingerprint ${id} survived the cap`);
+  assert.equal(ids1.has("u0"), false, "the oldest uncounted row paid the cap");
+  // Refresh 2: nothing re-samples (every store id is still snapshotted) and
+  // nothing re-counts — under the old code the evicted `c0` fingerprint
+  // would re-sample here and double-count to COUNTED + 151.
+  await budget.refreshRoi();
+  assert.equal(payload.roi.months[AUG_KEY].merged, COUNTED + 150);
+  assert.equal(payload.roi.pending.length, 200);
+});
+
+test("refreshRoi: a failed jobs read protects every counted fingerprint from the cap (BET-1487)", async () => {
+  let payload = defaultBudgetPayload();
+  payload.roi = {
+    months: {},
+    pending: [
+      { id: "counted", branch: "cto/counted", cwd: "/p", finishedAt: MIDNIGHT - 1000, counted: true }, // oldest position
+      ...Array.from({ length: 201 }, (_, i) => ({ id: `u${i}`, branch: `cto/u${i}`, cwd: "/p", finishedAt: MIDNIGHT - 500, counted: false })),
+    ], // 202 rows → the cap is over by 2
+  };
+  const store = { load: async () => payload, save: async (p) => (payload = p) };
+  let readFails = true;
+  const budget = createCtoBudget({
+    store,
+    jobsRead: async () => {
+      if (readFails) throw new Error("jobs store down");
+      return [];
+    },
+    gitProbe: async () => ({ exists: true, isAncestor: false }), // nothing merges — rows stay uncounted
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now: () => MIDNIGHT,
+  });
+  await budget.refreshRoi();
+  // With the read failed, liveness is unknowable — the cap still bounds the
+  // uncounted rows (its actual job) but the counted fingerprint survives
+  // even at the oldest position. The old blind slice evicted it first.
+  assert.equal(payload.roi.pending.length, 200);
+  assert.equal(payload.roi.pending.some((j) => j.id === "counted"), true);
+  assert.equal(payload.roi.pending.some((j) => j.id === "u0"), false);
+  assert.equal(payload.roi.pending.some((j) => j.id === "u201"), true);
 });
 
 // BET-1466 item 4: budget.json is not covered by the store sweep — the spend

--- a/src/server/ctoSuggest.mjs
+++ b/src/server/ctoSuggest.mjs
@@ -86,7 +86,9 @@ export const VERDICT_MIN = TRUST_VERDICT_MIN;
 
 // BET-1465: bound `es.suggest.usedKeys` so it cannot become the next
 // unbounded engine-state store — the `ctoStores.mjs` sweep does not cover
-// engine-state. Same trailing-slice idiom as `ctoBudget.mjs`'s `.slice(-200)`.
+// engine-state. Plain trailing slice — unlike `ctoBudget.mjs`'s ROI pending
+// cap (BET-1487), these keys carry no counted-fingerprint semantics, so a
+// blind bound is safe here.
 const USED_KEYS_CAP = 200;
 
 // §9.1 per-class gate thresholds (BET-1471 — implements the BET-1470

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -2336,12 +2336,13 @@ const adaptiveCtoBudget = ctoBudget.createCtoBudget({
   // read (merged-branch detection), verdicts, segments (user-prompt history
   // for the incidents heuristic) and the §14.5 ledger.
   jobsRead: async () => {
-    try {
-      const { jobs = [] } = await delegateEngine.listJobs();
-      return jobs;
-    } catch {
-      return [];
-    }
+    // No catch: a failed read must reach refreshRoi as a failure, not as an
+    // empty store — its count-aware pending cap (BET-1487) reads absence
+    // from a successfully-read store as proof that a counted fingerprint's
+    // job can never re-sample, and an empty-on-error list would strip that
+    // protection. refreshRoi's own catch degrades the failure safely.
+    const { jobs = [] } = await delegateEngine.listJobs();
+    return jobs;
   },
   gitProbe: async ({ cwd, branch }) => {
     const dir = typeof cwd === "string" && cwd ? cwd : null;


### PR DESCRIPTION
## Summary — BET-1487

`refreshRoi` (`src/server/ctoBudget.mjs`) bounded `roi.pending` with a blind trailing `.slice(-200)` applied after the retention filter. Pending rows are dedupe fingerprints: a **counted** row evicted by the cap while its delegate job is still inside the jobs store's terminal-retention window can be re-sampled and re-counted into its month accumulator (a silent double count). Reaching it requires >200 counted CTO delegate jobs within the 7-day sweep window on one box — rare, but the failure is silent data corruption and the fix is local.

### What changed

- **`trimPendingCap(rows, { cap, liveIds })`** replaces the blind slice. Eviction is oldest-first but count-aware:
  - an **uncounted** row is always evictable — re-sampling it merely re-probes a job that has never been counted;
  - a **counted** row is evictable only once the same refresh's jobs-store snapshot proves its record is gone (ids are minted once and the store's sweeper only removes records, so absence is final);
  - a failed jobs read (`liveIds = null`) makes liveness unknowable → no counted row is evictable;
  - when protection leaves more than `cap` rows, the list **exceeds the cap** rather than lose a fingerprint.
- `refreshRoi` step 4 builds `liveIds` from the step-1 store snapshot and hands it to the cap.
- Three new tests: a `trimPendingCap` unit matrix plus two integration paths through `refreshRoi` (normal trim, and failed-read protection). The second-refresh integration test genuinely pins the old bug: under `.slice(-200)` the evicted counted fingerprint re-samples on refresh 2 and double-counts (merged 202 vs 201).

### Why two files beyond the issue's named scope

- **`src/server/index.mjs` — required for correctness (error propagation).** The `jobsRead` adapter swallowed read errors and returned `[]`. Under the new cap, an empty-on-error store would read as "every job record is gone" and strip **every counted fingerprint of its protection on a transient failure**. The try/catch is removed so a failed read reaches `refreshRoi` as a failure; `refreshRoi`'s existing catch then degrades it safely (`jobs = []` + `jobsReadOk = false` → counted rows protected). `delegateEngine.listJobs()` has a single consumer.
- **`src/server/ctoSuggest.mjs` — comment-only.** The `USED_KEYS_CAP` comment cited `ctoBudget.mjs`'s `.slice(-200)` idiom, which this PR removes; the comment now states why a plain blind bound is safe there (`usedKeys` carries no counted-fingerprint semantics).

### Test results

Branch `multica/BET-1487-roi-pending-cap` @ `06646641` (measured by manta-reviewer, review cycle 1):

- `npm run typecheck` → exit 0, zero errors
- `npm test` → vitest: 198 files, **3901 passed** (7 skipped); node:test: **3818 passed, 0 failed**
- All three new BET-1487 tests ran and pass

Relates to BET-1487 (parent epic BET-1461).
