### PR TITLE
test(server): usedKeys cap test covers the full boundary (BET-1480)

### DIFF
--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -756,16 +756,38 @@ test("dedupe: a second runPass over the same findings makes no new model calls, 
   assert.equal(h.notified.length, 1, "no new fireNotify");
 });
 
-test("usedKeys is capped at 200 entries; the oldest fall off", async () => {
+test("usedKeys cap: exactly-at-cap holds every entry; the 201st evicts the OLDEST and preserves the MRU tail", async () => {
+  // Seed one short of the cap, then fill to exactly 200 through the real
+  // processFinding → markUsed append path.
   const h = makeSug({
-    engineState: { v: 1, suggest: { usedKeys: Array.from({ length: 200 }, (_, i) => `old-${i}`) } },
+    engineState: { v: 1, suggest: { usedKeys: Array.from({ length: 199 }, (_, i) => `old-${i}`) } },
   });
-  await h.sug.processFinding({ id: "rec:new", sourceKind: "fact-anomaly", text: "x", refs: [] }, { coldStart: false, tier: "medium" });
-  const used = h.getEs().suggest.usedKeys;
+  const process = (id) =>
+    h.sug.processFinding({ id, sourceKind: "fact-anomaly", text: "x", refs: [] }, { coldStart: false, tier: "medium" });
+
+  // At-cap state: the 200th distinct key lands with NO eviction.
+  await process("rec:fill");
+  let used = h.getEs().suggest.usedKeys;
   assert.equal(used.length, 200);
-  assert.ok(used.includes("rec:new"));
-  assert.ok(!used.includes("old-0")); // the oldest entry fell off
-  assert.ok(used.includes("old-1")); // next-oldest survives — only one entry was dropped
+  assert.equal(used[0], "old-0", "nothing evicted while filling to exactly the cap");
+  assert.equal(used[199], "rec:fill", "the newest key sits at the tail");
+
+  // One past the cap: the 201st distinct key evicts exactly one entry —
+  // the OLDEST (front), not the newest being dropped. Trailing-slice FIFO
+  // is the chosen rule (documented idiom shared with ctoBudget.mjs).
+  await process("rec:over");
+  used = h.getEs().suggest.usedKeys;
+  assert.equal(used.length, 200, "the cap holds: length never exceeds 200");
+  assert.ok(!used.includes("old-0"), "the 201st key evicts the OLDEST entry");
+  assert.ok(used.includes("rec:over"), "the newest key is kept, not dropped");
+
+  // The surviving keys are exactly the expected ones, in order —
+  // old-1..old-198 (198 entries) plus the two appends at the tail (MRU preserved).
+  assert.deepEqual(used, [
+    ...Array.from({ length: 198 }, (_, i) => `old-${i + 1}`),
+    "rec:fill",
+    "rec:over",
+  ]);
 });
 
 test("notify: fireNotify carries a distinct, non-global tag per candidate WITHOUT synthesizing a sessionID (defect 2, review fix)", async () => {


### PR DESCRIPTION
Closes BET-1480. Extends the single-entry-eviction cap test left as a BET-1465 review nit so it pins the full cap boundary.

**Base: origin/main @ 74a23e46**

## What changed

One test rewritten in `src/server/ctoSuggest.test.mjs` (`usedKeys cap: exactly-at-cap holds every entry; the 201st evicts the OLDEST and preserves the MRU tail`):

1. **At-cap state** — seeds 199 keys, then fills to exactly 200 through the real `processFinding` → `markUsed` path and asserts nothing is evicted at exactly the cap (length 200, oldest still first, newest at the tail).
2. **One-past-cap** — the 201st distinct key: length stays 200, the OLDEST entry (`old-0`) is evicted, and the newest key is kept (not dropped).
3. **Surviving keys** — full `deepEqual` of all 200 surviving entries, pinning both membership and order (MRU preserved at the tail).

## Eviction rule: chosen, not accidental

The asserted rule is oldest-evicted / newest-kept (trailing-slice FIFO). This is deliberate in the implementation — `src/server/ctoSuggest.mjs` documents the BET-1465 cap as the "same trailing-slice idiom as `ctoBudget.mjs`'s `.slice(-200)`", and the implementation is `[...prior, ...fresh].slice(-USED_KEYS_CAP)` — so nothing needed flagging.

**Unreachable-batch note (per the issue's "flag accidental rules in the PR" instruction):** a single `markUsed` batch larger than the cap could in principle drop even newly-appended keys (`slice(-200)` keeps only the tail). This case is unreachable: both `markUsed` call sites (`ctoSuggest.mjs`) pass exactly one key per call (`markUsed([finding.id])`), and `markUsed` dedupes within a batch — a >200-key batch cannot occur in practice.

## Verification results

- **Files changed:** 1 file, +29/-7 (`src/server/ctoSuggest.test.mjs`).
- PR branch (`multica/BET-1480-usedkeys-cap-test` @ 3e13a7dd):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3818 pass / 0 fail / 0 skip. log sha256: `285ec1cc7aba31fb21a71362775a3f921ec398dfbb95960ccbf5d47b1f78bbc4`
- Base (`main` @ 74a23e46):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3818 pass / 0 fail / 0 skip. log sha256: `764816dc0d37ab1a2c59eb34e8aa712c427f91b70d33cdf4dd4c638b6a75df56`
- **Conclusion:** 0 test failures on either branch; the change is test-only and adds assertions without changing any behaviour under test.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
