### PR TITLE
fix(install): Caddy key import can no longer hang the install on a retry

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1673,9 +1673,44 @@ main() {
         || die "apt-get update failed"
       apt_priv install -y debian-keyring debian-archive-keyring apt-transport-https curl \
         || die "apt-get install prerequisites for Caddy failed"
-      curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
-        | sudo_priv gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
-        || die "failed to download Caddy GPG key"
+      # Import Caddy's repo signing key. Staged through temp files and made
+      # NON-INTERACTIVE for the same reason apt_priv exists (see its comment):
+      # this script runs over `ssh -tt` with stdin ignored, so ANY command
+      # that asks a question blocks forever inside the "Starting the service"
+      # stage while the UI's elapsed timer keeps ticking — it reads as alive.
+      # Reported from the field on Ubuntu 22.04.
+      #
+      #   --batch --yes
+      #       `gpg --dearmor -o <path>` prompts "File '<path>' exists.
+      #       Overwrite? (y/N)" when the keyring is ALREADY THERE, which is
+      #       the normal state on a retry: the first attempt writes the key,
+      #       fails or is cancelled later, and every subsequent run then hangs
+      #       HERE deterministically. That self-perpetuating trap is the bug —
+      #       overwriting is always what we want (the key is re-fetched from
+      #       source in the line above).
+      #   --connect-timeout / --max-time
+      #       The key is ~7KB from a third-party host (Cloudsmith). Unreachable
+      #       rather than slow, a bare curl waits forever — same symptom, same
+      #       stage, different cause. Bounded so it FAILS and gets reported.
+      #
+      # Staging to a temp file also fixes the pipeline's error handling: in
+      # `curl … | gpg …` only gpg's status is checked, so a truncated download
+      # could be dearmored into a corrupt keyring that poisons apt later.
+      _caddy_key_asc="$(mktemp)"
+      _caddy_key_gpg="$(mktemp)"
+      if ! curl -1sLf --connect-timeout 15 --max-time 60 \
+          https://dl.cloudsmith.io/public/caddy/stable/gpg.key -o "$_caddy_key_asc"; then
+        rm -f "$_caddy_key_asc" "$_caddy_key_gpg"
+        die "failed to download the Caddy signing key from dl.cloudsmith.io (network unreachable, or the host is down).
+        Check the server can reach it:  curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/gpg.key >/dev/null"
+      fi
+      if ! gpg --batch --yes --dearmor -o "$_caddy_key_gpg" < "$_caddy_key_asc"; then
+        rm -f "$_caddy_key_asc" "$_caddy_key_gpg"
+        die "failed to decode the Caddy signing key"
+      fi
+      install_root_file "$_caddy_key_gpg" /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
+        || { rm -f "$_caddy_key_asc" "$_caddy_key_gpg"; die "failed to install the Caddy signing key"; }
+      rm -f "$_caddy_key_asc" "$_caddy_key_gpg"
       # Write the apt repo line DIRECTLY with a resolved, known-good codename
       # instead of piping Cloudsmith's config.deb.txt. That script probes
       # /etc/os-release and, on a distro its detector doesn't recognize (e.g.

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -3524,6 +3524,92 @@ test("apt_priv is the ONLY way install.sh runs apt (no call bypasses the chokepo
   );
 });
 
