### PR TITLE
refactor(renderer): type ctoView card-selector inputs as CtoCard (BET-1475)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -182,10 +182,10 @@ export function CtoPanel({
   const [tonightLoading, setTonightLoading] = useState(false);
   const [tonightPinned, setTonightPinned] = useState(false);
   const [tonightWindowOpen, setTonightWindowOpen] = useState(false);
-  const blockerCardList = useMemo(() => blockerCards(cards as unknown as ReadonlyArray<Record<string, unknown>>), [cards]);
+  const blockerCardList = useMemo(() => blockerCards(cards), [cards]);
   const suggestionCards = useMemo(() => decisionCards(cards), [cards]);
-  const vetoList = useMemo(() => vetoCards(cards as unknown as ReadonlyArray<Record<string, unknown>>), [cards]);
-  const connectList = useMemo(() => connectCards(cards as unknown as ReadonlyArray<Record<string, unknown>>), [cards]);
+  const vetoList = useMemo(() => vetoCards(cards), [cards]);
+  const connectList = useMemo(() => connectCards(cards), [cards]);
 
   const busy = digestBusy(state);
   const busyRef = useRef(busy);

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -24,6 +24,7 @@ import {
   type CtoState,
   type CtoHealthStat,
 } from "./ctoView";
+import type { CtoCard } from "../shared/api";
 
 const base: CtoState = {
   enabled: true,
@@ -417,7 +418,7 @@ it("decisionCards: selects decision-variant cards only", () => {
     { id: "d1", variant: "decision", title: "dec", options: [] },
     { id: "c1", variant: "connect", title: "con" },
   ];
-  const out = decisionCards(cards as unknown as Record<string, unknown>[]);
+  const out = decisionCards(cards as unknown as CtoCard[]);
   expect(out.length).toBe(1);
   expect(out[0].id).toBe("d1");
 });
@@ -535,7 +536,7 @@ it("vetoCards: selects veto-variant cards with the countdown fields", () => {
     { id: "b1", variant: "blocker", title: "blk" },
     { id: "overnight:veto", variant: "veto", title: "Overnight run planned", body: "3 tasks", dueMs: 5000, options: [{ label: "Cancel tonight", action: { type: "veto-cancel", payload: {} } }] },
   ];
-  const out = vetoCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  const out = vetoCards(cards as unknown as CtoCard[]);
   expect(out.length).toBe(1);
   expect(out[0].id).toBe("overnight:veto");
   expect(out[0].dueMs).toBe(5000);
@@ -554,7 +555,7 @@ it("blockerCards: selects blocker-variant cards only — a connect card is NOT s
     { id: "v1", variant: "veto", title: "vet" },
     { id: "c1", variant: "connect", title: "con" },
   ];
-  const out = blockerCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  const out = blockerCards(cards as unknown as CtoCard[]);
   expect(out.length).toBe(1);
   expect(out[0].id).toBe("b1");
 });
@@ -565,7 +566,7 @@ it("blockerCards: drops a row with neither title nor body", () => {
     { id: "b2", variant: "blocker", title: "", body: "has body" },
     { id: "b3", variant: "blocker", title: "has title", body: "" },
   ];
-  const out = blockerCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  const out = blockerCards(cards as unknown as CtoCard[]);
   expect(out.map((c) => c.id)).toEqual(["b2", "b3"]);
 });
 
@@ -574,7 +575,7 @@ it("vetoCards: drops a row with neither title nor body", () => {
     { id: "v1", variant: "veto", title: "", body: "", dueMs: 1000, options: [] },
     { id: "v2", variant: "veto", title: "Overnight run planned", body: "", dueMs: 1000, options: [] },
   ];
-  const out = vetoCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  const out = vetoCards(cards as unknown as CtoCard[]);
   expect(out.map((c) => c.id)).toEqual(["v2"]);
 });
 
@@ -584,7 +585,7 @@ it("connectCards: selects connect-variant cards and drops a row with neither tit
     { id: "c1", variant: "connect", title: "", body: "", options: [] },
     { id: "c2", variant: "connect", title: "GitHub", body: "used 6 times this week", options: [] },
   ];
