### PR TITLE
fix(server): one-time prune of legacy contentless open cards from cards.json (BET-1498)

### DIFF
--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -43,6 +43,7 @@
 // ctoPath() (test-sandbox rule).
 
 import { createHash } from "node:crypto";
+import { cardHasContent } from "../shared/ctoCard.mjs";
 import {
   INBOX_TTL_MS,
   cardsStore,
@@ -85,6 +86,31 @@ export const CONNECT_SOURCE_KIND = "tool";
 // failure that degraded the digest. Keyed by `<tool>/<probe>`; the body
 // deep-links (in copy) to the secrets surface — the fix is a rotated key.
 export const PROBE_SOURCE_KIND = "probe";
+
+// BET-1498: engine-state.json marker key for the one-time prune of the
+// pre-BET-1469 contentless open cards. Same idempotency contract as the
+// watchers migration (ctoWatchers.mjs migrateLegacy): the stamp lands only
+// after the prune's save succeeded, so a failed write retries next boot and
+// a re-deploy is a no-op.
+export const CONTENTLESS_CARD_PRUNE_KEY = "contentlessCardPrune";
+
+// Pure split for the BET-1498 one-time prune: drop ONLY open rows that fail
+// the shared cardHasContent predicate — the §10.3-invisible residue BET-1469
+// stopped writing (no coerced title AND no coerced body renders in no pane
+// section and, since BET-1476, no longer counts toward the badge, so nothing
+// could ever resolve or dismiss it). Rows that are not open — and malformed
+// rows — are left exactly where they are; this retires dead rows, it does
+// not relitigate the store's schema.
+export function splitContentlessOpenCards(cards) {
+  const rows = Array.isArray(cards) ? cards : [];
+  const keep = [];
+  const dropped = [];
+  for (const c of rows) {
+    if (c && c.state === "open" && !cardHasContent(c)) dropped.push(c);
+    else keep.push(c);
+  }
+  return { keep, dropped };
+}
 
 // §10.6-7 probe-auth-failure card copy (3 consecutive auth failures — the
 // runner's AUTH_FAIL_ESCALATE). `secretKey` is the vault KEY NAME (not a
@@ -626,6 +652,52 @@ export function createCtoCards(deps = {}) {
     return { seeded: keep.length, dropped };
   }
 
+  // BET-1498: one-time retirement of the pre-BET-1469 residue — open cards in
+  // cards.json with neither a title nor a body. BET-1476 already stopped the
+  // badge counting them, so they render nowhere and nothing can ever resolve
+  // or dismiss them: dead rows that only a load-time prune can retire.
+  // Marker-guarded in engine-state.json with the same contract as the
+  // watchers migration (ctoWatchers migrateLegacy): the stamp lands only
+  // AFTER the prune's save succeeded, so a failed write retries next boot and
+  // a re-deploy is a no-op. The prune itself is a patchStore read-fresh-write
+  // under the cards mutex (BET-1464 defect 3) — an already-clean store is a
+  // pure no-op (no save). `{pruned, marked}` for diagnostics/tests; a missing
+  // engine-state writer (standalone/test usage) skips only the stamp.
+  async function pruneLegacyOpenCards() {
+    let meta = {};
+    try {
+      meta = (await engineState.load()) ?? {};
+    } catch {
+      meta = {};
+    }
+    if (meta?.[CONTENTLESS_CARD_PRUNE_KEY]?.pruned === true) {
+      return { pruned: 0, marked: false };
+    }
+    let pruned = 0;
+    await patchStore(cardStore, (fresh) => {
+      const cards = Array.isArray(fresh?.cards) ? fresh.cards : [];
+      const { keep, dropped } = splitContentlessOpenCards(cards);
+      pruned = dropped.length;
+      return dropped.length ? { cards: keep } : {};
+    });
+    let marked = false;
+    if (typeof patchEngineStatePatch === "function") {
+      try {
+        await patchEngineStatePatch((fresh) => ({
+          [CONTENTLESS_CARD_PRUNE_KEY]: {
+            ...(fresh?.[CONTENTLESS_CARD_PRUNE_KEY] || {}),
+            pruned: true,
+            at: now(),
+          },
+        }));
+        marked = true;
+      } catch {
+        /* best-effort — an unstamped marker just re-prunes a clean store next boot */
+      }
+    }
+    return { pruned, marked };
+  }
+
   // Source (2): read the watchdog's blocker-card requests that A2 already
   // writes to engine-state.json `pendingBlockers` and turn the unresolved ones
   // into health blocker cards. `{changed}` for tests/diagnostics.
@@ -907,6 +979,7 @@ export function createCtoCards(deps = {}) {
     onAskResolved,
     onInboxBlocker,
     seedPendingAsks,
+    pruneLegacyOpenCards,
     promoteDue,
     ingestHealthEscalations,
     onHealthRecovered,

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -2303,6 +2303,20 @@ export function createCtoEngine(deps = {}) {
         /* best-effort */
       }
     }
+    // BET-1498: one-time prune of the pre-BET-1469 contentless open cards in
+    // cards.json — the §10.3-invisible rows BET-1476's badge filter stopped
+    // counting but nothing can ever resolve or dismiss. Marker-guarded
+    // (idempotent) and best-effort, exactly like the seed above: a failed
+    // prune degrades to the BET-1476 status quo (invisible, uncounted rows)
+    // and retries on the next boot. Same seam guard — a test-injected cards
+    // fake without the method stays valid.
+    if (typeof cards?.pruneLegacyOpenCards === "function") {
+      try {
+        await cards.pruneLegacyOpenCards();
+      } catch {
+        /* best-effort */
+      }
+    }
     // Load the persisted segmentation G (minutes) from engine-state (§5.1-d).
     if (segmenter && typeof segmenter.boot === "function") {
       void segmenter.boot().catch(() => {});

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -15,12 +15,13 @@ import {
   RATE_LIMITS,
   isRunningCtoRow,
   buildFactsContext,
+  defaultGetCounts,
 } from "./ctoEngine.mjs";
 import { createSegmenter } from "./ctoSegments.mjs";
 import { startOfDay } from "./ctoRollups.mjs";
 import { createFactsEngine } from "./ctoFacts.mjs";
 import { windowFor } from "./ctoRollups.mjs";
-import { BLOCKER_AFTER_MS } from "./ctoCards.mjs";
+import { BLOCKER_AFTER_MS, CONTENTLESS_CARD_PRUNE_KEY, createCtoCards } from "./ctoCards.mjs";
 import { inboxStore, sweepInbox } from "./ctoStores.mjs";
 import { createCtoInbound } from "./cto.mjs";
 
@@ -588,6 +589,111 @@ test("defaultGetCounts counts only open cards with content from an injected card
     tonightCount: 0,
   });
 // ---------------------------------------------------------------------------
+});
+
+// ---------------------------------------------------------------------------
+// BET-1498: the one-time prune of the pre-BET-1469 residue — contentless OPEN
+// cards in cards.json that render in no pane section and (since BET-1476) no
+// longer count toward the badge, so nothing could ever resolve or dismiss
+// them. Retired at boot by a marker-guarded prune reusing the shared
+// cardHasContent predicate.
+// ---------------------------------------------------------------------------
+
+test("BET-1498: pruneLegacyOpenCards retires contentless open cards once (marker-guarded) and keeps every other row", async () => {
+  let cardPayload = {
+    v: 1,
+    cards: [
+      { id: "a", state: "open" }, // the BET-1469 fixture-pollution shape
+      { id: "b", state: "open", title: "Probe failing", body: "rotate the key" },
+      { id: "c", state: "resolved" }, // not open → untouched
+      { id: "d" }, // no state → untouched
+    ],
+  };
+  let saves = 0;
+  const cardStore = {
+    name: "cards",
+    load: async () => cardPayload,
+    save: async (p) => {
+      saves += 1;
+      cardPayload = p;
+    },
+  };
+  let engineState = { v: 1 };
+  const patchEngineState = async (mutation) => {
+    const patch = typeof mutation === "function" ? await mutation(engineState) : mutation;
+    engineState = { ...engineState, ...patch };
+  };
+  const cards = createCtoCards({
+    cardStore,
+    engineState: {
+      load: async () => engineState,
+      save: async (p) => {
+        engineState = p;
+      },
+    },
+    ledger: { append: async () => true },
+    now: () => 1_000_000,
+    patchEngineState,
+  });
+
+  const r1 = await cards.pruneLegacyOpenCards();
+  assert.deepEqual(r1, { pruned: 1, marked: true });
+  assert.deepEqual(
+    cardPayload.cards.map((c) => c.id),
+    ["b", "c", "d"],
+    "the contentless open row is retired; titled open, resolved and stateless rows survive",
+  );
+  assert.equal(engineState[CONTENTLESS_CARD_PRUNE_KEY].pruned, true);
+  assert.equal(engineState[CONTENTLESS_CARD_PRUNE_KEY].at, 1_000_000);
+
+  // The guarded re-run is a pure no-op: the marker short-circuits before any
+  // cards.json read-write (no save fired).
+  const r2 = await cards.pruneLegacyOpenCards();
+  assert.deepEqual(r2, { pruned: 0, marked: false });
+  assert.equal(saves, 1, "the marker-guarded re-run never rewrites cards.json");
+
+  // A box whose engine-state already carries the marker (re-deploy) prunes
+  // nothing and skips the stamp.
+  const fresh = createCtoCards({
+    cardStore: {
+      name: "cards",
+      load: async () => cardPayload,
+      save: async () => {},
+    },
+    engineState: {
+      load: async () => engineState,
+      save: async () => {},
+    },
+    ledger: { append: async () => true },
+    now: () => 1_000_000,
+    patchEngineState,
+  });
+  assert.deepEqual(await fresh.pruneLegacyOpenCards(), { pruned: 0, marked: false });
+
+  // The counting module agrees with the retired store — the badge now counts
+  // exactly the rows a pane section can render (BET-1476 parity, BET-1498 hygiene).
+  assert.deepEqual(await defaultGetCounts(cardStore), {
+    needsYouCount: 1,
+    generationInFlight: false,
+    tonightCount: 0,
+  });
+});
+
+test("BET-1498: engine start() prunes the contentless open cards from cards.json at boot", async () => {
+  const h = makeHarness({ realCards: true });
+  // Seed the residue straight into the store, like a box that still carries a
+  // fixture-polluted cards.json from before BET-1469.
+  h.cardsStore().cards = [
+    { id: "a", state: "open" },
+    { id: "b", state: "open", title: "Question waiting", body: "answer me" },
+  ];
+  await h.engine.start();
+  h.engine.dispose();
+  assert.deepEqual(
+    h.cardsStore().cards.map((c) => c.id),
+    ["b"],
+    "boot retires the dead row; the actionable card survives",
+  );
 });
 // A6 segmentation wiring (observeEvent → segmenter) (§5.1)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

