### PR TITLE
feat(server): wire real §6.7 checkable-verify surfaces into the facts engine (BET-1409)

### DIFF
--- a/src/server/ctoFactSurfaces.mjs
+++ b/src/server/ctoFactSurfaces.mjs
@@ -1,0 +1,175 @@
+// ctoFactSurfaces.mjs — BET-1409: the REAL §6.7 checkable-verify surfaces and
+// the §6.6 trace resolver, as one injectable bundle for createCtoEngine's
+// factSurfaceExists / factVerify / factResolveRef seams (which default to
+// no-ops, ctoEngine.mjs BET-1389 — nothing got stamped checkable without
+// this). Surfaces are OPPORTUNISTIC (§6.7): a fact is only stamped checkable
+// when its verification surface actually exists on the box —
+//   git   → a git binary AND the fact's project resolving to a git worktree
+//           (probe: `git cat-file -e`, which resolves branch names and
+//           commit/short-shas alike through the revision machinery)
+//   ci    → a gh binary AND a usable repo surface (probe polarity checked
+//           against the latest completed run's conclusion)
+//   issue → a multica binary AND a consented issue tool in the §7 registry
+//           ("a consented tool for issue facts" — consent metadata ring)
+// Any other surface (e.g. "version") is unimplemented here → surfaceExists
+// false → the fact stays an ordinary fact. A probe that cannot run (no cwd,
+// CLI error, no runs) is a FAILED check, not a crash — the engine's
+// verify-supersede path routes it through the gatekeeper.
+//
+// The trace resolver (§6.6 gatekeeper spot-check) resolves only what it can
+// CONFIDENTLY resolve — opencode message/session ids via the read-only db
+// handle and commit shas via git exec; everything else (file paths, issue
+// keys, opaque ids) passes with no opinion, because the spot-check must never
+// reject an honest proposal it merely fails to understand.
+
+export const COMMIT_SHA_RE = /^(?:[0-9a-f]{7,12}|[0-9a-f]{40})$/i;
+// Deliberately NOT 13-39 hex: a bare 32-hex string is a box_id (the token
+// identity model), not a commit — tracing it against git would reject honest
+// proposals. 7-12 covers the short shas agents copy from `git log --oneline`;
+// 40 is the full sha1 form.
+
+export const MESSAGE_REF_RE = /^(?:msg|ses|part)_[A-Za-z0-9]+$/;
+
+const CI_POSITIVE = new Set(["green", "passing", "passed"]);
+const CI_NEGATIVE = new Set(["failed", "failing", "broken"]);
+
+// Pure: does the latest completed run's conclusion confirm the statement's
+// CI-status probe? Positive probes ("CI is green") match success only;
+// negative probes ("CI is broken") match ANY completed non-success conclusion
+// (failure, cancelled, timed_out, startup_failure) — a run that did not
+// succeed confirms "broken".
+export function ciConclusionMatches(probe, conclusion) {
+  const p = String(probe ?? "").toLowerCase();
+  const c = String(conclusion ?? "").toLowerCase();
+  if (!p || !c) return false;
+  if (CI_POSITIVE.has(p)) return c === "success";
+  if (CI_NEGATIVE.has(p)) return c !== "success";
+  return false;
+}
+
+export function createFactSurfaces(deps = {}) {
+  const {
+    // async (project|null) → ordered candidate cwds. A project (tmux session
+    // name — the facts store's project key) narrows to that project's
+    // worktree(s); null (the trace resolver's commit check) yields every
+    // known project cwd, first match wins.
+    cwdsFor = async () => [],
+    // async (cwd, args) → stdout; THROWS on non-zero exit.
+    runGit = async () => {
+      throw new Error("runGit not wired");
+    },
+    // async (name) → boolean — binary presence on PATH.
+    hasBinary = async () => false,
+    // async (cwd) → boolean — is this directory a usable verification
+    // surface (a git worktree; the wiring adds the origin-remote requirement
+    // it needs for CI). Absent → every cwd is treated as ready.
+    gitRepoReady = null,
+    // async (key) → { found: boolean, open: boolean } | null (null =
+    // lookup unavailable). `open` is authoritative: done/cancelled → false.
+    issueLookup = async () => null,
+    // async (cwd) → latest COMPLETED workflow run's conclusion string, or
+    // null when none/unknown (gh error, no runs yet).
+    ciLatestConclusion = async () => null,
+    // async (id) → boolean | null (null = db unavailable → no opinion).
+    messageExists = async () => null,
+    // async () → boolean — the §7 registry reports an issue tool whose
+    // metadata consent ring is "yes".
+    issueToolConsented = async () => false,
+  } = deps;
+
+  async function readyCwds(project) {
+    const out = [];
+    for (const cwd of await cwdsFor(project ?? null)) {
+      if (typeof cwd !== "string" || !cwd) continue;
+      if (!gitRepoReady || (await gitRepoReady(cwd).catch(() => false))) out.push(cwd);
+    }
+    return out;
+  }
+
+  // §6.7 surface guard — called by maybeStampCheckable with
+  // { project } ctx (the facts store key). No surface → no stamp.
+  async function surfaceExists(surface, ctx = {}) {
+    try {
+      if (surface === "git") {
+        if (!(await hasBinary("git"))) return false;
+        return (await readyCwds(ctx?.project)).length > 0;
+      }
+      if (surface === "ci") {
+        if (!(await hasBinary("gh"))) return false;
+        return (await readyCwds(ctx?.project)).length > 0;
+      }
+      if (surface === "issue") {
+        if (!(await hasBinary("multica"))) return false;
+        return (await issueToolConsented()) === true;
+      }
+      return false; // "version" and anything unknown → ordinary fact
+    } catch {
+      return false;
+    }
+  }
+
+  // §6.7 verify probe — called by verifyDue as
+  // { surface, probe, project }. Returns { ok, result }.
+  async function verify({ surface, probe, project } = {}) {
+    if (surface === "git") {
+      const cwds = await readyCwds(project ?? null).catch(() => []);
+      if (cwds.length === 0) return { ok: false, result: "no surface" };
+      try {
+        await runGit(cwds[0], ["cat-file", "-e", String(probe ?? "")]);
+        return { ok: true, result: "exists" };
+      } catch {
+        return { ok: false, result: "missing" };
+      }
+    }
+    if (surface === "ci") {
+      const cwds = await readyCwds(project ?? null).catch(() => []);
+      if (cwds.length === 0) return { ok: false, result: "no surface" };
+      const conclusion = await ciLatestConclusion(cwds[0]).catch(() => null);
+      if (!conclusion) return { ok: false, result: "unavailable" };
+      return { ok: ciConclusionMatches(probe, conclusion), result: String(conclusion) };
+    }
+    if (surface === "issue") {
+      const r = await issueLookup(String(probe ?? "")).catch(() => null);
+      if (!r) return { ok: false, result: "unavailable" };
+      if (!r.found) return { ok: false, result: "not-found" };
+      return { ok: r.open === true, result: r.open ? "open" : "closed" };
+    }
+    return { ok: false, result: "no surface" };
+  }
+
+  // §6.6 trace spot-check — gatekeeperPrecheck calls resolveRef(ref) === true
+  // per ref; ANY throw counts as unresolved, so this never throws. Only
+  // confidently-recognizable shapes are traced; everything else passes with
+  // no opinion (never punish a proposal for a ref we can't interpret).
+  async function resolveRef(ref) {
+    const s = String(ref ?? "").trim();
+    if (!s) return false;
+    try {
+      if (MESSAGE_REF_RE.test(s)) {
+        const exists = await messageExists(s);
+        return exists !== false; // null (no db) → no opinion → pass
+      }
+      if (COMMIT_SHA_RE.test(s)) {
+        // Try every ready git surface — facts cite commits from whatever repo
+        // the work was about, and the box hosts several checkouts. No ready
+        // cwd at all → no opinion.
+        const cwds = await readyCwds(null).catch(() => []);
+        if (cwds.length === 0) return true;
+        for (const cwd of cwds) {
+          try {
+            await runGit(cwd, ["cat-file", "-e", s]);
+            return true;
+          } catch {
+            /* not in this repo — try the next candidate */
+          }
+        }
+        return false;
+      }
+      return true; // file paths, issue keys, opaque ids — no opinion
+    } catch {
+      return true;
+    }
+  }
+
+  return { surfaceExists, verify, resolveRef };
+}

