### PR TITLE
BET-1507: CTO inbox blocker cards duplicate per restatement — group by condition, not by prose

### DIFF
--- a/src/renderer/ctoSections.tsx
+++ b/src/renderer/ctoSections.tsx
@@ -54,10 +54,39 @@ export const BlockerSection = memo(function BlockerSection({
           >
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2 text-sm">
-                <span className="font-medium text-text">{card.title}</span>
-                <span className="text-xs text-text-faint">{relativeTime(card.pendingSince, now)}</span>
+                <span className="truncate font-medium text-text">{card.title}</span>
+                <span className="shrink-0 text-xs text-text-faint">
+                  {relativeTime(card.pendingSince, now)}
+                </span>
+                {/* The escalation signal that used to be expressed as N
+                    separate cards. Only shown once it means something. */}
+                {card.repeatCount > 1 ? (
+                  <span
+                    className="shrink-0 rounded-sm px-1 text-xs text-text-faint"
+                    style={{ background: "var(--fill-hover)" }}
+                    title={`Reported ${card.repeatCount} times since ${new Date(card.pendingSince).toLocaleString()}`}
+                  >
+                    ×{card.repeatCount}
+                  </span>
+                ) : null}
               </div>
-              {card.body ? <p className="mt-1 text-sm text-text-muted">{card.body}</p> : null}
+              {/* The rail is a glanceable list of what needs you, not a
+                  transcript: these bodies run to several hundred characters.
+                  Clamped to two lines; the full text is one click away in the
+                  Answer-now detail surface. */}
+              {card.body ? (
+                <p
+                  className="mt-1 text-sm text-text-muted"
+                  style={{
+                    display: "-webkit-box",
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }}
+                >
+                  {card.body}
+                </p>
+              ) : null}
             </div>
             <button
               type="button"

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -206,6 +206,7 @@ const card = (over = {}) => ({
   sessionID: "s1",
   pendingSince: 1000,
   refs: [] as string[],
+  repeatCount: 1,
   ...over,
 });
 
@@ -584,6 +585,17 @@ it("blockerCards: drops a row with neither title nor body", () => {
   ];
   const out = blockerCards(cards as unknown as CtoCard[]);
   expect(out.map((c) => c.id)).toEqual(["b2", "b3"]);
+});
+
+it("blockerCards: repeatCount defaults to 1 for pre-counter cards and junk, and carries a real count", () => {
+  const cards = [
+    { id: "b1", variant: "blocker", title: "old card", body: "written before the counter existed" },
+    { id: "b2", variant: "blocker", title: "recurring", body: "x", repeatCount: 7 },
+    { id: "b3", variant: "blocker", title: "junk", body: "x", repeatCount: 0 },
+    { id: "b4", variant: "blocker", title: "junk", body: "x", repeatCount: "many" },
+  ];
+  const out = blockerCards(cards as unknown as CtoCard[]);
+  expect(out.map((c) => c.repeatCount)).toEqual([1, 7, 1, 1]);
 });
 
 it("vetoCards: drops a row with neither title nor body", () => {

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -326,6 +326,8 @@ export type BlockerCard = {
   sessionID: string | null;
   pendingSince: number;
   refs: string[];
+  // >= 1. How many times this condition has been reported (see CtoCard).
+  repeatCount: number;
 };
 
 // Selector: the open blocker cards among the wire cards (§10.3). Selected
@@ -349,6 +351,10 @@ export function blockerCards(cards: ReadonlyArray<CtoCard>): BlockerCard[] {
       sessionID: typeof c.sessionID === "string" ? c.sessionID : null,
       pendingSince: Number.isFinite(c.pendingSince) ? (c.pendingSince as number) : 0,
       refs: Array.isArray(c.refs) ? (c.refs as string[]) : [],
+      // Absent on cards written before the counter existed → reported once.
+      repeatCount: Number.isFinite(c.repeatCount) && (c.repeatCount as number) > 0
+        ? (c.repeatCount as number)
+        : 1,
     }));
 }
 
@@ -453,7 +459,10 @@ export function digestExpandable(item: { deep?: string | null } | null | undefin
 // passed as `digestHasItems` so an empty-but-present digest counts as empty.
 export function resting(
   inputs: {
-    cards?: BlockerCard[] | null;
+    // Only the COUNT is read — any card-ish list is a valid input, so this
+    // must not demand a fully-selected BlockerCard (the caller passes the raw
+    // wire rows).
+    cards?: readonly unknown[] | null;
     nowActive?: unknown[] | null;
     finished?: unknown[] | null;
     digestHasItems?: boolean;

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -181,11 +181,70 @@ export function askResolveInfo(evt) {
   return { sessionID: typeof props.sessionID === "string" ? props.sessionID : null };
 }
 
+// ----- Inbox-note grouping (pure) -----
+//
+// The §10.3 never-duplicate rule applied to inbox blocker notes. Health
+// escalations already fold by CONDITION (healthGroupKey); inbox notes used to
+// key on `tag || message`, so a watchdog reporting the SAME condition every
+// tick — with the percentage, free-GB and tick timestamp moving each time —
+// minted a brand-new card per tick. That is the literal 2026-09-01 incident:
+// five "Blocker flagged for CTO" cards, one root-disk condition.
+//
+// The key is layered, first hit wins:
+//   1. `tag`      — the sender's own dedupe key (§4.4). Authoritative.
+//   2. `project`  — the sender session's resolved workspace, when the session
+//                   is tmux-stamped. Sessionless / subagent senders (which is
+//                   most watchdogs) resolve to nothing, hence layer 3.
+//   3. sender slug — the agent's self-identifying prefix, the way these notes
+//                   actually open ("tenanture-ops watchdog: …", "🤖 tenanture-ops
+//                   tick …"). One recurring reporter → one card.
+//   4. message    — the old whole-text hash, kept as the last resort so a note
+//                   that identifies itself in no way at all still gets a card.
+
+// Leading decoration a note may open with before its slug: emoji/pictographs,
+// zero-width joiners, variation selectors, and surrounding whitespace.
+const NOTE_DECORATION_RE = /^[\s\u200d\ufe0f\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}]+/u;
+
+// The sender's self-identifying slug: the leading `word` (letters/digits with
+// internal - or _) of a note, lowercased. Returns null when the note does not
+// open with one, or when the leading token is a bare number/date (never an
+// identity). Deliberately NOT a general text normalizer — it reads only the
+// prefix agents use to name themselves, which is stable while the rest of the
+// sentence (percentages, sizes, timestamps) moves every tick.
+export function senderSlug(text) {
+  if (typeof text !== "string") return null;
+  const stripped = text.replace(NOTE_DECORATION_RE, "");
+  const m = stripped.match(/^([A-Za-z][A-Za-z0-9]*(?:[-_][A-Za-z0-9]+)*)/);
+  if (!m) return null;
+  const slug = m[1].toLowerCase();
+  // A single letter is noise ("A note that…"); two characters is already a
+  // real identity in practice (work-unit names like "U6").
+  return slug.length >= 2 ? slug : null;
+}
+
+// The grouping identity for one inbox blocker note. Pure; `project` is the
+// caller-resolved workspace (may be undefined). Always returns a non-empty
+// string so a card is never dropped for want of a key.
+export function inboxGroupKey({ tag, title, message, project } = {}) {
+  if (typeof tag === "string" && tag) return `tag:${tag}`;
+  if (typeof project === "string" && project) return `project:${project}`;
+  const slug = senderSlug(title) ?? senderSlug(message);
+  if (slug) return `sender:${slug}`;
+  return `text:${typeof message === "string" ? message : ""}`;
+}
+
 // Human blocker copy for a worker-ask event (title/body). Pure.
-export function blockerTitle(kind) {
+// `noteTitle` (inbox only) is the SENDER's own headline — every one of these
+// notes carries a good one ("Root fs 95% on runtime host — needs human cleanup
+// decision") and the card used to throw it away for a constant, which is a
+// large part of why several distinct cards read as one thing repeated.
+export function blockerTitle(kind, noteTitle) {
   if (kind === "permission") return "Permission needed";
   if (kind === "question") return "Question waiting";
-  if (kind === "inbox") return "Blocker flagged for CTO";
+  if (kind === "inbox") {
+    const t = typeof noteTitle === "string" ? noteTitle.trim() : "";
+    return t || "Blocker flagged for CTO";
+  }
   return "Health check";
 }
 
@@ -226,10 +285,14 @@ function healthGroupKey(b) {
 // card, ignoring `updatedAt` (which always moves — it is the "when did we
 // last check" stamp, not content). A content-identical rebuild is not a
 // change: no save, no CARD_CREATED ledger row. Arrays are compared by value.
+// `repeatCount` is excluded for the same reason as `updatedAt`: it is
+// bookkeeping ABOUT the change, not content. Including it would make every
+// rebuild differ from itself and defeat the no-op rule entirely.
 function cardContentEqual(a, b) {
   if (!a || !b) return false;
   const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
   keys.delete("updatedAt");
+  keys.delete("repeatCount");
   for (const key of keys) {
     const av = a[key];
     const bv = b[key];
@@ -255,6 +318,11 @@ export function createCtoCards(deps = {}) {
     // router (push.mjs fireNotify). Only `onInboxBlocker` uses it — worker-ask
     // and health cards keep the "no notification path" invariant.
     fireNotify = async () => {},
+    // Resolves a session id to its workspace (`{project}`) — the engine's own
+    // getSessionInfo. Used ONLY as grouping layer 2 for inbox notes; a
+    // sessionless/subagent sender (most watchdogs) resolves to nothing and
+    // falls through to the sender-slug layer. Best-effort by contract.
+    getSessionInfo = null,
     now = () => Date.now(),
     // BET-1463: the writer for consuming/dropping a `pendingBlockers` entry in
     // engine-state.json once its health card has been upserted or its card
@@ -288,6 +356,21 @@ export function createCtoCards(deps = {}) {
   // the injected router exactly once, and registers a pending blocker so the
   // card timer (promoteDue) promotes it at > 10 min like any ask. Read-only on
   // the inbox itself — the inbound funnel already persisted the entry.
+  // Grouping layer 2: the sender session's workspace, when it is tmux-stamped.
+  // Never throws and never blocks the card path — an unresolvable sender just
+  // falls through to the slug layer.
+  async function resolveNoteProject(sessionID) {
+    if (typeof getSessionInfo !== "function" || typeof sessionID !== "string" || !sessionID) {
+      return undefined;
+    }
+    try {
+      const info = await getSessionInfo(sessionID);
+      return typeof info?.project === "string" && info.project ? info.project : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   async function onInboxBlocker({ message, title, refs = [], tag, sessionID, ts = now() } = {}) {
     const text = typeof message === "string" ? message.trim() : "";
     if (!text) return { changed: false, notified: false };
@@ -302,19 +385,28 @@ export function createCtoCards(deps = {}) {
     } catch (e) {
       console.warn("[cto] inbox blocker notify failed:", e?.message ?? e);
     }
-    // Register a pending blocker so the card appears at > 10 min. Key by the
-    // sending session when known, else by a stable hash of the tag/message;
-    // the card id stays stable across re-reports of the same note (upsert).
-    const sourceId = stableCardId(INBOX_SOURCE_KIND, tag || text);
+    // Register a pending blocker so the card appears at > 10 min. The card id
+    // is keyed by the note's CONDITION (inboxGroupKey), not its prose, so a
+    // watchdog restating the same condition every tick upserts one card
+    // instead of minting a new one per tick.
+    const project = await resolveNoteProject(sessionID);
+    const groupKey = inboxGroupKey({ tag, title, message: text, project });
+    const sourceId = stableCardId(INBOX_SOURCE_KIND, groupKey);
     await registerAsk({
       sourceKind: INBOX_SOURCE_KIND,
       sourceId,
-      sessionID: typeof sessionID === "string" ? sessionID : undefined,
+      // Deliberately NOT keyed by sessionID: a recurring reporter opens a new
+      // session per tick, so keying the registry by session would re-open the
+      // per-tick duplication the group key just closed. `askKeyOf` falls back
+      // to sourceId, which IS the condition.
+      sessionID: undefined,
+      noteSessionID: typeof sessionID === "string" ? sessionID : undefined,
+      title: typeof title === "string" ? title : undefined,
       body: text,
       refs: Array.isArray(refs) ? refs : [],
       askedAt: ts,
     });
-    return { changed: true, notified: true };
+    return { changed: true, notified: true, groupKey };
   }
 
   // BET-1407: best-effort persist of one registry change through the engine's
@@ -422,6 +514,12 @@ export function createCtoCards(deps = {}) {
       const cards = Array.isArray(fresh?.cards) ? fresh.cards : [];
       const existing = cards.find((c) => c?.id === id && c?.state === "open");
       const created = existing?.created ?? ts;
+      // A regeneration keeps the EARLIEST outstanding age (§9.1 carried-forward
+      // open state): a recurring condition has been waiting since its first
+      // report, not since its latest restatement.
+      const since = Number.isFinite(existing?.pendingSince)
+        ? Math.min(existing.pendingSince, pendingSince)
+        : pendingSince;
       const card = buildBlockerCard({
         id,
         sourceKind,
@@ -430,7 +528,7 @@ export function createCtoCards(deps = {}) {
         title,
         body,
         refs,
-        pendingSince,
+        pendingSince: since,
         created,
       });
       cardRefs = card.refs;
@@ -441,9 +539,15 @@ export function createCtoCards(deps = {}) {
       if (existing && cardContentEqual(existing, { ...card, updatedAt: ts })) return {};
       changed = true;
       isNew = !existing;
+      // A genuine restatement of an existing condition — the count is the
+      // escalation signal ("this has now fired 7 times"), which was previously
+      // expressed as seven separate cards.
+      const repeatCount = existing ? (existing.repeatCount ?? 1) + 1 : 1;
       const nextCards = existing
-        ? cards.map((c) => (c === existing ? { ...existing, ...card, created, updatedAt: ts } : c))
-        : [...cards, card];
+        ? cards.map((c) =>
+            c === existing ? { ...existing, ...card, created, repeatCount, updatedAt: ts } : c,
+          )
+        : [...cards, { ...card, repeatCount }];
       return { cards: nextCards };
     });
     if (changed) {
@@ -590,13 +694,14 @@ export function createCtoCards(deps = {}) {
     const consumedKeys = [];
     for (const ask of pendingAsks.values()) {
       if (nowMs - ask.askedAt < BLOCKER_AFTER_MS) continue;
+      const fallbackRef = ask.sessionID ?? ask.noteSessionID;
       const r = await upsertBlocker({
         sourceKind: ask.sourceKind,
         sourceId: ask.sourceId,
         sessionID: ask.sessionID,
-        title: blockerTitle(ask.sourceKind),
+        title: blockerTitle(ask.sourceKind, ask.title),
         body: blockerBody(ask.sourceKind, ask.body),
-        refs: Array.isArray(ask.refs) && ask.refs.length ? ask.refs : ask.sessionID ? [ask.sessionID] : [],
+        refs: Array.isArray(ask.refs) && ask.refs.length ? ask.refs : fallbackRef ? [fallbackRef] : [],
         ts: nowMs,
         pendingSince: ask.askedAt,
       });

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -12,8 +12,10 @@ import {
   askResolveInfo,
   askStartInfo,
   createCtoCards,
+  inboxGroupKey,
   isAskResolveEvent,
   isAskStartEvent,
+  senderSlug,
   stableCardId,
 } from "./ctoCards.mjs";
 import { INBOX_TTL_MS } from "./ctoStores.mjs";
@@ -24,7 +26,7 @@ import { INBOX_TTL_MS } from "./ctoStores.mjs";
 // (a static patch object, or a `(fresh) => patch` function; a key set to
 // `undefined` deletes it) but without its mutex — fine for these
 // single-threaded, sequential-await tests.
-function makeHarness({ pendingBlockers = [], fireNotify = false } = {}) {
+function makeHarness({ pendingBlockers = [], fireNotify = false, getSessionInfo = null } = {}) {
   const clock = { ms: 1_000_000 };
   let cardPayload = { v: 1, cards: [] };
   const ledgerRows = [];
@@ -47,6 +49,7 @@ function makeHarness({ pendingBlockers = [], fireNotify = false } = {}) {
     },
     ledger: { append: async (row) => ledgerRows.push(row) },
     ...(fireNotify ? { fireNotify: async (a) => notified.push(a) } : {}),
+    ...(getSessionInfo ? { getSessionInfo } : {}),
     now: () => clock.ms,
     patchEngineState: async (mutation) => {
       patchCalls.push(mutation);
@@ -425,6 +428,105 @@ test("BET-1397 source 3: an inbox blocker fires the blocking-tier notify exactly
   assert.deepEqual(open[0].refs, ["BET-777"]);
 });
 
+// ---------------------------------------------------------------------------
+// Inbox-note grouping: one card per CONDITION, not one per restatement.
+// ---------------------------------------------------------------------------
+
+test("senderSlug: reads the agent's self-identifying prefix, ignoring decoration", () => {
+  assert.equal(senderSlug("tenanture-ops watchdog: root filesystem / is at 92%"), "tenanture-ops");
+  assert.equal(senderSlug("🤖 tenanture-ops early warning (tick 2026-08-31T20:35Z): …"), "tenanture-ops");
+  assert.equal(senderSlug("tenanture-ops tick 2026-09-01T00:10Z: root fs at 93%"), "tenanture-ops");
+  assert.equal(senderSlug("U6 SafeModules background job cannot run."), "u6");
+  // Not an identity: a bare number, a too-short token, or no leading word.
+  assert.equal(senderSlug("2026-08-31 disk report"), null);
+  assert.equal(senderSlug("  "), null);
+  assert.equal(senderSlug(undefined), null);
+});
+
+test("inboxGroupKey: tag wins, then project, then sender slug, then raw text", () => {
+  assert.equal(
+    inboxGroupKey({ tag: "root-disk", title: "x", message: "y", project: "p" }),
+    "tag:root-disk",
+  );
+  assert.equal(inboxGroupKey({ title: "x", message: "y", project: "tenanture" }), "project:tenanture");
+  assert.equal(inboxGroupKey({ message: "tenanture-ops watchdog: disk" }), "sender:tenanture-ops");
+  // Title is preferred over message for the slug.
+  assert.equal(
+    inboxGroupKey({ title: "ops-bot: disk", message: "other-bot: disk" }),
+    "sender:ops-bot",
+  );
+  assert.equal(inboxGroupKey({ message: "2026 report" }), "text:2026 report");
+});
+
+test("REGRESSION (2026-09-01): a watchdog restating one condition each tick yields ONE card, not one per tick", async () => {
+  const h = makeHarness({ fireNotify: true });
+  // The five real notes that produced five "Blocker flagged for CTO" cards:
+  // same condition, prose moving every tick (percentage, free-GB, timestamp),
+  // no dedupe tag, and a DIFFERENT sender session each tick.
+  const notes = [
+    ["tenanture-ops watchdog: root filesystem / is at 92% (6.2 GiB free of 75G)", "Root disk 92%"],
+    ["🤖 tenanture-ops early warning (tick 2026-08-31T20:35Z): root filesystem / is at 92% (6.1G free)", "Root fs at 92%"],
+    ["🤖 tenanture-ops watchdog (tick 2026-08-31T21:08Z): ROOT filesystem / is at 93% (5.5G free)", "Root fs 93%"],
+    ["tenanture-ops tick 2026-09-01T00:10Z: root filesystem / at 93% (5.4G free of 75G)", "Root disk 93%"],
+    ["tenanture-ops INFRA-DOWN escalation: root filesystem / at 96% (3.4G free of 75G)", "Root fs 96%"],
+  ];
+  for (const [message, title] of notes) {
+    await h.cards.onInboxBlocker({ message, title, sessionID: `ses-${Math.random()}`, ts: h.clock.ms });
+    h.advance(BLOCKER_AFTER_MS + 1);
+    await h.cards.promoteDue();
+  }
+
+  const open = h.store().cards.filter((c) => c.state === "open");
+  assert.equal(open.length, 1, "one condition → one card");
+  const card = open[0];
+  // The newest restatement is what the card says…
+  assert.match(card.body, /96%/);
+  // …under the SENDER's own headline, not the old constant.
+  assert.equal(card.title, "Root fs 96%");
+  // …aged from the FIRST report, and counting the restatements.
+  assert.equal(card.pendingSince, 1_000_000);
+  assert.equal(card.repeatCount, 5);
+  // Every note still fired its own blocking-tier notification (unchanged).
+  assert.equal(h.notified.length, 5);
+});
+
+test("inbox grouping: distinct conditions still get distinct cards", async () => {
+  const h = makeHarness();
+  await h.cards.onInboxBlocker({ message: "tenanture-ops watchdog: disk full", ts: h.clock.ms });
+  await h.cards.onInboxBlocker({ message: "U6 SafeModules job cannot run", ts: h.clock.ms });
+  await h.cards.onInboxBlocker({ message: "deploy-bot: release stuck", tag: "rel", ts: h.clock.ms });
+  h.advance(BLOCKER_AFTER_MS + 1);
+  await h.cards.promoteDue();
+  assert.equal(openCardCount(h), 3);
+});
+
+test("inbox grouping: an identical repeat is a pure no-op (no save, no ledger row, no count bump)", async () => {
+  const h = makeHarness();
+  await h.cards.onInboxBlocker({ message: "ops-bot: disk full", title: "Disk", ts: h.clock.ms });
+  h.advance(BLOCKER_AFTER_MS + 1);
+  await h.cards.promoteDue();
+  const rowsAfterFirst = h.ledgerRows.filter((r) => r.kind === CARD_CREATED).length;
+  const countAfterFirst = h.store().cards.find((c) => c.state === "open").repeatCount;
+
+  await h.cards.onInboxBlocker({ message: "ops-bot: disk full", title: "Disk", ts: h.clock.ms });
+  h.advance(BLOCKER_AFTER_MS + 1);
+  await h.cards.promoteDue();
+
+  assert.equal(openCardCount(h), 1);
+  assert.equal(h.ledgerRows.filter((r) => r.kind === CARD_CREATED).length, rowsAfterFirst);
+  assert.equal(h.store().cards.find((c) => c.state === "open").repeatCount, countAfterFirst);
+});
+
+test("inbox grouping: a tmux-resolvable sender groups by workspace", async () => {
+  const h = makeHarness({ getSessionInfo: async () => ({ owner: "user", project: "tenanture" }) });
+  // Two notes whose slugs DIFFER — only the resolved workspace can group them.
+  await h.cards.onInboxBlocker({ message: "alpha-bot: disk full", sessionID: "s1", ts: h.clock.ms });
+  await h.cards.onInboxBlocker({ message: "beta-bot: disk still full", sessionID: "s2", ts: h.clock.ms });
+  h.advance(BLOCKER_AFTER_MS + 1);
+  await h.cards.promoteDue();
+  assert.equal(openCardCount(h), 1);
+});
+
 test("upsertDecision: writes a decision card, and regenerating the same id upserts (no duplicate)", async () => {
   const h = makeHarness();
   const first = await h.cards.upsertDecision({
@@ -621,19 +723,27 @@ test("BET-1407: onAskStart persists the ask into engine-state pendingAsks; re-re
   assert.equal(h.engineStateSnapshot().pendingAsks.length, 1);
 });
 
-test("BET-1407: onInboxBlocker persists its registration under the same idiom (keyed by sessionID or sourceId)", async () => {
+test("BET-1407: onInboxBlocker persists its registration under the same idiom (keyed by the note's CONDITION)", async () => {
   const h = makeHarness({ fireNotify: true });
   await h.cards.onInboxBlocker({ message: "deploy failed", tag: "deploy", sessionID: "s7", ts: h.clock.ms });
   let rows = h.engineStateSnapshot().pendingAsks;
   assert.equal(rows.length, 1);
-  assert.equal(rows[0].sessionID, "s7");
   assert.equal(rows[0].sourceKind, "inbox");
-  // A sessionless note keys by its stable source id.
+  // An inbox note is registered WITHOUT a sessionID, on purpose: a recurring
+  // reporter opens a new session per tick, so keying the registry by session
+  // would re-open the per-tick duplication the group key exists to close. The
+  // originating session is retained separately for traceability.
+  assert.equal(rows[0].sessionID, undefined);
+  assert.equal(rows[0].noteSessionID, "s7");
+  assert.ok(rows[0].sourceId);
+  // A different condition is a separate registry row.
   await h.cards.onInboxBlocker({ message: "disk almost full", tag: "disk", ts: h.clock.ms });
   rows = h.engineStateSnapshot().pendingAsks;
   assert.equal(rows.length, 2);
-  assert.equal(rows[1].sessionID, undefined);
-  assert.ok(rows[1].sourceId);
+  assert.notEqual(rows[0].sourceId, rows[1].sourceId);
+  // The SAME condition from a new session replaces its row, never adds one.
+  await h.cards.onInboxBlocker({ message: "deploy failed again", tag: "deploy", sessionID: "s8", ts: h.clock.ms });
+  assert.equal(h.engineStateSnapshot().pendingAsks.length, 2);
 });
 
 test("BET-1407: promoteDue consumes the promoted ask — removed from the registry and engine-state, no re-promotion", async () => {

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -369,6 +369,11 @@ export function createCtoEngine(deps = {}) {
       cardStore: bundle.cards,
       engineState,
       patchEngineState: (mutation) => patchEngineState(mutation, { engineState }),
+      // Inbox-note grouping layer 2 (§10.3 never-duplicate). Wrapped in a
+      // thunk, not passed by reference: `getSessionInfo` is destructured
+      // BELOW `cards` in this same binding, so naming it directly here is a
+      // TDZ error. The arrow body runs long after destructuring settles.
+      getSessionInfo: (sid) => getSessionInfo(sid),
       // The engine's clock is authoritative for the cards module too — one
       // now for promoteDue thresholds AND the BET-1407 seed's retention
       // bound (a test's fake clock must not make every persisted ask look

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -265,6 +265,11 @@ export type CtoCard = {
   pendingSince: number;
   created: number;
   state: "open" | "resolved" | "dismissed";
+  // How many times this same condition has been reported (blocker variant).
+  // 1 (or absent, on cards written before the counter existed) = reported
+  // once. A recurring watchdog now bumps this instead of minting a new card,
+  // so the count IS the escalation signal.
+  repeatCount?: number;
   // BET-1392 decision cards (§9.1) — present only when variant === "decision".
   // `why` is the one-paragraph rationale; `options` are the bound-action
   // buttons (closed ACTION_TYPES enum); `evidence` feeds the "evidence ▸"


### PR DESCRIPTION
## Problem

A watchdog restating the same condition every tick minted a **brand-new blocker card per tick**. Observed live on 2026-09-01: five `Blocker flagged for CTO` cards for one root-disk condition, none of which could be dismissed.

`onInboxBlocker` keyed the card on `tag || message`. The message carries a percentage, a free-GB figure and a tick timestamp — all of which move every tick — so the key changed every time and the §10.3 never-duplicate upsert never matched.

Health escalations already fold by CONDITION (`healthGroupKey`, BET-1463). The inbox source never got the same treatment. This is that treatment.

## Fix

- **`inboxGroupKey`** — layered, first hit wins: the sender's dedupe `tag` → the sender session's resolved workspace → the agent's **self-identifying slug** (`tenanture-ops watchdog: …`) → the old whole-text hash as a last resort.

  The slug layer is what carries the real case. These senders are subagents with no tmux-stamped session and a **new session id per tick**, so both the tag and the workspace layers come up empty, while the prefix the agent names itself with is stable across every restatement.

- **An inbox ask is registered without a `sessionID`, deliberately.** Keying the registry by session would re-open the per-tick duplication the group key just closed. The originating session is retained as `noteSessionID` and still reaches the card's `refs`.

- **The card carries the sender's own headline.** It was previously replaced with the constant "Blocker flagged for CTO", identical on every card — a large part of why distinct escalations read as one thing stuttering.

- **Repeats escalate instead of accumulating.** A regeneration keeps the earliest outstanding age and bumps `repeatCount`, so a recurring condition is one card marked `×5`. `repeatCount` is excluded from `cardContentEqual` for the same reason `updatedAt` is — it is bookkeeping *about* the change, not content, and including it would make every rebuild differ from itself and defeat the no-op rule.

- **Renderer** — the Blocker rail clamps the body to two lines (these bodies run 577–887 characters) and shows the `×N` badge only once it means something. Full text stays one click away in Answer-now.

- `resting()` no longer demands a fully-selected `BlockerCard`; it only reads `.length`, and the caller passes raw wire rows.

## Tests

- `senderSlug` / `inboxGroupKey` unit coverage including decoration stripping and layer precedence.
- **A regression test built from the five real notes** — asserts one card, the newest body, the sender's title, age from the first report, `repeatCount === 5`, and that all five still fired their own blocking-tier notification.
- Distinct conditions still get distinct cards; an identical repeat is a pure no-op (no save, no ledger row, no count bump); a tmux-resolvable sender groups by workspace.

Server 3285 pass, renderer/shared 3584 pass, typecheck clean.

## Not in this PR

Blocker cards still have **no dismiss control** — the server has `dismissById` but no route exposes it and no button calls it, so an inbox blocker card cannot be closed by any route and emits no verdict for the trust ladder. Filed separately.