-  const out = connectCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  const out = connectCards(cards as unknown as CtoCard[]);
   expect(out.map((c) => c.id)).toEqual(["c2"]);
 });
 

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -533,7 +533,7 @@ export function suggestionConfidence(card: DecisionCardRow): number | null {
 // Selector: the open decision cards among the wire cards (the rest of the
 // store stays the Blocker section's).
 export function decisionCards(cards: ReadonlyArray<CtoCard>): DecisionCardRow[] {
-  return (cards ?? []).filter((c): c is CtoCard & { variant: "decision" });
+  return (cards ?? []).filter((c): c is CtoCard & { variant: "decision" } => c.variant === "decision");
 }
 
 // BET-1419: the open veto card (§10.3) among the wire cards — the overnight

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -2,7 +2,7 @@
 // The CTO pane (§10) renders from a single `{kind:"ctoState"}` bus event
 // (payload shape below) plus a `GET /api/cto/state` initial read. This module
 // holds only deterministic mapping — no window.api, no React.
-import type { Api } from "../shared/api";
+import type { Api, CtoCard } from "../shared/api";
 import type { DelegateStartInput } from "../shared/types";
 import { cardHasContent } from "../shared/ctoCard.mjs";
 
@@ -335,7 +335,9 @@ export type BlockerCard = {
 // blockers (BET-1467). Also drops a card with neither title nor body (via the
 // shared cardHasContent predicate, BET-1476) so an empty card never reaches
 // BlockerSection's live "Answer now" control.
-export function blockerCards(cards: ReadonlyArray<Record<string, unknown>>): BlockerCard[] {
+// BET-1475: the input is the wire-typed `CtoCard[]` — selectors can no longer
+// be handed arbitrary shapes, and callers need no cast.
+export function blockerCards(cards: ReadonlyArray<CtoCard>): BlockerCard[] {
   return (cards ?? [])
     .filter((c) => c?.variant === "blocker" && cardHasContent(c))
     .map((c) => ({
@@ -530,8 +532,8 @@ export function suggestionConfidence(card: DecisionCardRow): number | null {
 
 // Selector: the open decision cards among the wire cards (the rest of the
 // store stays the Blocker section's).
-export function decisionCards(cards: ReadonlyArray<Record<string, unknown>>): DecisionCardRow[] {
-  return (cards ?? []).filter((c) => c?.variant === "decision") as DecisionCardRow[];
+export function decisionCards(cards: ReadonlyArray<CtoCard>): DecisionCardRow[] {
+  return (cards ?? []).filter((c): c is CtoCard & { variant: "decision" });
 }
 
 // BET-1419: the open veto card (§10.3) among the wire cards — the overnight
@@ -544,7 +546,7 @@ export type VetoCardRow = {
   options: { label: string; action: { type: string; payload: Record<string, unknown> } }[];
 };
 
-export function vetoCards(cards: ReadonlyArray<Record<string, unknown>>): VetoCardRow[] {
+export function vetoCards(cards: ReadonlyArray<CtoCard>): VetoCardRow[] {
   return (cards ?? [])
     .filter((c) => c?.variant === "veto" && cardHasContent(c))
     .map((c) => ({
@@ -567,7 +569,7 @@ export type ConnectCardRow = {
   options: { label: string; answer: string; action: { type: string; payload: Record<string, unknown> } }[];
 };
 
-export function connectCards(cards: ReadonlyArray<Record<string, unknown>>): ConnectCardRow[] {
+export function connectCards(cards: ReadonlyArray<CtoCard>): ConnectCardRow[] {
   return (cards ?? [])
     .filter((c) => c?.variant === "connect" && cardHasContent(c))
     .map((c) => ({


### PR DESCRIPTION
## BET-1475 — type the ctoView card-selector signatures (drop the blockerCards double cast)

Closes the below-bar cleanup nit from BET-1467's review (PR #1443).

### What changed

- `src/renderer/ctoView.ts` — `blockerCards`, `decisionCards`, `vetoCards`, `connectCards` now take `ReadonlyArray<CtoCard>` (the shared wire type, one of the two shapes the issue offers) instead of `ReadonlyArray<Record<string, unknown>>`. The selectors can no longer be handed arbitrary shapes. `decisionCards`' blanket `as DecisionCardRow[]` becomes a filter type predicate (same runtime comparison). Mapper bodies untouched.
- `src/renderer/CtoPanel.tsx` — the three redundant `as unknown as ReadonlyArray<Record<string, unknown>>` casts at the selector call sites (185/187/188) are deleted; the calls pass `cards` directly.
- `src/renderer/ctoView.test.ts` — the six fixture assertions retarget `as unknown as CtoCard[]` (issue-anticipated retyping; fixture literals unchanged).

### Scope note

The issue lists `CtoPanel.tsx` as off-limits "(BET-1468 territory)", but its own Done-when requires the cast gone from the `blockerCards` call site **in CtoPanel.tsx** — the cast lives there, so it cannot be removed without touching that file. BET-1468 (PR #1449) is merged, so the collision window is closed; the edit is strictly the three cast deletions on the four selector lines. Nothing else in CtoPanel is touched.

### Verification

- `npm run typecheck` — green (both tsconfigs).
- `npm test` — **3820 pass / 0 fail / 0 skipped**.
- `grep "as unknown as"` — zero hits in `CtoPanel.tsx` and `ctoView.ts`.
- No behaviour change — filter/mapper logic byte-identical to BET-1467's shipped form; no new exports, no new files.

### Follow-ups

None filed — this change is self-contained; no drift traps or sibling paths surfaced.

Base: origin/main @ cc2dea14
