### PR TITLE
BET-1495: remove dead saveInbox dep from createCtoEngine

### DIFF
--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -138,7 +138,6 @@ export function createCtoEngine(deps = {}) {
     readProfile = null,
     readToolRegistry = null,
     loadInbox = async () => inboxStore.load(),
-    saveInbox = async (data) => inboxStore.save(data),
     now = () => Date.now(),
   } = deps;
 


### PR DESCRIPTION
BET-1495 (reviewer nit from BET-1492, cycle-2 PASS): `createCtoEngine` still declares a `saveInbox` dependency that nothing uses since BET-1492 routed `drainInbox` through `patchStore`. Delete-only cleanup.

Base: origin/main @ `c5d06a12`

## Changes

- `src/server/cto.mjs` — remove the dead `saveInbox = async (data) => inboxStore.save(data),` line from `createCtoEngine`'s deps destructuring. One line deleted, nothing else.
- `createCtoInbound`'s legacy `loadInbox`/`saveInbox` seam (~lines 1108-1125) is intentionally untouched — it is live and test-injected.
- `cto.test.mjs` has no `saveInbox` references, so no test changes were needed.

## Verification

- PR branch (`multica/BET-1495-remove-dead-saveinbox-dep` @ `e2725338`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3823 pass / 0 fail / 0 skip. Failures: none. log sha256: `bfa6344a11407e2f8d58a524ec9b172675072630d5b78a4ed2be885138452d17`
- Base (`main` @ `c5d06a12`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3823 pass / 0 fail / 0 skip. Failures: none. log sha256: `af98f5e4fdd772357d39b58e9a7db7027239150a9c8e72fdacdeead79fdb4244`
- **Conclusion:** 0 new failures, 0 pre-existing, 0 resolved — identical suites on both branches (the typecheck logs hash identically).

Grep-clean verified: `saveInbox` remains only inside `createCtoInbound` (and its test file), nowhere in `createCtoEngine`'s body.
