### PR TITLE
fix(server): needs-you badge ignores contentless open cards (BET-1476)

### DIFF
--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -4,6 +4,7 @@
 // holds only deterministic mapping — no window.api, no React.
 import type { Api } from "../shared/api";
 import type { DelegateStartInput } from "../shared/types";
+import { cardHasContent } from "../shared/ctoCard.mjs";
 
 export type CtoDot = "active" | "disabled" | "thrifty" | "paused";
 
@@ -331,11 +332,12 @@ export type BlockerCard = {
 // POSITIVELY (`variant === "blocker"`) rather than by excluding the other
 // variants — a denylist that must be updated whenever a variant is added is
 // exactly the defect that let connect cards double-render as dead-end
-// blockers (BET-1467). Also drops a row with neither title nor body so an
-// empty card never reaches BlockerSection's live "Answer now" control.
+// blockers (BET-1467). Also drops a card with neither title nor body (via the
+// shared cardHasContent predicate, BET-1476) so an empty card never reaches
+// BlockerSection's live "Answer now" control.
 export function blockerCards(cards: ReadonlyArray<Record<string, unknown>>): BlockerCard[] {
   return (cards ?? [])
-    .filter((c) => c?.variant === "blocker")
+    .filter((c) => c?.variant === "blocker" && cardHasContent(c))
     .map((c) => ({
       id: String(c.id ?? ""),
       title: String(c.title ?? ""),
@@ -345,8 +347,7 @@ export function blockerCards(cards: ReadonlyArray<Record<string, unknown>>): Blo
       sessionID: typeof c.sessionID === "string" ? c.sessionID : null,
       pendingSince: Number.isFinite(c.pendingSince) ? (c.pendingSince as number) : 0,
       refs: Array.isArray(c.refs) ? (c.refs as string[]) : [],
-    }))
-    .filter((c) => c.title || c.body);
+    }));
 }
 
 // Readable relative time (age stamps, Just-finished relative time). Short
@@ -545,15 +546,14 @@ export type VetoCardRow = {
 
 export function vetoCards(cards: ReadonlyArray<Record<string, unknown>>): VetoCardRow[] {
   return (cards ?? [])
-    .filter((c) => c?.variant === "veto")
+    .filter((c) => c?.variant === "veto" && cardHasContent(c))
     .map((c) => ({
       id: String(c.id ?? ""),
       title: String(c.title ?? ""),
       body: String(c.body ?? ""),
       dueMs: Number.isFinite(c.dueMs) ? (c.dueMs as number) : null,
       options: Array.isArray(c.options) ? (c.options as VetoCardRow["options"]) : [],
-    }))
-    .filter((c) => c.title || c.body);
+    }));
 }
 
 // BET-1395: the open connect-ask cards (§10.3 connect variant) among the wire