+// ----------------------------------------------------------------------------
+// Caddy signing-key import — the SECOND unanswerable prompt on the same stage.
+//
+// Same root cause as apt_priv above (ssh -tt, stdin ignored, nothing can
+// answer a question), different command: `gpg --dearmor -o <path>` asks
+// "File '<path>' exists. Overwrite? (y/N)" whenever the keyring is already
+// there. That is the NORMAL state on a retry — the first attempt writes the
+// key, fails or is cancelled later, and every run after that hangs HERE
+// deterministically, which is why the field report read as "stalls forever,
+// every time". Reported on Ubuntu 22.04, stuck at "Starting the service".
+// ----------------------------------------------------------------------------
+
+test("gpg --dearmor is always non-interactive (--batch --yes) in install.sh", () => {
+  // Assert on the whole file, not one branch: a single prompting call site
+  // reopens the hang. Mirrors the apt_priv chokepoint test above.
+  const bare = [];
+  for (const line of readFileSync(INSTALL_SH, "utf-8").split("\n")) {
+    if (line.trim().startsWith("#")) continue;
+    if (!/\bgpg\b.*--dearmor/.test(line)) continue;
+    if (!line.includes("--batch") || !line.includes("--yes")) bare.push(line.trim());
+  }
+  assert.deepEqual(
+    bare,
+    [],
+    `gpg --dearmor without --batch --yes (prompts + hangs on a retry):\n${bare.join("\n")}`,
+  );
+});
+
+test("gpg --dearmor: --batch --yes overwrites an existing keyring instead of asking", () => {
+  // The behavioural half — proves the flags actually fix it rather than just
+  // being present. With a tty (what `ssh -tt` gives the installer) the bare
+  // form BLOCKS on the prompt forever; with stdin closed and no tty, as here,
+  // the same prompt surfaces as a hard failure instead. Either way the bare
+  // form cannot succeed against an existing file and the fixed form must.
+  const gpg = spawnSync("gpg", ["--version"], { encoding: "utf-8" });
+  if (gpg.error) return; // no gpg on this machine — nothing to assert
+  const dir = mkdtempSync(join(tmpdir(), "manta-gpgkey-"));
+  try {
+    const src = join(dir, "key.asc");
+    const out = join(dir, "keyring.gpg");
+    // A real armored key so --dearmor has valid input.
+    writeFileSync(
+      src,
+      execSync(
+        "gpg --batch --yes --quiet --passphrase '' --quick-generate-key manta-test-key default default never" +
+          " >/dev/null 2>&1; gpg --armor --export manta-test-key",
+        { encoding: "utf-8", env: { ...process.env, GNUPGHOME: dir } },
+      ),
+    );
+    const run = (args) =>
+      spawnSync("gpg", [...args, "--dearmor", "-o", out], {
+        input: readFileSync(src),
+        encoding: "utf-8",
+        timeout: 20_000,
+      });
+
+    // Fresh target: both forms work, so the target must exist for the
+    // assertions below to mean anything.
+    assert.equal(run(["--batch", "--yes"]).status, 0);
+    assert.ok(statSync(out).size > 0);
+
+    // Existing target: the bare form cannot get through…
+    assert.notEqual(run([]).status, 0);
+    // …the fixed form does, silently.
+    assert.equal(run(["--batch", "--yes"]).status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the Caddy signing key fetch is time-bounded (unreachable host fails, never hangs)", () => {
+  // The key comes from a third-party host (Cloudsmith). Unreachable rather
+  // than slow, an unbounded curl waits forever — same stage, same symptom as
+  // the prompt above, so it needs the same treatment.
+  // Join `\`-continued lines first (the invocation wraps), then anchor on a
+  // line that STARTS with the command — the die message below it quotes the
+  // same URL as advice for the user, and matching that would assert nothing.
+  const line = readFileSync(INSTALL_SH, "utf-8")
+    .replace(/\\\n\s*/g, " ")
+    .split("\n")
+    .find((l) => /^\s*(if\s+!\s+)?curl\b/.test(l) && l.includes("dl.cloudsmith.io"));
+  assert.ok(line, "expected a curl invocation for the Caddy signing key");
+  assert.match(line, /--connect-timeout \d+/);
+  assert.match(line, /--max-time \d+/);
+});
+
 test("BET-979: setup_askpass creates the SUDO_ASKPASS helper and exports it", () => {
   const dir = mkdtempSync(join(tmpdir(), "manta-setupask-"));
   try {


### PR DESCRIPTION
## What

An install on Ubuntu 22.04 stalls forever at **"Starting the service" (4 of 6)** with the log ending on the Caddy prerequisites, and reproduces on every retry.

## Why

The installer runs over `ssh -tt` with stdin ignored, so any command that asks a question blocks forever. apt's prompts were already closed off (`apt_priv`); the Caddy signing-key import immediately after them was not.

`gpg --dearmor -o <path>` prompts `File '<path>' exists. Overwrite? (y/N)` when the keyring is already present — which is the normal state on a **retry**. The first attempt writes the key, fails or is cancelled later, and every run after that hangs there deterministically. The elapsed timer keeps ticking, so it reads as alive rather than stuck.

Reproduced directly: with the target file present and a pty attached, the old command sits on the prompt until killed.

## Changes

- `--batch --yes` on the dearmor so the overwrite is silent (the key is re-fetched from source immediately above, so overwriting is always correct).
- `--connect-timeout 15 --max-time 60` on the key fetch — unreachable rather than slow, the old unbounded curl hung the same way, same stage.
- Stage through temp files + `install_root_file`. In `curl … | gpg …` only gpg's status was checked, so a truncated download could be dearmored into a corrupt keyring that poisons apt later.

## Tests

- File-wide chokepoint: no bare `gpg --dearmor` anywhere in install.sh (mirrors the existing `apt_priv` chokepoint test).
- Behavioural: the flags actually overwrite an existing keyring where the bare form cannot.
- The key fetch carries both timeouts.

Red/green verified — the two static tests fail against the old code.

## Not in scope

The release-tarball download is still unbounded on purpose; a `--max-time` there would break large downloads over slow links.