### PR TITLE
chore(server): CTO follow-up sweep — fix queryMultiba stub key, delete dead countOpen, shallow-clone hint in baseline-diff (BET-1502)

### DIFF
--- a/scripts/visual/baseline-diff.mjs
+++ b/scripts/visual/baseline-diff.mjs
@@ -43,6 +43,25 @@ function gitShow(rev, path) {
   return execFileSync("git", ["show", `${rev}:${path}`], { cwd: ROOT });
 }
 
+/**
+ * True when this checkout has truncated history (`.git/shallow` present —
+ * `git clone --depth N`, a throwaway checkout, …). Memoized; a non-repo reads
+ * as not-shallow. (BET-1500: on a shallow clone the base rev's blob objects
+ * can be absent and `git show` dies with a bare git "object not found" that
+ * does not point at the real cause — say shallow instead.)
+ */
+let shallow;
+function isShallowRepo() {
+  if (shallow === undefined) {
+    try {
+      shallow = git(["rev-parse", "--is-shallow-repository"]) === "true";
+    } catch {
+      shallow = false;
+    }
+  }
+  return shallow;
+}
+
 /** List every baseline PNG modified and added against `base`, in git order. */
 function changedBaselines(base) {
   const modified = git([
@@ -104,7 +123,19 @@ async function main() {
       labels = ["(new — no prior baseline)", "after"];
       log(`new baseline      → ${name}.png (no prior baseline, grey panel)`);
     } else {
-      before = gitShow(base, path);
+      try {
+        before = gitShow(base, path);
+      } catch (e) {
+        if (isShallowRepo()) {
+          log(
+            `shallow clone: run \`git fetch --unshallow origin\` — the committed ` +
+              `"before" blob for ${path} at ${base} is absent from the truncated ` +
+              `history (git: ${String(e?.message ?? e).split("\n")[0]})`,
+          );
+          process.exit(1);
+        }
+        throw e;
+      }
       labels = ["before", "after"];
       log(`re-recorded       → ${name}.png`);
     }

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -864,17 +864,6 @@ export function createCtoCards(deps = {}) {
     return { ok: true, changed, isNew };
   }
 
-  // needs-you surface: only open cards count (§10.3 — resolved/dismissed cards
-  // left cards.json for the ledger).
-  async function countOpen() {
-    try {
-      const { cards } = await openCards();
-      return cards.filter((c) => c && c.state === "open").length;
-    } catch {
-      return 0;
-    }
-  }
-
   // BET-1419 (§9.2/§10.3): the veto-window card — announce tonight's run 30
   // min ahead with a live countdown. One open veto card at a time (the
   // overnight countdown is unique per window): re-arming upserts by id so the
@@ -990,7 +979,6 @@ export function createCtoCards(deps = {}) {
     upsertVeto,
     upsertConnect,
     resolveConnectCards,
-    countOpen,
     listOpen,
   };
 }

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -397,17 +397,6 @@ test("dismiss moves a card out of cards.json with a card.dismissed ledger row", 
   assert.equal(h.ledgerRows.filter((x) => x.kind === CARD_DISMISSED).length, 1);
 });
 
-test("countOpen reflects only open cards", async () => {
-  const h = makeHarness();
-  assert.equal(await h.cards.countOpen(), 0);
-  await h.cards.onAskStart({ sourceKind: "question", sourceId: "que_c", sessionID: "sC", body: "", ts: h.clock.ms });
-  h.advance(BLOCKER_AFTER_MS);
-  await h.cards.promoteDue();
-  assert.equal(await h.cards.countOpen(), 1);
-  await h.cards.onAskResolved({ sessionID: "sC" });
-  assert.equal(await h.cards.countOpen(), 0);
-});
-
 test("BET-1397 source 3: an inbox blocker fires the blocking-tier notify exactly once and promotes a card", async () => {
   const h = makeHarness({ fireNotify: true });
   const r = await h.cards.onInboxBlocker({

--- a/src/server/ctoInbound.test.mjs
+++ b/src/server/ctoInbound.test.mjs
@@ -250,7 +250,7 @@ test("normalizeInboxKind maps unknown/bare to blocker; coalesceInboxEntry unions
 // ---------------------------------------------------------------------------
 
 function makeEngine(overrides = {}) {
-  return createCtoEngine(makeEngineDeps({ queryMultiba: async () => ({ ok: true }), ...overrides }));
+  return createCtoEngine(makeEngineDeps({ queryMultica: async () => ({ ok: true }), ...overrides }));
 }
 
 // Gate that reports confirm only for `watch` (the confirm-mode tool).


### PR DESCRIPTION
Batches the three parked mechanical follow-ups from the BET-1461 CTO remediation epic (supersedes BET-1496 + BET-1499 + BET-1500) into one PR.

Base: origin/main @ 361a992d

## Changes

1. **Rename `queryMultiba` -> `queryMultica`** (was BET-1496) — `src/server/ctoInbound.test.mjs:253`: the `makeEngineDeps` override key typo'd in the BET-1490 fixture extraction. Functionally inert either way (reviewer-verified on PR #1468, which offered "spell it back or delete the key" — spelled back per the issue). `queryMultiba` now appears nowhere under `src/server/`.
2. **Delete `countOpen`** (was BET-1499) — `src/server/ctoCards.mjs`: the second open-card counter without the shared `cardHasContent` predicate had zero production callers (the live needs-you badge counts via `defaultGetCounts` with `cardHasContent` since BET-1476). Deletion chosen per the issue's preference; its test in `ctoCards.test.mjs` goes with it. One semantic counter over the cards store, not two.
3. **Shallow-clone hint in `visual:baselines`** (was BET-1500) — `scripts/visual/baseline-diff.mjs`: when `git show <base>:<path>` fails on a shallow clone, print a one-line `shallow clone: run git fetch --unshallow origin` hint before exiting instead of a bare git "object not found". Mirrors the BET-1491 change in `conformance-freshness.test.mjs` (`git rev-parse --is-shallow-repository`, memoized, non-repo reads as not-shallow).

Scope: the three files only. No product code.

## Verification results:
- PR branch (`multica/BET-1502-cto-followup-sweep` @ `47307bcd`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3822` pass / `0` fail / `0` skip. Failures: none. log sha256: `57db6d66f6d3c727a31d329ee1d91898574ff86e58a3d03fed2136cc7d385849`
  - duplication-gate (`scripts/check-duplication-gate.sh origin/main`): PASS — 4 changed files scanned, no clones
- Base (`main` @ `361a992d`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3823` pass / `0` fail / `0` skip. Failures: none. log sha256: `7d0fb4c0c092fd807bb88cd14e66010c8660a4bbba79133304d40fb71c22f2ca`
- **Conclusion:** 0 test failures pre-existing, 0 new failures caused by this PR, 1 test removed by this PR (the deleted `countOpen` test — main's 3823 vs PR's 3822).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.