@@ -569,7 +569,7 @@ export type ConnectCardRow = {
 
 export function connectCards(cards: ReadonlyArray<Record<string, unknown>>): ConnectCardRow[] {
   return (cards ?? [])
-    .filter((c) => c?.variant === "connect")
+    .filter((c) => c?.variant === "connect" && cardHasContent(c))
     .map((c) => ({
       id: String(c.id ?? ""),
       title: String(c.title ?? ""),
@@ -584,8 +584,7 @@ export function connectCards(cards: ReadonlyArray<Record<string, unknown>>): Con
             }),
           )
         : [],
-    }))
-    .filter((c) => c.title || c.body);
+    }));
 }
 
 // BET-1431 (BET-1395 residue): the connect answer's argument-building step,

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -67,6 +67,7 @@ import {
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
 import { createVerdictEngine, createAsSourceSink } from "./ctoVerdicts.mjs";
+import { cardHasContent } from "../shared/ctoCard.mjs";
 // BET-1403: the earned-trust ladder (§9.3/§9.4). Its per-class Beta counters
 // ride the §9.5 verdict sink registry below; the digest announces acts and
 // tier changes through the same engine.
@@ -276,6 +277,10 @@ export function computeDot({ enabled, paused, thrifty }) {
 // tonight counts not populated until later pipeline issues. Wired to the real
 // cards schema (BET-1382): an open card (state === "open") is a needs-you item;
 // resolved/dismissed cards have already moved off cards.json into the ledger.
+// BET-1476: an open card with neither a title nor a body is the renderer-
+// invisible residue BET-1469 stopped writing (§10.3) — the mappers drop it, so
+// counting it would badge an answerable item the pane never renders. The same
+// shared predicate (cardHasContent) decides content on both sides.
 // Defensive — a malformed or missing store yields zeros, never a throw.
 // BET-1469: the cards store is injectable so a test can exercise the counting
 // logic without writing the real cards.json (the engine's own default passes
@@ -285,7 +290,7 @@ export async function defaultGetCounts(cardStore = cardsStore) {
   try {
     const cards = await cardStore.load();
     const arr = Array.isArray(cards?.cards) ? cards.cards : [];
-    needsYouCount = arr.filter((c) => c && c.state === "open").length;
+    needsYouCount = arr.filter((c) => c && c.state === "open" && cardHasContent(c)).length;
   } catch {
     needsYouCount = 0;
   }

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -559,15 +559,20 @@ test("resume() clears health-escalation blocker cards (health recovered)", async
   assert.ok(h.cardCalls.some((c) => c.fn === "onHealthRecovered"));
 });
 
-test("defaultGetCounts counts open cards from an injected cards store (BET-1469)", async () => {
+test("defaultGetCounts counts only open cards with content from an injected cards store (BET-1469, BET-1476)", async () => {
   const { defaultGetCounts } = await import("./ctoEngine.mjs");
   // The counting logic needs no real store: the cards store is injectable, so
   // this test no longer writes cards.json (sandboxed or otherwise).
+  // BET-1476: a contentless open card is the §10.3-invisible residue BET-1469
+  // stopped writing — it must NOT increment the needs-you count (the badge
+  // would advertise an answerable item no pane section renders), while a
+  // titled open card still does.
   let payload = {
     v: 1,
     cards: [
       { id: "a", state: "open" },
-      { id: "b", state: "resolved" },
+      { id: "b", state: "open", title: "Probe failing", body: "update \"GROQ\" on the secrets surface" },
+      { id: "c", state: "resolved", title: "Probe failing" },
     ],
   };
   const cardStore = {

--- a/src/shared/ctoCard.d.mts
+++ b/src/shared/ctoCard.d.mts
@@ -1,0 +1,9 @@
+// Hand-written type declarations for ctoCard.mjs. The implementation is
+// plain JS so it can be imported by both Node-side modules (ctoEngine) and
+// the renderer (ctoView). Keep this in sync with src/shared/ctoCard.mjs.
+
+// True when the raw wire card carries a non-empty coerced title or body —
+// the exact drop rule the §10.3 card mappers apply (BET-1467), shared with
+// the server's needs-you count (BET-1476). Defensive: null/undefined or a
+// non-object card carries no content.
+export function cardHasContent(card: unknown): boolean;

--- a/src/shared/ctoCard.mjs
+++ b/src/shared/ctoCard.mjs
@@ -1,0 +1,14 @@
+// One predicate for "does this needs-you card carry actionable content?",
+// shared by the server's needs-you badge count (ctoEngine defaultGetCounts,
+// BET-1476) and the renderer's §10.3 card selectors (ctoView blocker/veto/
+// connect mappers). BET-1467 made the mappers drop a card whose coerced
+// title AND body are both empty; BET-1476 makes needsYouCount agree so the
+// sidebar badge never shows an answerable item that renders nowhere. The
+// coercion below matches the mappers' String(c.title ?? "") /
+// String(c.body ?? "") exactly — a non-string (number, false, object)
+// coerces like the mappers see it, so the two sides cannot drift.
+
+export function cardHasContent(card) {
+  if (!card || typeof card !== "object") return false;
+  return String(card.title ?? "") !== "" || String(card.body ?? "") !== "";
+}

--- a/src/shared/ctoCard.test.ts
+++ b/src/shared/ctoCard.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { cardHasContent } from "./ctoCard.mjs";
+
+describe("cardHasContent", () => {
+  it("keeps a titled or bodied card (the §10.3 mapper rule)", () => {
+    expect(cardHasContent({ id: "a", state: "open", title: "Fix key", body: "rotate" })).toBe(true);
+    expect(cardHasContent({ id: "a", state: "open", title: "Fix key" })).toBe(true);
+    expect(cardHasContent({ id: "a", state: "open", body: "rotate" })).toBe(true);
+  });
+
+  it("drops a card with neither title nor body (BET-1469 residue)", () => {
+    expect(cardHasContent({ id: "a", state: "open" })).toBe(false);
+    expect(cardHasContent({ id: "a", state: "open", title: "", body: "" })).toBe(false);
+    expect(cardHasContent({ id: "a", state: "open", title: null, body: undefined })).toBe(false);
+  });
+
+  it("coerces non-string fields exactly like the mappers' String() pass", () => {
+    expect(cardHasContent({ title: 0 })).toBe(true);
+    expect(cardHasContent({ title: false })).toBe(true);
+    expect(cardHasContent({ title: { why: "x" } })).toBe(true);
+    expect(cardHasContent({ title: [] })).toBe(false);
+    expect(cardHasContent({ title: " " })).toBe(true);
+  });
+
+  it("is defensive about a malformed card", () => {
+    expect(cardHasContent(null)).toBe(false);
+    expect(cardHasContent(undefined)).toBe(false);
+    expect(cardHasContent("nope")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

BET-1469 stopped writing the contentless open card fixture, but a box whose `cards.json` still holds one keeps a phantom needs-you badge: `defaultGetCounts` counted every open card, while the §10.3 pane mappers (BET-1467) drop a card whose coerced title AND body are both empty — so the badge advertised an answerable item that renders nowhere.

## Fix (single defect, shared predicate)

- **New `src/shared/ctoCard.mjs`** (+ `.d.mts`, + vitest test): `cardHasContent(card)` — one code path for "does this card carry actionable content", with coercion byte-identical to the mappers' `String(c.title ?? "")` / `String(c.body ?? "")` pass.
- **`src/server/ctoEngine.mjs`** `defaultGetCounts`: counts open cards that also pass `cardHasContent`.
- **`src/renderer/ctoView.ts`**: the three mappers (`blockerCards`, `vetoCards`, `connectCards`) now apply the shared predicate pre-map; the redundant post-map `.filter((c) => c.title || c.body)` is gone. Drop-rule behavior is unchanged (pre-map predicate on the raw card is exactly equivalent to the post-map coercion filter — the existing BET-1467 selector tests pass unchanged).
- **`src/server/ctoEngine.test.mjs`**: the counting test now pins the issue's two assertions — a contentless open card does NOT increment `needsYouCount`; a titled open card still does (a resolved titled card doesn't).

Duplicate-site list: the content rule existed at `ctoView.ts` ×3 (post-map filters) and implicitly nowhere on the server (raw open-count). Single source of truth is now `src/shared/ctoCard.mjs`, delete/replace count 3→0 renderer-side, +1 server adoption. A characterization test pins the predicate.

Not touched, deliberately: `src/server/ctoDigest.mjs:318` formats open cards as `- [id] title || body || "needs you"` — a copy-formatting site with a graceful fallback, not a count, so no drift risk. `decisionCards` keeps no content filter (as today): decision/veto/connect writers always populate a title fallback (`"CTO suggestion"` etc.), so a contentless decision card is unreachable in practice; only the blocker path could omit both, and the pane drops it.

Out of scope per issue: no cards.json migration — residue rows are now invisible-but-harmless; parked as BET-1498.

Base: origin/main @ f5a5e31

## Verification results

**Files changed:** 6 files (+76/−14): `src/renderer/ctoView.ts`, `src/server/ctoEngine.mjs`, `src/server/ctoEngine.test.mjs`, `src/shared/ctoCard.mjs` (new), `src/shared/ctoCard.d.mts` (new), `src/shared/ctoCard.test.ts` (new).

**Verification results:**
- PR branch (`multica/BET-1476-needs-you-contentless-badge` @ `1ebf31f`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, vitest 3905 pass / 0 fail / 7 skip (199 files), node --test 3815 pass / 0 fail / 0 skip. Failures: none. log sha256: `137e84a683a438d0bc287f2669cfe61b0b4fe4e96d495f7ad784a47d61c8d579`
- Base (`main` @ `f5a5e31`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, vitest 3901 pass / 0 fail / 7 skip (198 files), node --test 3815 pass / 0 fail. Failures: none. log sha256: `65db07a36aee7b1a52f342fb774b5c0aea39c8120bf1f8e06a0fc75756edf5f5`
- **Conclusion:** 0 test failures pre-existing, 0 new failures. Delta vs base: +1 vitest file, +4 vitest tests (`ctoCard.test.ts`); node --test count unchanged (one test rewritten in place).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Closes BET-1476. Follow-up parked: BET-1498.
