### PR TITLE
fix(renderer): held modal error state instead of false empty-state (BET-1484)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -33,6 +33,7 @@ import {
   blockerTarget,
   resting,
   mayShowResting,
+  heldModalShowsError,
   relativeTime,
   finishedVariant,
   formatEta,
@@ -175,6 +176,11 @@ export function CtoPanel({
   // the §14.3 silence-audit "review held" modal (opened from the digest aside).
   const [heldOpen, setHeldOpen] = useState(false);
   const [heldRows, setHeldRows] = useState<CtoHeldRow[]>([]);
+  // BET-1484: a failed FIRST-EVER held load leaves `heldRows` empty, and the
+  // modal then renders the "Nothing held back." empty state — a factual claim
+  // ("the box holds nothing") when the truth is "we don't know". Track the
+  // failure so the modal can say so (the drill-downs' error + Retry shape).
+  const [heldLoadError, setHeldLoadError] = useState<string | null>(null);
   // BET-1419: veto cards (§9.2) render in their own Overnight section; the
   // Tonight drill-down (§10.4) fetches its task list when expanded.
   const [tonightExpanded, setTonightExpanded] = useState(false);
@@ -581,9 +587,23 @@ export function CtoPanel({
   // BET-1468 item 6: a failed load used to reset `heldRows` to `[]`, so the
   // modal opened claiming "Nothing held back." right after the digest said
   // otherwise. Keep whatever was last loaded (the Refresh button in the empty
-  // state covers retry) and toast the failure instead.
+  // state covers retry) and toast the failure instead. BET-1484: on a
+  // first-ever failure that kept list is empty, so also record the error and
+  // let the modal render its in-modal error line + Retry (drill-down shape)
+  // rather than the empty state.
   const openHeld = useCallback(() => {
-    void window.api?.ctoHeldList?.().then((r) => setHeldRows(r.rows)).catch(catchActionError("load held suggestions")).finally(() => setHeldOpen(true));
+    void (async () => {
+      try {
+        const r = await window.api?.ctoHeldList?.();
+        setHeldRows(r.rows);
+        setHeldLoadError(null);
+      } catch (e) {
+        setHeldLoadError(e instanceof Error ? e.message : String(e));
+        catchActionError("load held suggestions")(e);
+      } finally {
+        setHeldOpen(true);
+      }
+    })();
   }, [catchActionError]);
   // BET-1468 item 6: the row was removed from the list unconditionally even
   // when the verdict POST failed (or threw on a stale token) — the user sees
@@ -824,6 +844,7 @@ export function CtoPanel({
       {heldOpen && (
         <HeldListModal
           rows={heldRows}
+          loadError={heldLoadError}
           onClose={() => setHeldOpen(false)}
           onRefresh={() => openHeld()}
           onVerdict={handleHeldVerdict}
@@ -2200,11 +2221,13 @@ function rendererDelegateStart(input: {
 // N — review" aside.
 function HeldListModal({
   rows,
+  loadError,
   onClose,
   onRefresh,
   onVerdict,
 }: {
   rows: CtoHeldRow[];
+  loadError?: string | null;
   onClose: () => void;
   onRefresh: () => void;
   onVerdict: (row: CtoHeldRow, verdict: "accept" | "dismiss") => void;
@@ -2239,7 +2262,20 @@ function HeldListModal({
         </p>
         <div className="mt-2 flex-1 space-y-2 overflow-auto">
           {rows.length === 0 ? (
-            <div className="py-6 text-center text-sm text-text-faint">Nothing held back.</div>
+            heldModalShowsError({ loadError: !!loadError, rowCount: rows.length }) ? (
+              // BET-1484: a failed first-ever load renders this error line +
+              // Retry (the drill-downs' shape) instead of the empty state —
+              // "Nothing held back." would read as a factual claim when the
+              // read never came back. The toast still fired too.
+              <div className="flex flex-col items-start gap-1 py-6">
+                <p className="text-sm text-text-muted">Couldn&rsquo;t load held suggestions: {loadError}</p>
+                <button type="button" onClick={onRefresh} className="text-sm text-accent underline hover:text-accent-strong">
+                  Retry
+                </button>
+              </div>
+            ) : (
+              <div className="py-6 text-center text-sm text-text-faint">Nothing held back.</div>
+            )
           ) : (
             rows.map((row) => (
               <div key={row.id} className="rounded-md border border-strong bg-fill px-3 py-2">

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -15,6 +15,7 @@ import {
   digestExpandable,
   resting,
   mayShowResting,
+  heldModalShowsError,
   stateTone,
   nowCostLabel,
   nowRailMeta,
@@ -353,6 +354,20 @@ describe("mayShowResting (BET-1468 item 1 — no false all-clear)", () => {
   });
   it("is true only once loaded, without error, and actually resting", () => {
     expect(mayShowResting({ loaded: true, loadError: false, isResting: true })).toBe(true);
+  });
+});
+
+describe("heldModalShowsError (BET-1484 — no false \"nothing held back\")", () => {
+  it("is true when a first-ever load failed (rows still empty)", () => {
+    expect(heldModalShowsError({ loadError: true, rowCount: 0 })).toBe(true);
+  });
+  it("is false when the load succeeded and the box holds nothing", () => {
+    expect(heldModalShowsError({ loadError: false, rowCount: 0 })).toBe(false);
+  });
+  it("is false when rows are on screen even after a failed refresh", () => {
+    // Last known data (kept on a failed refresh per BET-1468 item 6) is real;
+    // the error line must not displace it. The toast carries the failure.
+    expect(heldModalShowsError({ loadError: true, rowCount: 3 })).toBe(false);
   });
 });
 

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -474,6 +474,17 @@ export function mayShowResting(inputs: { loaded: boolean; loadError: boolean; is
   return inputs.loaded && !inputs.loadError && inputs.isResting;
 }
 
+// BET-1484: the held modal's "Nothing held back." line is a factual claim
+// ("the box holds nothing") — it must not render when the load that would
+// have populated the list failed. A failed first-ever load leaves the rows
+// empty, so the empty state would show by default. The error line + Retry
+// replaces the empty state ONLY when there are no rows to show; with rows on
+// screen (last known data, kept on a failed refresh per BET-1468 item 6) the
+// rows are real and the toast already said the refresh failed.
+export function heldModalShowsError(inputs: { loadError: boolean; rowCount: number }): boolean {
+  return inputs.loadError && inputs.rowCount === 0;
+}
+
 // Now-rail/digest shared: does the list of sessions have any blocked one — the
 // "blocked — question above ↑" chip on a blocked Now card (never repeats the
 // question).


### PR DESCRIPTION
## BET-1484 — Held modal error state

Fixes the §14.3 silence gap: when the initial `ctoHeldList` read fails, the held modal opened showing **"Nothing held back."** — a factual claim ("the box holds nothing") when the truth is "we don't know". The digest aside may simultaneously say there are held items.

**Change (3 files):**
- `src/renderer/CtoPanel.tsx` — `openHeld` now records a `heldLoadError` on failure (try/catch/finally, drill-down shape from BET-1468 item 7); the toast (`catchActionError("load held suggestions")`) is unchanged and still fires. `HeldListModal` renders an in-modal error line + **Retry** (re-runs `openHeld`) instead of the empty state when the gate says so.
- `src/renderer/ctoView.ts` — new pure gate `heldModalShowsError({loadError, rowCount})`: the error line replaces the empty state **only when there are no rows to show**. With rows on screen (last known data, kept on a failed refresh per BET-1468 item 6) the rows are real and the toast carries the failure.
- `src/renderer/ctoView.test.ts` — 3 tests pinning the gate (failed first-ever load → error; clean empty → empty state; rows present after failed refresh → rows, no error line).

Anti-spaghetti: single call site (the digest aside's "N — review" link → `openHeld`); no duplicates. Pure logic extracted to `ctoView.ts` per repo convention rather than tested via a monolithic component mount.

**Base: origin/main @ c5d06a12**

**Verification results:**
- PR branch (`multica/BET-1484-held-modal-error-state` @ `ab372374`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3823 pass / 0 fail / 0 skip. Failures: none. log sha256: `4f864e64a9d917a67b284e50da4c99c14333b9d923561b66f0fdaaa2389b13d0`
- Base (`main` @ `c5d06a12`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3823 pass / 0 fail / 0 skip. Failures: none. log sha256: `9c5f29777240d3f729742321bf197a22eb28c118427a24ecb25c7b77c90b668a`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved. Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
