### PR TITLE
fix(scripts): report shallow-clone truncation instead of false STALE in conformance-freshness test (BET-1491)

### DIFF
--- a/docs/visual-verification.md
+++ b/docs/visual-verification.md
@@ -239,6 +239,19 @@ script import them.
 - **No retries** on the visual project. A retry on a deterministic gate only
   converts a real regression into an intermittent one.
 
+### Judging conformance records needs full history
+
+`scripts/conformance-freshness.test.mjs` reads each record's committed baseline
+at its "Last reviewed" sha. On a shallow clone (`git clone --depth N` — what
+agent runs and throwaway checkouts commonly produce) those objects are absent,
+and the suite refuses to judge rather than guessing: it fails with a
+`git fetch --unshallow origin` message instead of reporting STALE. **Run
+`git fetch --unshallow origin` before trusting this suite's verdict** — a green
+run on truncated history proves less than it looks like (records whose review
+sha falls inside the shallow window were judged; the rest were not). CI is
+unaffected: its checkout is full-depth, and the depth-1 `main` graft it adds on
+top leaves all recorded objects reachable.
+
 ## The marketing-shot drift gate (BET-341 / BET-444)
 
 `scripts/shots.mjs` captures the `website/shot-*.webp` marketing assets from the

--- a/scripts/conformance-freshness.test.mjs
+++ b/scripts/conformance-freshness.test.mjs
@@ -13,6 +13,27 @@ const SNAPSHOTS = "tests/visual/screens.visual.ts-snapshots";
 const gitBuf = (args) => execFileSync("git", args, { cwd: REPO_ROOT, encoding: "buffer" });
 
 /**
+ * True when this checkout has truncated history (`.git/shallow` present —
+ * `git clone --depth N`, a CI depth-1 graft, …). Memoized; a repo that is not
+ * a git repo at all reads as not-shallow so the per-test failures below keep
+ * their ordinary STALE meaning. (BET-1491: on a shallow clone an old
+ * recordSha's objects are absent, `git show` fails, and the unreachable case
+ * below must not be reported as STALE — the record may be perfectly fresh;
+ * the clone simply cannot prove it either way.)
+ */
+let shallow;
+const isShallowRepo = () => {
+  if (shallow === undefined) {
+    try {
+      shallow = gitBuf(["rev-parse", "--is-shallow-repository"]).toString().trim() === "true";
+    } catch {
+      shallow = false;
+    }
+  }
+  return shallow;
+};
+
+/**
  * Freshness of conformance records (BET-564). A conformance record is
  * judgement — no test can arbitrate what it says. But whether a record has
  * been LOOKED AT since its screen's baseline moved is mechanical, and that
@@ -23,8 +44,13 @@ const gitBuf = (args) => execFileSync("git", args, { cwd: REPO_ROOT, encoding: "
  * Mechanism (git, not file mtimes — mtimes lie after a fresh clone):
  *   recordSha       = the sha on the "Last reviewed" line
  *   reviewedBlob    = the committed <id>-visual-linux.png at recordSha
- *   FAIL            = reviewedBlob is missing or differs from the baseline on
- *                     disk — the baseline moved (or appeared) after the review.
+ *   FAIL            = reviewedBlob differs from the baseline on disk — the
+ *                     baseline moved after the review — or is unreachable at
+ *                     recordSha. Unreachable on a FULL clone means the record
+ *                     is stale (the baseline appeared after the review, or the
+ *                     sha is bad); unreachable on a SHALLOW clone only means
+ *                     the history is truncated, so that case fails with its
+ *                     own unshallow message instead of claiming STALE (BET-1491).
  *
  * We compare BLOB CONTENT at recordSha, NOT commit ancestry. Computing "the
  * last commit that touched a path" via `git log -- <path>` is not
@@ -85,9 +111,13 @@ for (const screen of SCREENS) {
 
     // Fresh = the committed baseline at the reviewed sha is byte-identical to
     // the baseline on disk. STALE when it differs, or isn't reachable at
-    // recordSha at all (a baseline that did not exist at the review, or a sha
-    // we cannot resolve, cannot prove the record current). See the mechanism
-    // comment above for why this is ancestry-equivalent but graft-immune.
+    // recordSha at all on a full clone (a baseline that did not exist at the
+    // review, or a sha we cannot resolve, cannot prove the record current).
+    // On a shallow clone, "not reachable" usually means the history is
+    // truncated, not that the record is stale — say so explicitly instead of
+    // reporting a false STALE with a visual:compare instruction (BET-1491).
+    // See the mechanism comment above for why this is ancestry-equivalent but
+    // graft-immune.
     let reviewedBlob;
     try {
       reviewedBlob = gitBuf(["show", `${recordSha}:${baseline}`]);
@@ -97,12 +127,18 @@ for (const screen of SCREENS) {
     const fresh = reviewedBlob !== null && reviewedBlob.equals(baselineBlob);
     assert.ok(
       fresh,
-      `conformance record for "${recordScreen}" is STALE: baseline ${screen.id} ` +
-        `differs from its committed state at the reviewed sha ${recordSha} ` +
-        `(${recordPath}) — the baseline moved after the review, so the ` +
-        `record does not describe the screen as it exists now. Fix: run ` +
-        `\`npm run visual:compare ${recordScreen}\`, reconcile ` +
-        `\`docs/screens/${recordScreen}/conformance.md\`, and update its Last reviewed sha.`,
+      reviewedBlob === null && isShallowRepo()
+        ? `conformance record for "${recordScreen}" cannot be judged on this ` +
+          `shallow clone: the reviewed sha ${recordSha} is outside the truncated ` +
+          `history, so its baseline object is absent — this is not evidence of ` +
+          `staleness (${recordPath}). Fix: run \`git fetch --unshallow origin\` ` +
+          `(or a full clone) and re-run the suite before judging conformance records.`
+        : `conformance record for "${recordScreen}" is STALE: baseline ${screen.id} ` +
+          `differs from its committed state at the reviewed sha ${recordSha} ` +
+          `(${recordPath}) — the baseline moved after the review, so the ` +
+          `record does not describe the screen as it exists now. Fix: run ` +
+          `\`npm run visual:compare ${recordScreen}\`, reconcile ` +
+          `\`docs/screens/${recordScreen}/conformance.md\`, and update its Last reviewed sha.`,
     );
   });
 }


### PR DESCRIPTION
## Problem

`scripts/conformance-freshness.test.mjs` reads the baseline blob at each conformance record's "Last reviewed" sha. On a shallow clone (`git clone --depth 20` — what agent runs and fresh checkouts commonly produce) those objects are absent, and the suite reported the records as STALE with a `npm run visual:compare …` fix instruction that is wrong for this cause — the records were fresh; the history was truncated. 15 tests failed this way on `main` before this fix.

## Fix

Detect a shallow repository (memoized `git rev-parse --is-shallow-repository` at the top of the test file) and gate the verdict on it **per failure**, not as a blanket skip. Chose explicit-failure-message over top-level skip deliberately:

- CI's `typecheck-test` job runs `git fetch --no-tags --depth=1 origin main` on top of a full checkout (`.github/workflows/ci.yml:71-74`), which **marks the repo shallow** even though all recorded objects remain reachable. A blanket "skip if shallow" would silently disable the entire conformance suite on every CI run.
- Per-failure gating keeps every existing verdict correct: reachable blob → content comparison as before; unreachable + not shallow → genuine STALE (baseline appeared after the review, or bad sha); unreachable + shallow → new explicit message: *"cannot be judged on this shallow clone … Fix: run `git fetch --unshallow origin` (or a full clone) and re-run the suite."*

Docs companion: added a "Judging conformance records needs full history" subsection to `docs/visual-verification.md` (Determinism section) — run `git fetch --unshallow origin` before trusting this suite; a green run on truncated history judged only the records inside the shallow window.

## Verification

Behavior verified on a real `--depth 20` shallow clone of this branch (via `gh`-authenticated GitHub clone, then `node --import ./scripts/testSandbox.mjs --test scripts/conformance-freshness.test.mjs`):

- shallow: 0 pass / 15 fail, every failure carrying the shallow-clone message (zero false-STALE claims)
- `git fetch --unshallow origin` in the same clone → 15 pass (matches the issue's observed recovery)
- shallow + bogus review sha is impossible to reach; full clone + unreachable sha (`deadbeef` simulated) still reports STALE — genuine-staleness message preserved
- full clone: 15/15 pass

**Files changed:** 2 files. `scripts/conformance-freshness.test.mjs` (+58/−11), `docs/visual-verification.md` (+13). No product code.

**Verification results:**
- PR branch (`multica/BET-1491-shallow-conformance` @ `8c22d2eb`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3820` pass / `0` fail / `0` skip. Failures: none. log sha256: `0067f9948aad4b56fc651295d55ee433c4c8fb37de704796c0b4bb9aea196fdd`
- Base (`main` @ `cc2dea14`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3820` pass / `0` fail / `0` skip. Failures: none. log sha256: `ec6404bfd331d03e2213a3cd244f1b19153efe15fa6129567678dd4fe4655dce`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved — both branches fully green. The shallow-clone reproduction above is additional behavioral evidence the unit suites can't express (they never run shallow).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Follow-up filed: BET-1500 (parked) — `scripts/visual/baseline-diff.mjs` is in the same shallow-truncation class (manual tool, fails loudly, not a gate).

Base: origin/main @ cc2dea14
