### PR TITLE
test(server): rename burn-baseline test to match its post-BET-1462 assertions (BET-1473)

### DIFF
--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -132,7 +132,7 @@ test("priceTokens prices via the model cost and a cache-heavy mix", () => {
   assert.equal(priceTokens({ model: { providerID: "x", id: "y" }, tokens: 1_000_000 }), 0);
 });
 
-test("expected hourly burn derives from trailing 7-day spend", () => {
+test("BET-1462: trailing spend pacing below the cap-equivalent pace floors at cap/24", () => {
   // Spend $16.80 over 7 days → 16.80 / 168h = $0.10/h — below the $2.50
   // cap-equivalent pace, so the new floor wins (BET-1462 defect 1).
   let p = defaultBudgetPayload();


### PR DESCRIPTION
## BET-1473 — CTO test hygiene (follow-up to BET-1462)

Closes the two reviewer nits from PR #1441. **Item 1 turned out to be already resolved on `main`** — details below; this PR carries item 2 only.

### Item 1 — duplicated test-fixture boilerplate in `ctoEngine.test.mjs`: already done

Commit `a9e24089` (BET-1492 dedupe wave, merged to `main` after this issue was filed) already extracted the exact 17-line spy-engine + watchdog construction shared by the two BET-1462 escalation tests into a local `makeSpyWatchdog()` helper, with a comment noting the history ("was a 17-line intra-file clone").

Verified with the gate's own tooling and config:

- `jscpd` (`.jscpd.json`: minTokens 70, minLines 5, maxLines 0) over `src/server/ctoEngine.test.mjs` + `src/server/ctoBudget.test.mjs` → **0 clones**
- `scripts/check-duplication-gate.sh origin/main` on this branch → **PASS**

No redundant re-extraction was made — touching the file again would only re-scan it for no gain.

### Item 2 — stale test name: renamed

Reviewer Nit 2 on [PR #1441](https://github.com/antoinedc/MantaUI/pull/1441#issuecomment-5479805248) locates the name drift in `src/server/ctoBudget.test.mjs` (the issue's "same file" phrasing pointed at `ctoEngine.test.mjs`; I checked that file's test names against their assertions and found no drift — the drift is the one the reviewer flagged). The test at `ctoBudget.test.mjs:135` was named **"expected hourly burn derives from trailing 7-day spend"** but, after BET-1462's re-pinning, both of its branches assert that trailing spend pacing *below* the cap-equivalent pace **floors at cap/24** — the trailing-7-day derivation is no longer what it exercises (the lone-active-day test covers that). Renamed to:

> `BET-1462: trailing spend pacing below the cap-equivalent pace floors at cap/24`

Pure rename — no assertion, comment, or behavior change.

**Base:** origin/main @ `f5a5e318`

**Verification results:**
- PR branch (`multica/BET-1473-cto-test-hygiene` @ `f4a3e8a6`):
  - typecheck: exit 0, none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, **3815 pass / 0 fail / 0 skip** (current count at fix time; issue's 3713 baseline predates BET-1466/1469/1492 merges). log sha256: `5b20e859c50000945d30e89fbac6b6e9d04b7b634a85d0509f58f49a25e49929`
  - duplication-gate vs `origin/main`: PASS (no clones)
- Base (`main` @ `f5a5e318`):
  - typecheck: exit 0, none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, **3815 pass / 0 fail / 0 skip**. log sha256: `9faca439b2950e2e8a1ff539ef5681c4b85382ff7ac6176a3cf2ff8a3b297451`
- **Conclusion:** 0 new failures, 0 pre-existing failures. Test count unchanged by this PR (a rename cannot change it).

**Files changed:** 1 — `src/server/ctoBudget.test.mjs` (1 insertion, 1 deletion)

*(Body replaced by the author agent; the original auto-opened body from the branch sweep is superseded — commits are unchanged.)*
