### PR TITLE
fix(server): ROI pending retention is liveness-aware (BET-1497)

### DIFF
--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -665,7 +665,8 @@ function monthAccumulator(months, key) {
 }
 
 // Pending rows older than this are dropped (bounded growth; a merge that
-// surfaced 60 days late is beyond the report's honest horizon).
+// surfaced 60 days late is beyond the report's honest horizon). BET-1497:
+// the drop is liveness-aware — see retainPendingHorizon.
 export const ROI_PENDING_RETENTION_MS = 60 * 24 * HOUR_MS;
 
 /**
@@ -698,6 +699,36 @@ export function trimPendingCap(rows, { cap = 200, liveIds = null } = {}) {
     else kept.push(row);
   }
   return kept;
+}
+
+/**
+ * The liveness-aware retention horizon on `roi.pending` (BET-1497). The
+ * BET-1466 filter assumed a counted row dropped at the horizon can never be
+ * re-counted — true only while the delegate store's sweeper eventually
+ * removes every terminal record. It does not: a job that finished with a
+ * dirty worktree (`cleanedUp === false`) is kept FOREVER (applyRetention
+ * spares it by time and by the 50-terminal-record cap alike). Dropping that
+ * job's fingerprint re-opens it to step 1's sampling — the same double-count
+ * the BET-1487 cap closed, reached through the retention path and
+ * independent of job volume. So the horizon drops:
+ *   - an uncounted row past the horizon (re-sampling it merely re-probes a
+ *     job that has never been counted — no double count), and
+ *   - a counted row past the horizon only once its record is provably gone
+ *     from the jobs snapshot — absence is final (job ids are minted once and
+ *     the store's sweeper only removes records), and
+ *   - never a counted row whose id is still in `liveIds`, nor any counted
+ *     row while liveness is unknowable (`liveIds === null` — the store read
+ *     failed; the same convention the cap applies).
+ * A counted row without a timestamp has no age to retire and is kept, as
+ * before. `liveIds` is the set shared with `trimPendingCap` — one snapshot
+ * read in step 1 answers both hygiene passes.
+ */
+export function retainPendingHorizon(rows, { cutoff, liveIds = null } = {}) {
+  return rows.filter((j) => {
+    if (typeof j.finishedAt !== "number") return j.counted === true;
+    if (j.finishedAt >= cutoff) return true;
+    return j.counted === true && (liveIds === null || liveIds.has(j.id));
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1155,29 +1186,29 @@ function validPrRef(ref) {
           }
 
           // 4. Hygiene: age out stale pending rows. The retention horizon
-          // applies to BOTH halves (BET-1466: it used to filter only counted
-          // rows while the never-merged ones — the rows that actually
-          // accumulate — were kept forever). A counted row is a dedupe
-          // fingerprint kept only past any possible re-sample: the delegate
-          // jobs store sweeps terminal records after 7 days, far inside the
-          // 60-day horizon, so a counted row dropped at the horizon can never
-          // be re-counted.
+          //    applies to BOTH halves (BET-1466: it used to filter only
+          //    counted rows while the never-merged ones — the rows that
+          //    actually accumulate — were kept forever). A counted row is a
+          //    dedupe fingerprint, so dropping one at the horizon requires
+          //    proof its job can never re-sample — and "the store sweeps
+          //    terminal records after 7 days" is not proof: a dirty-worktree
+          //    terminal record is never swept. The drop is liveness-aware
+          //    (BET-1497): a counted row past the horizon survives while its
+          //    record is still in the snapshot read in step 1 (or while the
+          //    read failed and liveness is unknowable) — the same rule the
+          //    cap below applies.
           const cutoff = t - ROI_PENDING_RETENTION_MS;
-          const kept = pending.filter((j) =>
-            j.counted === true
-              ? typeof j.finishedAt === "number" ? j.finishedAt >= cutoff : true
-              : typeof j.finishedAt === "number" && j.finishedAt >= cutoff,
-          );
+          const liveIds = jobsReadOk
+            ? new Set(jobs.map((j) => (j && typeof j.id === "string" ? j.id : null)).filter((id) => id !== null))
+            : null;
+          const kept = retainPendingHorizon(pending, { cutoff, liveIds });
           // The trailing cap is count-aware (BET-1487): a counted row is a
           // dedupe fingerprint while its delegate job could still re-sample —
-          // i.e. while its record is still in the store snapshot read in
+          // i.e. while its record is still in the jobs store snapshot read in
           // step 1. The cap evicts only fingerprints that snapshot proves
           // dead, so on a chatty box (>200 counted jobs inside the store's
           // terminal-retention window) the list exceeds the cap instead of
           // losing a fingerprint.
-          const liveIds = jobsReadOk
-            ? new Set(jobs.map((j) => (j && typeof j.id === "string" ? j.id : null)).filter((id) => id !== null))
-            : null;
           const trimmed = trimPendingCap(kept, { liveIds });
           pending = trimmed;
 

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -483,6 +483,7 @@ import {
   isJobMerged,
   roiRecommendation,
   trimPendingCap,
+  retainPendingHorizon,
 } from "./ctoBudget.mjs";
 
 const AUG_KEY = roiMonthKey(MIDNIGHT); // 2026-08 local
@@ -861,8 +862,40 @@ test("trimPendingCap evicts oldest-first but spares counted fingerprints that ca
   assert.equal(t5.length, 205);
 });
 
-test("refreshRoi: the pending cap never evicts a counted fingerprint whose job is still in the store (BET-1487)", async () => {
-  let payload = defaultBudgetPayload();
+// BET-1497: the retention horizon is liveness-aware — a counted row past the
+// horizon is a still-needed dedupe fingerprint while its delegate record can
+// re-sample (a dirty-worktree terminal record is never swept), so the drop
+// waits for the snapshot to prove the record gone.
+test("retainPendingHorizon ages rows past the horizon but spares counted fingerprints that can still re-sample (BET-1497)", () => {
+  const stale = MIDNIGHT - ROI_PENDING_RETENTION_MS - 1;
+  const cutoff = MIDNIGHT - ROI_PENDING_RETENTION_MS;
+  const row = (id, counted, finishedAt = stale) => ({ id, counted, finishedAt });
+  // Fresh rows (both kinds) and a counted row without a timestamp: kept, as before.
+  const fresh = [row("f", false, MIDNIGHT - 1), row("fc", true, MIDNIGHT - 1), row("cn", true, null)];
+  assert.deepEqual(
+    retainPendingHorizon(fresh, { cutoff, liveIds: new Set() }).map((j) => j.id),
+    ["f", "fc", "cn"],
+  );
+  // Past the horizon with the record provably swept: both kinds drop (BET-1466).
+  assert.deepEqual(
+    retainPendingHorizon([row("u", false), row("c", true)], { cutoff, liveIds: new Set() }).map((j) => j.id),
+    [],
+  );
+  // Past the horizon with the record STILL in the store: the counted
+  // fingerprint survives; the uncounted row still ages out.
+  assert.deepEqual(
+    retainPendingHorizon([row("u", false), row("c", true)], { cutoff, liveIds: new Set(["c"]) }).map((j) => j.id),
+    ["c"],
+  );
+  // A failed jobs read (liveIds null) keeps the counted fingerprint —
+  // liveness unknowable, the same convention the cap applies.
+  assert.deepEqual(
+    retainPendingHorizon([row("u", false), row("c", true)], { cutoff, liveIds: null }).map((j) => j.id),
+    ["c"],
+  );
+});
+
+test("refreshRoi: the pending cap never evicts a counted fingerprint whose job is still in the store (BET-1487)", async () => {  let payload = defaultBudgetPayload();
   const COUNTED = 50;
   const countedIds = Array.from({ length: COUNTED }, (_, i) => `c${i}`);
   // The 50 counted rows' delegate jobs are STILL in the jobs store (inside
@@ -935,6 +968,50 @@ test("refreshRoi: a failed jobs read protects every counted fingerprint from the
   assert.equal(payload.roi.pending.some((j) => j.id === "counted"), true);
   assert.equal(payload.roi.pending.some((j) => j.id === "u0"), false);
   assert.equal(payload.roi.pending.some((j) => j.id === "u200"), true);
+});
+
+// BET-1497: a counted row past the horizon whose delegate record lives
+// forever (dirty worktree → applyRetention never prunes it) must keep its
+// fingerprint — dropping it would let step 1 re-sample the still-stored job
+// and re-count it into its month accumulator.
+test("refreshRoi: a counted row past the horizon survives while its dirty-worktree record is still in the store (BET-1497)", async () => {
+  let payload = defaultBudgetPayload();
+  payload.roi = {
+    months: { [AUG_KEY]: { merged: 1 } }, // the job was counted once, long ago
+    pending: [
+      { id: "old", branch: "cto/old", cwd: "/p", finishedAt: MIDNIGHT - ROI_PENDING_RETENTION_MS - 1, counted: true },
+    ],
+  };
+  const store = { load: async () => payload, save: async (p) => (payload = p) };
+  const job = {
+    id: "old",
+    actor: "cto",
+    status: "done",
+    branch: "cto/old",
+    cwd: "/p",
+    finishedAt: MIDNIGHT - ROI_PENDING_RETENTION_MS - 1,
+    cleanedUp: false, // dirty worktree → the store never sweeps this record
+  };
+  let recordLive = true;
+  const budget = createCtoBudget({
+    store,
+    jobsRead: async () => (recordLive ? [job] : []),
+    gitProbe: async () => ({ exists: true, isAncestor: true }), // reads merged — a re-sample would re-count
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now: () => MIDNIGHT,
+  });
+  await budget.refreshRoi();
+  assert.equal(payload.roi.months[AUG_KEY].merged, 1, "no re-count while the record is live");
+  assert.deepEqual(payload.roi.pending.map((j) => j.id), ["old"], "the fingerprint survives the horizon");
+  // The worktree is finally cleaned and the record is swept: absence from the
+  // snapshot proves the fingerprint dead, and the row drops at the horizon —
+  // with no re-sample and no second count.
+  recordLive = false;
+  await budget.refreshRoi();
+  assert.equal(payload.roi.months[AUG_KEY].merged, 1);
+  assert.equal(payload.roi.pending.length, 0);
 });
 
 // BET-1466 item 4: budget.json is not covered by the store sweep — the spend


### PR DESCRIPTION
## What

The step-4 retention filter in `refreshRoi` (`src/server/ctoBudget.mjs`) still carried BET-1466's assumption that a counted row dropped at the 60-day `ROI_PENDING_RETENTION_MS` horizon can never be re-counted, because "the delegate jobs store sweeps terminal records after 7 days". That assumption is false for a job that finished with a dirty worktree: `applyRetention` (`src/server/delegate.mjs`) spares a terminal record with `cleanedUp === false` by time AND by the 50-terminal-record cap, so the record can live forever. Dropping that job's counted fingerprint re-opens it to step 1's sampling — the same double-count the BET-1487 cap fixed, reached through the retention path and independent of job volume (one old dirty-worktree delegate job whose PR still reads merged is enough).

The retention drop is now liveness-aware, the same rule the cap applies: a counted row past the horizon survives while its id is still present in the refresh's jobs snapshot (`liveIds`), or while the snapshot read failed (liveness unknowable), and drops only once absence proves the record gone. Uncounted rows age out exactly as before (re-sampling one merely re-probes a never-counted job — no double count).

## How

- Extracted the inline filter as the pure, exported `retainPendingHorizon(rows, { cutoff, liveIds })` next to `trimPendingCap` (same DI/test convention); `liveIds` is computed once in step 4 and shared by both hygiene passes.
- Updated the stale step-4 comment (it stated the false BET-1466 rationale verbatim) and the `ROI_PENDING_RETENTION_MS` note.
- Tests: a pure-helper test (fresh keep / provably-dead drop / live-record sparing / failed-read sparing / null-timestamp counted keep) and a `refreshRoi` integration test reproducing the exact failure — a counted row past the horizon whose `cleanedUp: false` record is still returned by `jobsRead` keeps its fingerprint and never re-counts; once the record is swept, the row drops at the horizon with no re-sample.

## Anti-spaghetti notes

- Single site: the retention filter existed only inline in `refreshRoi`; the other `pending.filter` hits (`ctoCards.mjs`, `ctoTrust.mjs`) are unrelated lists. `index.mjs`'s `jobsRead` comment (BET-1487 read-failure semantics) stays accurate.
- Root cause (the false retention assumption), not the symptom: the fix lives in the shared hygiene step, not at any probe site.

## Verification results

- PR branch (`multica/BET-1497-roi-retention-liveness` @ `692a8c52`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3824` pass / `0` fail / `0` skip. Failures: none. log sha256: `443af44df04d130f23a5d54247b800ad32cfe74c73715ba7f9b9b13aded467d5`
- Base (`main` @ `705d6f5a`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3822` pass / `0` fail / `0` skip. Failures: none. log sha256: `c30f777bdab28569532f25a4e19642e355d6c3fec939abb5aeeb764b10aecb90`
- **Conclusion:** 0 test failures pre-existing, 0 new failures caused by this PR; the +2 delta is this PR's new BET-1497 tests.

`Base: origin/main @ 705d6f5a`

Follow-up: uncounted rows past the horizon whose dirty-worktree records live forever churn (re-sampled + re-probed every refresh, losing their `pr`/`prTried` markers each cycle) — pre-existing, report-only waste; filed separately.