BET-1476 made the server's needs-you badge ignore open cards with neither a title nor a body (shared `cardHasContent` predicate), and BET-1469 stopped writing new ones — but a box whose `cards.json` still holds one from before that fix has an invisible row that nothing can ever resolve or dismiss. This PR retires the residue with a **one-time, marker-guarded boot prune**, reusing the shared predicate (no re-derivation).

- `src/server/ctoCards.mjs`: `splitContentlessOpenCards` (pure split: drops ONLY open rows failing `cardHasContent`; resolved/dismissed/stateless rows untouched) + `pruneLegacyOpenCards()` on the cards manager — reads the engine-state marker, prunes via a `patchStore` read-fresh-write under the cards mutex, stamps the marker only AFTER the save succeeded (same idempotency contract as the BET-1398 watchers migration: a failed write retries next boot, a re-deploy is a no-op; an already-clean store is a pure no-op with no save).
- `src/server/ctoEngine.mjs`: `start()` invokes `cards.pruneLegacyOpenCards()` best-effort next to the existing `seedPendingAsks` call, with the same seam guard for test-injected fakes.
- `src/server/ctoEngine.test.mjs` (the counting module's test file, next to the BET-1476 test): manager-level test (contentless open retired; titled open / resolved / stateless survive; marker stamped; guarded re-run never rewrites the store; a pre-marked engine-state prunes nothing; `defaultGetCounts` parity after the prune) + an engine `start()` wiring test over the real cards manager.

## Why boot-time + marker (not per-tick or unguarded)

The residue is write-once history, not a recurring condition: BET-1469 closed the writers, so one boot prune per box retires it permanently. A marker-guarded sweep matches the dispatch's named pattern and avoids a permanent per-tick/per-boot read for a transient residue.

## Verification results

**Files changed:** 3 files, +194/−1. `src/server/ctoCards.mjs`, `src/server/ctoEngine.mjs`, `src/server/ctoEngine.test.mjs`

**Verification results:**
- PR branch (`multica/BET-1498-prune-contentless-cards` @ `5e5413bc`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0 — vitest 199 files / 3905 pass / 7 skip; node:test 3817 pass / 0 fail (includes the 2 new tests). Failures: none. log sha256: `4eaba19d8f48e239aad40cd85e7aa80d774b31533937e08bcf1d066068c2475a`
- Base (`main` @ `7947f41e`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0 — vitest 199 files / 3905 pass / 7 skip; node:test 3815 pass / 0 fail. Failures: none. log sha256: `60541e8882bba72e7dd8642e678ceb45bddb43e23b4a200c953f2e389b96f8fc`
- **Conclusion:** 0 test failures pre-existing, 0 new failures caused by this PR; +2 tests added (node:test 3815 → 3817).

**Base:** origin/main @ `7947f41e`

## Notes

- Root-cause framing: the prune retires the rows at the store, so every reader (badge, pane mappers, digest `listOpenCards` consumers) agrees by construction — no per-reader filtering added.
- Single source of truth kept: `cardHasContent` from `src/shared/ctoCard.mjs` decides content; the prune adds no second rule.
- Parked follow-up filed: **BET-1499** — `countOpen()` in `ctoCards.mjs` is a second, unused open-card counter without the shared filter (dead-code alignment, low).

Closes BET-1498.