--- a/src/server/ctoFactSurfaces.test.mjs
+++ b/src/server/ctoFactSurfaces.test.mjs
@@ -1,0 +1,243 @@
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
+
+// ctoFactSurfaces.test.mjs — BET-1409: the real §6.7 checkable-verify
+// surfaces + §6.6 trace resolver, exercised through fakes only (no live
+// tmux/git/multica/gh — every dep is injected).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { COMMIT_SHA_RE, MESSAGE_REF_RE, ciConclusionMatches, createFactSurfaces } from "./ctoFactSurfaces.mjs";
+
+function makeSurfaces(over = {}) {
+  const calls = { surfaceExists: [], verify: [], resolveRef: [] };
+  const surfaces = createFactSurfaces({
+    cwdsFor: async (project) => (project == null ? ["/repo/a", "/repo/b"] : project === "p1" ? ["/repo/p1"] : []),
+    runGit: async (cwd, args) => {
+      if (args[0] === "cat-file" && args[2] === "ghost") throw new Error("not found");
+      return "";
+    },
+    hasBinary: async (name) => ["git", "gh", "multica"].includes(name),
+    issueLookup: async (key) => (key === "BET-1" ? { found: true, open: true } : key === "BET-2" ? { found: true, open: false } : null),
+    ciLatestConclusion: async (cwd) => (cwd === "/repo/p1" ? "success" : null),
+    messageExists: async (id) => (id === "msg_ghost" ? false : id === "msg_ok" ? true : null),
+    issueToolConsented: async () => true,
+    ...over,
+  });
+  return { surfaces, calls };
+}
+
+// ---------------------------------------------------------------------------
+// ciConclusionMatches (pure probe polarity)
+// ---------------------------------------------------------------------------
+
+test("ciConclusionMatches: positive probes match success only", () => {
+  for (const p of ["green", "passing", "passed"]) {
+    assert.equal(ciConclusionMatches(p, "success"), true, p);
+    assert.equal(ciConclusionMatches(p, "failure"), false, p);
+    assert.equal(ciConclusionMatches(p, "cancelled"), false, p);
+  }
+});
+
+test("ciConclusionMatches: negative probes match any completed non-success", () => {
+  for (const p of ["failed", "failing", "broken"]) {
+    assert.equal(ciConclusionMatches(p, "failure"), true, p);
+    assert.equal(ciConclusionMatches(p, "timed_out"), true, p);
+    assert.equal(ciConclusionMatches(p, "startup_failure"), true, p);
+    assert.equal(ciConclusionMatches(p, "success"), false, p);
+  }
+  assert.equal(ciConclusionMatches("unknown-probe", "success"), false);
+  assert.equal(ciConclusionMatches("green", ""), false);
+});
+
+// ---------------------------------------------------------------------------
+// surfaceExists — the §6.7 opportunism guard
+// ---------------------------------------------------------------------------
+
+test("surfaceExists git: requires the binary AND a git-ready cwd for the project", async () => {
+  const { surfaces } = makeSurfaces();
+  assert.equal(await surfaces.surfaceExists("git", { project: "p1" }), true);
+  assert.equal(await surfaces.surfaceExists("git", { project: "gone" }), false);
+  const noBin = makeSurfaces({ hasBinary: async () => false });
+  assert.equal(await noBin.surfaces.surfaceExists("git", { project: "p1" }), false);
+  const noRepo = makeSurfaces({ gitRepoReady: async () => false });
+  assert.equal(await noRepo.surfaces.surfaceExists("git", { project: "p1" }), false);
+});
+
+test("surfaceExists ci: requires gh AND a git-ready cwd", async () => {
+  const { surfaces } = makeSurfaces();
+  assert.equal(await surfaces.surfaceExists("ci", { project: "p1" }), true);
+  assert.equal(await surfaces.surfaceExists("ci", { project: "gone" }), false);
+  const noGh = makeSurfaces({ hasBinary: async (n) => n === "git" });
+  assert.equal(await noGh.surfaces.surfaceExists("ci", { project: "p1" }), false);
+});
+
+test("surfaceExists issue: requires the multica binary AND consented issue tool", async () => {
+  const { surfaces } = makeSurfaces();
+  assert.equal(await surfaces.surfaceExists("issue"), true);
+  const noConsent = makeSurfaces({ issueToolConsented: async () => false });
+  assert.equal(await noConsent.surfaces.surfaceExists("issue"), false);
+  const noCli = makeSurfaces({ hasBinary: async (n) => n !== "multica" });
+  assert.equal(await noCli.surfaces.surfaceExists("issue"), false);
+});
+
+test("surfaceExists: unimplemented surfaces (version) stay false — ordinary facts", async () => {
+  const { surfaces } = makeSurfaces();
+  assert.equal(await surfaces.surfaceExists("version"), false);
+  assert.equal(await surfaces.surfaceExists("bogus"), false);
+  assert.equal(await surfaces.surfaceExists(undefined), false);
+});
+
+test("surfaceExists: a throwing dep degrades to false, never a throw into the engine", async () => {
+  const { surfaces } = makeSurfaces({ cwdsFor: async () => { throw new Error("tmux down"); } });
+  assert.equal(await surfaces.surfaceExists("git", { project: "p1" }), false);
+});
+
+// ---------------------------------------------------------------------------
+// verify — the §6.7 probe
+// ---------------------------------------------------------------------------
+
+test("verify git: cat-file -e confirms branch/commit probes in the project cwd", async () => {
+  const seen = [];
+  const { surfaces } = makeSurfaces({
+    runGit: async (cwd, args) => {
+      seen.push([cwd, args]);
+      if (args[2] === "ghost") throw new Error("not found");
+      return "";
+    },
+  });
+  assert.deepEqual(await surfaces.verify({ surface: "git", probe: "multica/BET-1/x", project: "p1" }), {
+    ok: true,
+    result: "exists",
+  });
+  assert.deepEqual(await surfaces.verify({ surface: "git", probe: "a8df41a9", project: "p1" }), {
+    ok: true,
+    result: "exists",
+  });
+  assert.deepEqual(await surfaces.verify({ surface: "git", probe: "ghost", project: "p1" }), {
+    ok: false,
+    result: "missing",
+  });
+  assert.equal(seen.length, 3);
+  assert.equal(seen[0][0], "/repo/p1");
+  assert.deepEqual(seen[0][1], ["cat-file", "-e", "multica/BET-1/x"]);
+});
+
+test("verify git: no ready cwd → failed check, not a crash", async () => {
+  const { surfaces } = makeSurfaces({ gitRepoReady: async () => false });
+  assert.deepEqual(await surfaces.verify({ surface: "git", probe: "main", project: "p1" }), {
+    ok: false,
+    result: "no surface",
+  });
+});
+
+test("verify ci: probe polarity against the latest completed conclusion", async () => {
+  const { surfaces } = makeSurfaces();
+  assert.equal((await surfaces.verify({ surface: "ci", probe: "green", project: "p1" })).ok, true);
+  assert.equal((await surfaces.verify({ surface: "ci", probe: "failed", project: "p1" })).ok, false);
+  // A ready cwd with no completed run → unavailable (a failed check, not ok).
+  const noRuns = makeSurfaces({ ciLatestConclusion: async () => null });
+  const r = await noRuns.surfaces.verify({ surface: "ci", probe: "green", project: "p1" });
+  assert.equal(r.ok, false);
+  assert.equal(r.result, "unavailable");
+  // No cwd at all → no surface.
+  const gone = await surfaces.verify({ surface: "ci", probe: "green", project: "other" });
+  assert.equal(gone.ok, false);
+  assert.equal(gone.result, "no surface");
+});
+
+test("verify issue: open → ok, closed/not-found/unavailable → not ok", async () => {
+  const { surfaces } = makeSurfaces();
+  assert.deepEqual(await surfaces.verify({ surface: "issue", probe: "BET-1" }), { ok: true, result: "open" });
+  assert.deepEqual(await surfaces.verify({ surface: "issue", probe: "BET-2" }), { ok: false, result: "closed" });
+  const unavailable = await surfaces.verify({ surface: "issue", probe: "NOPE-9" });
+  assert.equal(unavailable.ok, false);
+  assert.equal(unavailable.result, "unavailable");
+});
+
+test("verify: unknown surface → failed", async () => {
+  const { surfaces } = makeSurfaces();
+  assert.deepEqual(await surfaces.verify({ surface: "version", probe: "1.2.3" }), {
+    ok: false,
+    result: "no surface",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRef — the §6.6 trace spot-check (never over-rejects)
+// ---------------------------------------------------------------------------
+
+test("resolveRef: message ids resolve via the db handle; null db is no-opinion", async () => {
+  const { surfaces } = makeSurfaces();
+  assert.equal(await surfaces.resolveRef("msg_ok"), true);
+  assert.equal(await surfaces.resolveRef("msg_ghost"), false);
+  assert.equal(await surfaces.resolveRef("ses_fa184ccccffey4AFyFsPG9w1T2"), true);
+  const noDb = makeSurfaces({ messageExists: async () => null });
+  assert.equal(await noDb.surfaces.resolveRef("msg_ghost"), true);
+});
+
+test("resolveRef: commit shas resolve against ANY candidate cwd", async () => {
+  const tried = [];
+  const { surfaces } = makeSurfaces({
+    // Only /repo/b knows ONE specific sha — the null-project candidate list
+    // must all be tried before the spot-check gives up.
+    runGit: async (cwd, args) => {
+      tried.push([cwd, args[2]]);
+      if (cwd !== "/repo/b" || args[2] !== "a8df41a9") throw new Error("not found");
+      return "";
+    },
+  });
+  assert.equal(await surfaces.resolveRef("a8df41a9"), true);
+  assert.deepEqual(tried, [["/repo/a", "a8df41a9"], ["/repo/b", "a8df41a9"]]);
+  tried.length = 0;
+  assert.equal(await surfaces.resolveRef("deadbee"), false);
+  assert.deepEqual(tried, [["/repo/a", "deadbee"], ["/repo/b", "deadbee"]]);
+});
+
+test("resolveRef: a 32-hex box_id is NOT a commit — no opinion, never a rejection", async () => {
+  const tried = [];
+  const { surfaces } = makeSurfaces({
+    runGit: async (cwd, args) => {
+      tried.push(args[2]);
+      return "";
+    },
+  });
+  assert.equal(await surfaces.resolveRef("ab49c3e2023943cb81cf32d3ee9102f2"), true);
+  assert.deepEqual(tried, [], "box ids must not be cat-file'd");
+});
+
+test("resolveRef: git-less box, unknown shapes, empty → no-opinion pass / empty fails", async () => {
+  const noGit = makeSurfaces({ hasBinary: async () => false, gitRepoReady: async () => false });
+  assert.equal(await noGit.surfaces.resolveRef("a8df41a9"), true);
+  const { surfaces } = makeSurfaces();
+  assert.equal(await surfaces.resolveRef("src/server/ctoFacts.mjs"), true);
+  assert.equal(await surfaces.resolveRef("BET-1409"), true);
+  assert.equal(await surfaces.resolveRef("https://github.com/x/y/pull/1"), true);
+  assert.equal(await surfaces.resolveRef(""), false);
+  assert.equal(await surfaces.resolveRef(null), false);
+});
+
+test("resolveRef: throwing deps degrade to no-opinion, never a throw", async () => {
+  const { surfaces } = makeSurfaces({ messageExists: async () => { throw new Error("db boom"); } });
+  assert.equal(await surfaces.resolveRef("msg_ok"), true);
+});
+
+// ---------------------------------------------------------------------------
+// regex shapes
+// ---------------------------------------------------------------------------
+
+test("ref regexes: commit shapes (7-12 hex, full sha1) and opencode ids", () => {
+  assert.ok(COMMIT_SHA_RE.test("a8df41a"));
+  assert.ok(COMMIT_SHA_RE.test("a8df41a9"));
+  assert.ok(COMMIT_SHA_RE.test("a8df41a999b"));
+  assert.ok(COMMIT_SHA_RE.test("a8df41a999bbbbccccddddeeeeffff0000111122"));
+  assert.ok(!COMMIT_SHA_RE.test("a8df41")); // 6 — too short
+  assert.ok(!COMMIT_SHA_RE.test("ab49c3e2023943cb81cf32d3ee9102f2")); // 32-hex box_id
+  assert.ok(!COMMIT_SHA_RE.test("msg_00e7066d0001cUkaSdjol8L1SO"));
+  assert.ok(!COMMIT_SHA_RE.test("BET-1409"));
+  assert.ok(MESSAGE_REF_RE.test("msg_00e7066d0001cUkaSdjol8L1SO"));
+  assert.ok(MESSAGE_REF_RE.test("ses_fa184ccccffey4AFyFsPG9w1T2"));
+  assert.ok(MESSAGE_REF_RE.test("part_abc123"));
+  assert.ok(!MESSAGE_REF_RE.test("a8df41a"));
+  assert.ok(!MESSAGE_REF_RE.test("msg-00e7066d"));
+});

--- a/src/server/ctoFactSurfacesWiring.test.mjs
+++ b/src/server/ctoFactSurfacesWiring.test.mjs
@@ -1,0 +1,80 @@
+// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+import "./ctoTestGuard.mjs";
+
+// ctoFactSurfacesWiring.test.mjs — BET-1409 wiring gate. index.mjs cannot be
+// imported (it boots the server on import), so the wiring is asserted by a
+// brace-balanced source scan (same discipline as ctoBudgetWiring.test.mjs):
+// the three §6.7 seams MUST sit inside the `createCtoEngine({...})`
+// construction that feeds the facts engine, and MUST reference the
+// factSurfaces bundle. A seam stranded in any other deps literal is silently
+// ignored by createCtoEngine — the feature would stay dormant behind green
+// unit tests, exactly the failure mode this gate exists for.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const indexSource = readFileSync(join(here, "index.mjs"), "utf8");
+
+function depsBlock(source, openMarker) {
+  const call = source.indexOf(openMarker);
+  if (call === -1) return "";
+  const open = source.indexOf("{", call);
+  let depth = 0;
+  let quote = null;
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
+    const prev = i > 0 ? source[i - 1] : "";
+    const next = i + 1 < source.length ? source[i + 1] : "";
+    if (quote) {
+      if (ch === quote && prev !== "\\") quote = null;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      i = source.indexOf("\n", i);
+      if (i === -1) break;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open, i + 1);
+    }
+  }
+  return "";
+}
+
+function engineDeps() {
+  return depsBlock(indexSource, "ctoEngine.createCtoEngine({");
+}
+
+test("BET-1409: the three §6.7 fact seams are wired inside createCtoEngine's deps", () => {
+  const deps = engineDeps();
+  assert.ok(deps.length > 0, "createCtoEngine deps block found");
+  for (const seam of ["factSurfaceExists", "factVerify", "factResolveRef"]) {
+    assert.ok(deps.includes(`${seam}:`), `${seam} must sit inside the createCtoEngine deps block`);
+  }
+  assert.ok(deps.includes("factSurfaces.surfaceExists"), "factSurfaceExists delegates to the factSurfaces bundle");
+  assert.ok(deps.includes("factSurfaces.verify"), "factVerify delegates to the factSurfaces bundle");
+  assert.ok(deps.includes("factSurfaces.resolveRef"), "factResolveRef delegates to the factSurfaces bundle");
+});
+
+test("BET-1409: the factSurfaces bundle is constructed with the real surface deps", () => {
+  const open = indexSource.indexOf("createFactSurfaces({");
+  assert.ok(open !== -1, "createFactSurfaces construction present in index.mjs");
+  const block = depsBlock(indexSource, "createFactSurfaces({");
+  for (const dep of ["cwdsFor", "runGit", "hasBinary", "gitRepoReady", "issueLookup", "ciLatestConclusion", "messageExists", "issueToolConsented"]) {
+    assert.ok(block.includes(`${dep}:`), `factSurfaces dep ${dep} must be wired`);
+  }
+  // The issue surface is consent-gated through the §7 tool registry.
+  assert.ok(block.includes("getTools().listTools()"), "issueToolConsented must read the tool registry");
+  // The message-id leg rides the shared read-only opencode db handle.
+  assert.ok(block.includes("getDb()"), "messageExists must ride the opencodeDb handle");
+});

--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -562,13 +562,15 @@ export function matchCheckable(statement) {
   return null;
 }
 
-export async function maybeStampCheckable(fact, { surfaceExists = async () => false } = {}) {
+export async function maybeStampCheckable(fact, { surfaceExists = async () => false, project = null } = {}) {
   if (fact?.checkable) return fact;
   const match = matchCheckable(fact?.statement);
   if (!match || typeof surfaceExists !== "function") return fact;
   let exists = false;
   try {
-    exists = (await surfaceExists(match.surface)) === true;
+    // BET-1409: the surface guard receives the fact's project (the facts
+    // store key) so the real §6.7 surfaces can resolve a cwd / consent scope.
+    exists = (await surfaceExists(match.surface, { project })) === true;
   } catch {
     exists = false;
   }
@@ -831,7 +833,7 @@ export function createFactsEngine(deps = {}) {
           const newId = result.factId;
           const fi = newId ? activeFacts.findIndex((f) => f.id === newId) : -1;
           if (fi >= 0) {
-            const stamped = await maybeStampCheckable(activeFacts[fi], { surfaceExists });
+            const stamped = await maybeStampCheckable(activeFacts[fi], { surfaceExists, project: proj });
             if (stamped !== activeFacts[fi]) activeFacts[fi] = stamped;
           }
           await saveFacts(proj, activeFacts);
@@ -910,7 +912,9 @@ export function createFactsEngine(deps = {}) {
         let ok = false;
         let result = null;
         try {
-          const r = await verify({ surface: matchCheckable(f.statement)?.surface, probe: f.checkable.probe });
+          // BET-1409: verify receives the project so the real §6.7 surfaces
+          // can resolve the probe's cwd (git worktree / CI repo scope).
+          const r = await verify({ surface: matchCheckable(f.statement)?.surface, probe: f.checkable.probe, project: proj });
           ok = r?.ok === true;
           result = r?.result ?? null;
         } catch {

--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -784,11 +784,38 @@ export function createFactsEngine(deps = {}) {
     return { ...st, factReliability: rel };
   }
 
+  // §6.4 reliability accumulator shared by pump and verifyDue — the
+  // duplication gate blocks per-function clones of this 10-line note/merge
+  // pattern (reviewer Block on BET-1409 PR #1483; the clone pre-existed on
+  // main but any PR touching ctoFacts.mjs goes red until it is extracted).
+  // Each loop collects per-sender deltas locally and merges them into the
+  // engine state once, at the end.
+  function createRelTracker() {
+    const relDeltas = new Map(); // senderKey -> {confirmed, rejected}
+    return {
+      note: (sender, delta) => {
+        const key = senderKey(sender);
+        if (!key) return;
+        const e = relDeltas.get(key) ?? { confirmed: 0, rejected: 0 };
+        relDeltas.set(key, {
+          confirmed: e.confirmed + (delta.confirmed ?? 0),
+          rejected: e.rejected + (delta.rejected ?? 0),
+        });
+      },
+      mergeInto: (st) => {
+        let merged = st;
+        for (const [key, delta] of relDeltas) merged = mergeReliability(merged, key, delta);
+        return merged;
+      },
+      size: () => relDeltas.size,
+    };
+  }
+
   async function pump(project) {
     if (disposed) return { processed: 0, byAction: {} };
     let state = await loadState();
     const tally = { processed: 0, byAction: {} };
-    const relDeltas = new Map(); // senderKey -> {confirmed, rejected}
+    const rel = createRelTracker();
     // §6.4: per-fact sender reliability (Beta mean) feeds the retention/displacement
     // ranking. Unseen senders default to 1 (neutral) until they earn counters.
     const relOf = (fact) => {
@@ -796,15 +823,6 @@ export function createFactsEngine(deps = {}) {
       if (!k) return 1;
       const c = state.factReliability?.[k];
       return c ? senderReliability(c) : 1;
-    };
-    const noteRel = (sender, delta) => {
-      const key = senderKey(sender);
-      if (!key) return;
-      const e = relDeltas.get(key) ?? { confirmed: 0, rejected: 0 };
-      relDeltas.set(key, {
-        confirmed: e.confirmed + (delta.confirmed ?? 0),
-        rejected: e.rejected + (delta.rejected ?? 0),
-      });
     };
     const projects = project ? [project] : Object.keys(state.factQueue ?? {});
     for (const proj of projects) {
@@ -820,7 +838,7 @@ export function createFactsEngine(deps = {}) {
         let outcome;
         if (result.reject) {
           outcome = { action: "reject", reason: result.reason };
-          noteRel(proposal.sender, { rejected: 1 });
+          rel.note(proposal.sender, { rejected: 1 });
           await log({ kind: "cto.fact_reject", project: proj, proposalId: proposal.proposalId, reason: result.reason });
         } else {
           const capRes = enforceCap(result.facts, { cap: CAP_ACTIVE, nowMs: now(), halfLives: halfLivesNow, reliabilityOf: relOf });
@@ -848,7 +866,7 @@ export function createFactsEngine(deps = {}) {
               await saveState({ ...st, factTuning: { ...(st.factTuning ?? {}), lifespans } });
             }
             if (old && now() - (old.created ?? 0) < OVERTURN_WINDOW_MS) {
-              noteRel(old.sender, { rejected: 1 });
+              rel.note(old.sender, { rejected: 1 });
             }
           }
         }
@@ -857,9 +875,7 @@ export function createFactsEngine(deps = {}) {
         tally.byAction[outcome.action] = (tally.byAction[outcome.action] ?? 0) + 1;
       }
     }
-    for (const [key, delta] of relDeltas) {
-      state = mergeReliability(state, key, delta);
-    }
+    state = rel.mergeInto(state);
     await saveState(state);
     return tally;
   }
@@ -891,16 +907,7 @@ export function createFactsEngine(deps = {}) {
     let superseded = 0;
     let seq = 0;
     let state = await loadState();
-    const relDeltas = new Map();
-    const noteRel = (sender, delta) => {
-      const key = senderKey(sender);
-      if (!key) return;
-      const e = relDeltas.get(key) ?? { confirmed: 0, rejected: 0 };
-      relDeltas.set(key, {
-        confirmed: e.confirmed + (delta.confirmed ?? 0),
-        rejected: e.rejected + (delta.rejected ?? 0),
-      });
-    };
+    const rel = createRelTracker();
     for (const proj of await listKnownProjects()) {
       let working = await loadFacts(proj);
       let changed = false;
@@ -927,7 +934,7 @@ export function createFactsEngine(deps = {}) {
         if (ok) {
           changed = true;
           // §6.6: a verify-pass is a confirmed instance of the origin sender.
-          noteRel(f.sender, { confirmed: 1 });
+          rel.note(f.sender, { confirmed: 1 });
         }
       }
       for (const { f, ok } of failed) {
@@ -960,10 +967,8 @@ export function createFactsEngine(deps = {}) {
       }
       if (changed) await saveFacts(proj, working);
     }
-    for (const [key, delta] of relDeltas) {
-      state = mergeReliability(state, key, delta);
-    }
-    if (relDeltas.size > 0) await saveState(state);
+    state = rel.mergeInto(state);
+    if (rel.size() > 0) await saveState(state);
     return { checked, superseded };
   }
 

--- a/src/server/ctoFacts.test.mjs
+++ b/src/server/ctoFacts.test.mjs
@@ -432,6 +432,31 @@ test("checkable: stamping honors surface-exists; verify supersedes failures", as
   assert.ok(live.length >= 1);
 });
 
+// BET-1409: the real §6.7 surfaces need the fact's project (the store key) to
+// resolve a cwd / consent scope — pump and verifyDue must pass it through.
+test("checkable: pump and verifyDue pass the project ctx to the surface seams", async () => {
+  const seenSurface = [];
+  const seenVerify = [];
+  const { engine, facts } = makeEngine({
+    surfaceExists: async (s, ctx) => {
+      seenSurface.push([s, ctx]);
+      return s === "git";
+    },
+    verify: async (args) => {
+      seenVerify.push(args);
+      return { ok: true };
+    },
+  });
+  await engine.submitProposal({ proposalId: "cx", project: "alpha", kind: "status", statement: "branch fix/a is merged", refs: ["r1"] });
+  await engine.pump();
+  assert.ok(seenSurface.length >= 1, "surfaceExists consulted at stamp time");
+  assert.ok(seenSurface.some(([s, ctx]) => s === "git" && ctx?.project === "alpha"), "surfaceExists receives { project }");
+  await engine.verifyDue();
+  assert.ok(seenVerify.length >= 1, "verify consulted on the cycle");
+  assert.equal(seenVerify[0].project, "alpha", "verify receives the project");
+  assert.equal(seenVerify[0].surface, "git");
+});
+
 test("touchFacts bumps last_accessed + access_count on retrieval", async () => {
   const { engine, facts } = makeEngine();
   await engine.submitProposal({ proposalId: "ta", project: "alpha", kind: "status", statement: "touched", refs: ["r1"] });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -143,6 +143,7 @@ import * as appControl from "./appControl.mjs";
 import * as cto from "./cto.mjs";
 import * as ctoEngine from "./ctoEngine.mjs";
 import * as ctoBudget from "./ctoBudget.mjs";
+import { createFactSurfaces } from "./ctoFactSurfaces.mjs";
 import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore, digestsStore, factsStore, startCtoStoreSweeper, CTO_STORE_SWEEP_INTERVAL_MS } from "./ctoStores.mjs";
 import * as ctoOvernight from "./ctoOvernight.mjs";
 import { computeHealthStats } from "./ctoHealth.mjs";
@@ -2014,6 +2015,101 @@ async function collectGitRemotes() {
   return out;
 }
 
+// BET-1409: the REAL §6.7 checkable-verify surfaces + §6.6 trace resolver
+// (src/server/ctoFactSurfaces.mjs), injected through the facts engine's
+// no-op-default seams below. Every probe is a bounded local/CLI exec — no
+// model cost (§6.7) — and every failure degrades to "not ok"/"no opinion",
+// never a throw into the engine. Surfaces stay OPPORTUNISTIC: no git
+// worktree / no gh / no consented issue tool → the matching facts are never
+// stamped checkable (the BET-1389 default behavior for unimplemented kinds).
+const factSurfaces = createFactSurfaces({
+  // project (the facts store key = tmux session name) → its worktree cwd;
+  // null (the trace resolver's commit check) → every known project cwd.
+  cwdsFor: async (project) => {
+    let projects = [];
+    try {
+      projects = await tmux.listProjects();
+    } catch {
+      return [];
+    }
+    const rows = (Array.isArray(projects) ? projects : []).filter((p) => typeof p?.cwd === "string" && p.cwd);
+    if (project != null) return rows.filter((p) => p.tmuxSession === project).map((p) => p.cwd);
+    return rows.map((p) => p.cwd);
+  },
+  runGit: async (cwd, args) => (await promisify(execFile)("git", ["-C", cwd, ...args], { timeout: 5000 })).stdout,
+  hasBinary: async (name) => {
+    try {
+      await promisify(execFile)("sh", ["-c", `command -v ${name}`], { timeout: 5000 });
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  // A cwd is a usable verification surface only when it IS a worktree with a
+  // forge remote — branch probes cat-file locally, and `gh run list` resolves
+  // the repo from that remote. Conservative for both surfaces: a repo
+  // without origin simply never stamps checkable facts (§6.7 opportunism).
+  gitRepoReady: async (cwd) => {
+    try {
+      await promisify(execFile)("git", ["-C", cwd, "rev-parse", "--git-dir"], { timeout: 5000 });
+      await promisify(execFile)("git", ["-C", cwd, "remote", "get-url", "origin"], { timeout: 5000 });
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  // `multica issue get` — exit 0 = found; the status field decides open vs
+  // closed (done/cancelled close a "BET-N …" fact). Any CLI failure (auth,
+  // network, foreign-workspace key) degrades to unavailable via the module's
+  // catch — a failed lookup is not evidence of a closed issue.
+  issueLookup: async (key) => {
+    const { stdout } = await promisify(execFile)("multica", ["issue", "get", String(key), "--output", "json"], {
+      timeout: 15000,
+    });
+    const data = JSON.parse(stdout);
+    const status = String(data?.status ?? "");
+    return { found: true, open: status !== "done" && status !== "cancelled" };
+  },
+  // Latest COMPLETED workflow run's conclusion in the repo at cwd (newest
+  // first). No completed run (fresh repo, gh error) → null → "unavailable".
+  ciLatestConclusion: async (cwd) => {
+    const { stdout } = await promisify(execFile)("gh", ["run", "list", "--limit", "10", "--json", "conclusion,status"], {
+      cwd,
+      timeout: 15000,
+    });
+    const runs = JSON.parse(stdout);
+    const latest = (Array.isArray(runs) ? runs : []).find(
+      (r) => r?.status === "completed" && typeof r?.conclusion === "string",
+    );
+    return latest?.conclusion ?? null;
+  },
+  // §6.6 trace resolver's message-id leg — the read-only opencode db (same
+  // handle the ⌘F search uses). ses_/msg_/part_ ids map to their tables; a
+  // null db (no Node 24 runtime) → null → no opinion.
+  messageExists: async (id) => {
+    const db = await getDb();
+    if (!db) return null;
+    const key = String(id);
+    const table = key.startsWith("ses_") ? "session" : key.startsWith("part_") ? "part" : "message";
+    const row = db.prepare(`SELECT 1 FROM ${table} WHERE id = ? LIMIT 1`).get(key);
+    return row != null;
+  },
+  // §6.7 "a consented tool for issue facts": the §7 registry's metadata
+  // consent ring for the box's issue tool (multica / issue-tracker identity).
+  // Unasked or revoked consent → the issue surface does not exist. Lazy
+  // adaptiveCto read — the registry engine is constructed on first call.
+  issueToolConsented: async () => {
+    try {
+      const tools = await adaptiveCto.getTools().listTools();
+      return (Array.isArray(tools) ? tools : []).some(
+        (t) => /^(?:multica|issue-tracker)(?:[-/].*)?$/i.test(String(t?.tool ?? "")) && t?.consent?.metadata === "yes",
+      );
+    } catch {
+      return false;
+    }
+  },
+});
+
 const adaptiveCto = ctoEngine.createCtoEngine({
   configGet: () => local.configGet(),
   ledger: ledgerStore,
@@ -2077,6 +2173,13 @@ const adaptiveCto = ctoEngine.createCtoEngine({
   // its own one-time spend bound, so they bypass the engine's §3.3 rate gate.
   getDb,
   backfillRunEphemeral: runEphemeral,
+  // BET-1409: real §6.7 checkable-verify surfaces + §6.6 trace resolver —
+  // replaces these seams' no-op defaults so facts CAN be stamped checkable
+  // and verify-supersessions can fire (each guarded by surfaceExists, so
+  // stamping stays opportunistic).
+  factSurfaceExists: (surface, ctx) => factSurfaces.surfaceExists(surface, ctx),
+  factVerify: (args) => factSurfaces.verify(args),
+  factResolveRef: (ref) => factSurfaces.resolveRef(ref),
   cardFireNotify: (args) => push.fireNotify(args),
   // BET-1398: one-time migration of the superseded cto.json watcher poller's
   // watches into the standing-query engine (idempotent, marker-guarded).


### PR DESCRIPTION
## BET-1409 — Wire real §6.7 checkable-verify surfaces into the facts engine

Base: origin/main @ `a8df41a9`

### What

BET-1389's checkable-facts machinery shipped with the `factSurfaceExists` / `factVerify` / `factResolveRef` seams defaulting to no-ops — no fact was ever stamped checkable and no verify-supersession ever fired. This wires the real, deterministic surfaces through those seams:

- **git** — `git cat-file -e` in the fact's project worktree (resolves branch names and commit/short-shas alike through the revision machinery). Surface exists = git binary + a worktree-with-origin for the fact's tmux project.
- **ci** — probe polarity (`green`↔success, `failed/broken`↔any completed non-success) against the latest completed `gh run list` conclusion. Surface exists = gh binary + the same repo surface.
- **issue** — `multica issue get <KEY>`: open → confirmed, done/cancelled → failed check. Surface exists = multica binary **and** the §7 tool registry reporting metadata consent "yes" for the box's issue tool (`multica`/`issue-tracker` identity) — §6.7 "a consented tool for issue facts". Until consent is granted this surface stays dormant (opportunism, by design).
- **§6.6 `resolveRef` trace resolver** — message/session/part ids via the shared read-only opencodeDb handle; commit shas (7–12 hex short, 40 full; deliberately NOT 13–39 hex — a bare 32-hex string is a box_id, not a commit) via cat-file across candidate project cwds; everything else (file paths, issue keys, opaque ids) passes with no opinion so the spot-check never rejects an honest proposal it can't interpret.

New pure module `src/server/ctoFactSurfaces.mjs` (injected deps, degradation never throws); `ctoFacts.mjs` additively threads the fact's project (the store key) into `maybeStampCheckable`/`verifyDue` so the surfaces can resolve a cwd/consent scope; `index.mjs` builds the bundle (tmux project→cwd, bounded execs, getDb, registry consent) and passes the three seams in the `createCtoEngine` deps. No surface → no stamp — the BET-1389 default is untouched.

### Reviewer Block addressed (duplication gate)

The previous review cycle returned a Block: the ~10-line `relDeltas`/`noteRel` reliability-accumulator clone in `ctoFacts.mjs` (pre-existing on main, but any PR touching the file goes red on the strict changed-file scan). Fixed per the Block list: extracted into a shared `createRelTracker()` helper (`note` / `mergeInto` / `size`) used by both `pump` and `verifyDue`; behavior pinned by the existing reliability tests (`reject` counting, verify-pass confirming). `check-duplication-gate.sh origin/main` now passes locally: `duplication-gate: PASS — no clones`.

### Files changed

6 files, +669/−34: new `ctoFactSurfaces.mjs` + module tests + wiring gate; additive changes to `ctoFacts.mjs` (+ the tracker extract), `ctoFacts.test.mjs`, `index.mjs`.

### Verification results

- PR branch (`multica/BET-1409-checkable-surfaces` @ `52bc93ef`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3845 pass / 0 fail / 0 skip. Failures: none. log sha256: `645ba0add0ef8ae3ad557f2e4e98490a6beca36df1ec969d3262873ef574f00f`
  - strict duplication gate: PASS — no clones
- Base (`main` @ `a8df41a9`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3824 pass / 0 fail / 0 skip. Failures: none. log sha256: `69baa8e203ac0dfc43635ce25a667f155088736ed3a777fa79409bbc345f7ee2`
- **Conclusion:** 0 pre-existing failures, 0 new failures caused by this PR. 21 new tests (surface matrix, probe polarity, trace-resolver no-opinion guards, project pass-through, index.mjs wiring gate).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

### Known limitations (documented, follow-ups filed)

- The CI probe checks the repo's latest completed run across branches — `matchCheckable`'s regex loses the statement's branch context. Wrong-confirm risk filed: **BET-1504** (PM).
- `verifyDue` stores only ok/failed, discarding the probe's detail (closed/unavailable/missing). Parked: **BET-1505**.
- Issue surface limited to the multica CLI; a consented github tool could serve `#NNN`-style keys. Parked: **BET-1506**.

### Cross-cutting

- None. Server-only change; no IPC/renderer/preload surface, no route changes. The box's multica/gh/git are all present and gh is authenticated, so git + ci surfaces go live on deploy; the issue surface activates on tool consent.
