### PR TITLE
BET-1501: ctoView.ts — unify optional-chaining convention across the four card selectors

### DIFF
--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -416,6 +416,7 @@ it("decisionCards: selects decision-variant cards only", () => {
   const cards = [
     { id: "b1", variant: "blocker", title: "blk" },
     { id: "d1", variant: "decision", title: "dec", options: [] },
+    null,
     { id: "c1", variant: "connect", title: "con" },
   ];
   const out = decisionCards(cards as unknown as CtoCard[]);

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -531,9 +531,11 @@ export function suggestionConfidence(card: DecisionCardRow): number | null {
 }
 
 // Selector: the open decision cards among the wire cards (the rest of the
-// store stays the Blocker section's).
+// store stays the Blocker section's). BET-1501: the `c?.` null-element guard
+// matches the sibling selectors — a malformed wire payload carrying a null
+// element is skipped, not thrown on.
 export function decisionCards(cards: ReadonlyArray<CtoCard>): DecisionCardRow[] {
-  return (cards ?? []).filter((c): c is CtoCard & { variant: "decision" } => c.variant === "decision");
+  return (cards ?? []).filter((c): c is CtoCard & { variant: "decision" } => c?.variant === "decision");
 }
 
 // BET-1419: the open veto card (§10.3) among the wire cards — the overnight


### PR DESCRIPTION
## Summary

BET-1475 retyped the `ctoView.ts` card selectors to `ReadonlyArray<CtoCard>` but dropped the `c?.` optional chaining from `decisionCards`' filter predicate while its three siblings (`blockerCards`, `vetoCards`, `connectCards`) keep it. Restored `c?.` in `decisionCards` so one convention holds across all four: a malformed wire payload carrying a `null` element is **skipped**, not thrown on. Behavior for type-valid input is unchanged (a `null` element is type-invalid under `ReadonlyArray<CtoCard>`).

**Convention chosen: keep `c?.` everywhere** (3 of 4 selectors already had it; dropping it from all four would widen the throw-surface for malformed wire payloads — a behavior change).

Also extended the existing `decisionCards` test with a `null` element in the input to pin the skip behavior (no new test block, no new exports, no new files).

Base: origin/main @ `7cb4b134`

**Files changed:** 2 files. `src/renderer/ctoView.ts` (+4/-2 incl. comment), `src/renderer/ctoView.test.ts` (+1)

**Verification results:**
- PR branch (`multica/BET-1501-optional-chaining-card-selectors` @ `447540ea`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3823` pass / `0` fail / `0` skip. Failures: none. log sha256: `28362a02bf926377a500be8ab3d298d9538beef8a08daa77cb654d42efec7094`
- Base (`main` @ `7cb4b134`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3823` pass / `0` fail / `0` skip. Failures: none. log sha256: `3a87b93110cd1033eccd630579c83d4e7a7f635063ee8eabc9f1688505f10ee0`
- **Conclusion:** 0 test failures, 0 new, 0 pre-existing. Both branches fully green.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Closes BET-1501.