### PR TITLE
fix(server): drop project-less watcher hits from overnight candidacy (BET-1472)

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1442,14 +1442,21 @@ export function createCtoEngine(deps = {}) {
   function watcherCandidatesFromRows(rows) {
     const out = [];
     for (const hit of collectWatcherHitsFromLedger(rows)) {
+      // BET-1472 (BET-1436 decision c): overnight candidacy REQUIRES a hosting
+      // project. A project-less hit (usage-burn hits are box-wide; rows
+      // predating BET-1428 lack the field) can never be hosted by §11.5
+      // dispatch, so it is filtered at the source instead of producing a
+      // candidate that gets re-skipped on every tick of the open window. The
+      // B4 suggestion path is unaffected.
+      if (typeof hit.project !== "string" || !hit.project) continue;
       out.push({
         id: hit.id,
         name: hit.text,
         category: "watcher",
-        // BET-1428: the project whose evidence produced the hit — without it
-        // the §11.5 dispatch can never host the job and re-skips the hit on
-        // every tick of the open window.
-        project: typeof hit.project === "string" ? hit.project : undefined,
+        // BET-1428: the project whose evidence produced the hit — always a
+        // non-empty string here because project-less hits are filtered above
+        // (overnight candidacy requires a hosting project).
+        project: hit.project,
         value: 2,
         confidence: 0.8,
         predictedCost: 1,
@@ -2579,6 +2586,9 @@ export function createCtoEngine(deps = {}) {
       return getTools();
     },
     toolsScan: () => toolsTick(),
+    // BET-1472: the pure overnight watcher-candidacy predicate, exposed for
+    // diagnostics/tests (same pattern as toolsScan above).
+    watcherCandidatesFromRows,
     // BET-1419 tonight verbs (§10.4 drill-down + §9.2 veto card actions).
     tonightList,
     tonightAdd,

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -294,29 +294,30 @@ test("overnight: a watcher hit with a tracked project hosts the investigation th
   );
 });
 
-test("overnight: a watcher hit with no hostable project skips ONCE per window, not per tick (BET-1428)", async () => {
+test("overnight: a watcher hit with no hostable project produces NO candidate and NO skip rows (BET-1472, decision c)", async () => {
   const h = makeHarness({ trough: TROUGH, projects: [PROJECT_ROW] });
   h.ledgerRows.push(watcherHitRow({ watcherId: "w2", ts: h.now() - 60_000 }));
   await h.engine.tick();
   assert.equal(h.startedJobs.length, 0);
   assert.equal(
     h.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.id === "wh:w2").length,
-    1,
-    "one skip row for the unhostable hit",
+    0,
+    "the never-hostable hit is filtered at the candidacy source — no skip row is written",
   );
 
-  // The hit remains a candidate for the whole 24h collection window; the
-  // per-window skip dedupe keeps the ledger quiet while the retry stays live.
+  // BET-1472: the hit never enters the overnight plan, so repeated ticks of
+  // the open window stay fully silent — the old BET-1428 per-window skip rows
+  // are gone entirely.
   h.advance(60 * 1000);
   await h.engine.tick();
   h.advance(60 * 1000);
   await h.engine.tick();
+  assert.equal(h.startedJobs.length, 0);
   assert.equal(
     h.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.id === "wh:w2").length,
-    1,
-    "still one skip row after two more ticks",
+    0,
+    "still no skip rows after two more ticks",
   );
-  assert.equal(h.startedJobs.length, 0);
 });
 
 test("overnight: a hit whose project no longer resolves skips once per window, and a mid-window session opens the retry (BET-1428)", async () => {

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -23,6 +23,7 @@ import { windowFor } from "./ctoRollups.mjs";
 import { BLOCKER_AFTER_MS } from "./ctoCards.mjs";
 import { inboxStore, sweepInbox } from "./ctoStores.mjs";
 import { createCtoInbound } from "./cto.mjs";
+import { WATCHER_HIT_KIND, WATCHER_HIT_SALIENCE, EVENT_PATTERN, RATE_THRESHOLD, USAGE_BURN } from "./ctoWatchers.mjs";
 
 const delay = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -1092,4 +1093,43 @@ test("BET-1407: engine start() drops a persisted ask past the blocker retention 
   assert.deepEqual(h.pendingAsks.map((a) => a.sessionID), ["s_new"]);
   assert.deepEqual(h.state.pendingAsks.map((a) => a.sessionID), ["s_new"], "the stale row is dropped from the persisted half too");
   h.engine.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// BET-1472 (BET-1436 decision c): project-less watcher hits are dropped from
+// overnight candidacy at the source. A usage-burn hit (or any pre-BET-1428 hit
+// row) carries no `project`, so §11.5 dispatch could never host its job and
+// re-skipped it on every tick of the open window. The B4 suggestion path
+// (ctoSuggest.mjs) is untouched and still surfaces these hits during the day.
+// ---------------------------------------------------------------------------
+
+test("BET-1472: project-less watcher.hit rows (usage-burn and pre-BET-1428 shapes) produce NO overnight candidate", () => {
+  const h = makeHarness();
+  const rows = [
+    { kind: WATCHER_HIT_KIND, salience: WATCHER_HIT_SALIENCE, watcherId: "w_usage", predicateKind: USAGE_BURN, text: "Usage burn", refs: [], ts: 1 },
+    { kind: WATCHER_HIT_KIND, salience: WATCHER_HIT_SALIENCE, watcherId: "w_pre1428", predicateKind: EVENT_PATTERN, text: "Pre-BET-1428 hit", refs: [], ts: 2 },
+  ];
+  assert.deepEqual(h.engine.watcherCandidatesFromRows(rows), []);
+});
+
+test("BET-1472: a watcher.hit row with an empty-string project produces NO overnight candidate", () => {
+  const h = makeHarness();
+  const rows = [
+    { kind: WATCHER_HIT_KIND, salience: WATCHER_HIT_SALIENCE, watcherId: "w_empty", predicateKind: RATE_THRESHOLD, text: "Empty project", project: "", refs: [], ts: 3 },
+  ];
+  assert.deepEqual(h.engine.watcherCandidatesFromRows(rows), []);
+});
+
+test("BET-1472: a watcher.hit row WITH a project still becomes a candidate carrying that project (BET-1428 hostable path intact)", () => {
+  const h = makeHarness();
+  const rows = [
+    { kind: WATCHER_HIT_KIND, salience: WATCHER_HIT_SALIENCE, watcherId: "w_hosted", predicateKind: EVENT_PATTERN, text: "Hostable hit", project: "better-ui", refs: ["m:1"], ts: 4 },
+  ];
+  const out = h.engine.watcherCandidatesFromRows(rows);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].id, "wh:w_hosted");
+  assert.equal(out[0].category, "watcher");
+  assert.equal(out[0].name, "Hostable hit");
+  assert.equal(out[0].project, "better-ui");
+  assert.deepEqual(out[0].refs, ["m:1"]);
 });


### PR DESCRIPTION
## Summary

Implements **BET-1436 decision (c)** (BET-1472): a watcher hit with no hosting project no longer becomes an overnight candidate at all. Previously such a candidate (usage-burn hits, which are box-wide, and rows predating BET-1428) could never be hosted by §11.5 dispatch and produced one `cto.overnight.skip` ledger row per open window forever. Now it is filtered at the candidacy source; the daytime B4 suggestion path is untouched.

## Changes

- `src/server/ctoEngine.mjs` — `watcherCandidatesFromRows`: skip hits whose `project` is not a non-empty string before building the candidate; collapse the now-dead conditional spread to `project: hit.project`; update the BET-1428 comment (overnight candidacy REQUIRES a hosting project). Expose `watcherCandidatesFromRows` on the engine object for diagnostics/tests (same pattern as `toolsScan`).
- `src/server/ctoEngine.test.mjs` — 3 new tests: project-less hit rows (usage-burn + pre-BET-1428 shapes) produce no candidate; `project: ""` produces no candidate; a hit WITH a project still becomes a candidate carrying it.
- `src/server/ctoEngine.overnight.test.mjs` — the BET-1428 characterization test ("skips ONCE per window") pinned the exact behavior this issue removes; updated to assert NO skip rows for the never-hostable hit across repeated ticks.

Duplicate-site check: `collectWatcherHitsFromLedger` has two consumers — `watcherCandidatesFromRows` (overnight candidacy, filtered here) and the B4 suggestion path in `ctoSuggest.mjs` (deliberately unchanged per the issue). Out of scope and untouched: `ctoWatchers.mjs` (BET-1466), `dispatchPlan`/skip machinery (stays for genuinely transient cases).

Net diff: +63/−12 (includes 40 lines of new tests; the engine change itself is net-negative).

**Base: origin/main @ c4488091**

## Verification results

- PR branch (`multica/BET-1472-drop-projectless-watcher-candidates` @ `c7800de7`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, vitest 3901 pass / 7 skipped; node:test 3818 pass / 0 fail. Failures: none. log sha256: `1da1beb867fdb26a694e42655205a79bb8f22e74818a0e45c779b3f16f11ce95`
- Base (`main` @ `c4488091`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, vitest 3901 pass / 7 skipped; node:test 3815 pass / 0 fail. Failures: none. log sha256: `a117290d368824b9ac6ee411c14ec1a2704cde0a3f5593be0a4d310033229336`
- **Conclusion:** 0 new test failures. +3 tests on the PR branch (the BET-1472 candidacy tests); 1 pre-existing characterization test updated to the new contract.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
