### PR TITLE
feat(server): BET-1460 — classify all 500-body sites into the consumer-set contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1307,6 +1307,29 @@ Backup at `~/.tmux.conf.pre-MantaUI` on the remote if it was ever modified.
     in `src/server/tmux.test.mjs` + the `node -e` e2e in BET-307. Do NOT
     "simplify" by passing the cwd through unchanged — the chokepoint is
     what makes the silent `$HOME` fallback unreachable.
+- **HTTP 500-body contract (BET-1460) — classify every route by CONSUMER
+  before writing its error catch.** The contract is set by who reads the
+  body, decided once in BET-1460 and enforced by
+  `src/server/errorBodyContract.test.mjs`:
+  - **Class 1 — the 500 body can reach an END USER's screen** (chat panel
+    attachment chips, the CTO pane's toasts and load-error states, the iOS
+    composer). The body must be a SAFE HUMAN LITERAL and the underlying
+    error goes to `console.warn` server-side: write the 500 ONLY through
+    `respondSafe500(res, route, message, e)` from `src/server/safeApiError.mjs`
+    (the CTO family shares `CTO_SAFE_500_MESSAGE`; `/api/upload` is extracted
+    into `src/server/uploadRoute.mjs` on the `projectsRoute.mjs` pattern).
+    Never write `String(e?.message ?? e)` into a class-1 body — raw fs
+    paths and errno output on a user's screen is the leak BET-1454 fixed.
+  - **Class 2 — consumed only by an AI tool registrar / automation /
+    operator surface** (manta-native opencode tools relay the message
+    straight back to the model; the cap runner; Settings renders raw only
+    behind a `<details>` disclosure). Keep the raw body and put a
+    `// class-2 (BET-1460): …` marker comment on the catch — the gate test
+    asserts every remaining raw 500 carries one. Meaningful 400-class
+    bodies ("unknown action", "unauthorized") are untouched by this rule on
+    BOTH classes.
+  When adding a route, decide the class first; a class-1 conversion needs
+  the safe literal + warn, a class-2 route needs the marker comment.
 - **Queued message drain — abort at the next step boundary, then submit on
   idle.** When the user submits while `running` is true, the text gets pushed
   to `messageQueue` and the input clears. MantaUI does NOT wait for the whole

--- a/src/server/errorBodyContract.test.mjs
+++ b/src/server/errorBodyContract.test.mjs
@@ -1,0 +1,89 @@
+// errorBodyContract.test.mjs — BET-1460 wiring gate.
+//
+// index.mjs cannot be imported (it boots the server on import), so the
+// 500-body contract is asserted by a source scan, the same pattern as
+// ctoSweeperWiring.test.mjs:
+//
+//   - every remaining `respondJson(res, 500, String(e?.message ?? e))` site
+//     in index.mjs must be a class-2 route, carrying the
+//     `class-2 (BET-1460)` marker comment within the 3 lines above it;
+//   - every class-1 route writes its 500 through respondSafe500 (imported
+//     from safeApiError.mjs) — 21 CTO-family sites in index.mjs plus the
+//     upload handler extracted into uploadRoute.mjs.
+//
+// This is the regression gate: a new route that reaches for raw
+// String(e?.message ?? e) without classifying itself fails here.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const indexSource = readFileSync(join(here, "index.mjs"), "utf8");
+const indexLines = indexSource.split("\n");
+
+test("wiring: every remaining raw 500 in index.mjs is an annotated class-2 route (BET-1460)", () => {
+  const rawSites = [];
+  indexLines.forEach((line, i) => {
+    if (line.includes("respondJson(res, 500")) rawSites.push(i); // 0-based
+  });
+  assert.ok(rawSites.length > 0, "expected the class-2 sites to still be present");
+  for (const i of rawSites) {
+    const above = indexLines.slice(Math.max(0, i - 3), i).join("\n");
+    assert.match(
+      above,
+      /class-2 \(BET-1460\)/,
+      `raw 500 at line ${i + 1} is missing its class-2 (BET-1460) marker comment`,
+    );
+  }
+});
+
+test("wiring: class-1 CTO routes write their 500 through respondSafe500 (BET-1460)", () => {
+  assert.match(
+    indexSource,
+    /import \{ CTO_SAFE_500_MESSAGE, respondSafe500 \} from "\.\/safeApiError\.mjs"/,
+    "index.mjs must import the safe-500 writer",
+  );
+  // 21 CTO-family conversions in index.mjs (the 22nd — upload — lives in
+  // uploadRoute.mjs and is asserted in its own test).
+  const uses = indexSource.match(/respondSafe500\(res, "cto\//g) ?? [];
+  assert.equal(
+    uses.length,
+    21,
+    "expected exactly the 21 CTO-family class-1 conversions through respondSafe500",
+  );
+  assert.ok(
+    !indexSource.includes('respondSafe500(res, "upload"'),
+    "the upload 500 lives in uploadRoute.mjs, not index.mjs",
+  );
+});
+
+test("wiring: POST /api/upload is extracted into uploadRoute.mjs (projectsRoute pattern)", () => {
+  assert.match(
+    indexSource,
+    /import \{ createUploadHandler \} from "\.\/uploadRoute\.mjs"/,
+    "index.mjs must import the extracted upload handler",
+  );
+  assert.match(
+    indexSource,
+    /const uploadHandler = createUploadHandler\(\{ uploadRoot: UPLOAD_ROOT \}\);/,
+    "the upload handler must be wired with the box's upload root",
+  );
+  assert.ok(
+    indexSource.includes("return uploadHandler(req, res, url);"),
+    "the /api/upload call site must route through the extracted handler",
+  );
+  assert.ok(
+    !indexSource.includes("async function handleUpload("),
+    "the inline upload handler must be gone from index.mjs",
+  );
+});
+
+test("docs: the 500-body contract rule is recorded in AGENTS.md (BET-1460 deliverable 4)", () => {
+  const agents = readFileSync(join(here, "..", "..", "AGENTS.md"), "utf8");
+  assert.match(agents, /BET-1460/, "AGENTS.md must document the BET-1460 contract");
+  assert.match(agents, /class-1/, "AGENTS.md must name the two consumer classes");
+  assert.match(agents, /respondSafe500/, "AGENTS.md must point at the safe writer");
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -46,6 +46,8 @@ import * as pty from "./pty.mjs";
 import * as local from "./local.mjs";
 import { createPeekHandler } from "./peek.mjs";
 import { createProjectsHandler } from "./projectsRoute.mjs";
+import { createUploadHandler } from "./uploadRoute.mjs";
+import { CTO_SAFE_500_MESSAGE, respondSafe500 } from "./safeApiError.mjs";
 import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
 import { setTelemetrySink, shipCtxEvent } from "./optimizer/telemetry.mjs";
 import { blendedPrice } from "../shared/blendedPrice.mjs";
@@ -2900,50 +2902,10 @@ function requireLoopback(req, res, errorMessage) {
 // multipart parser.
 
 const UPLOAD_ROOT = uploadRoot();
-const SESSION_RE = /^[A-Za-z0-9._-]+$/;
-const BATCH_RE = /^[0-9]{6,20}$/;
-
-function safeBasename(name) {
-  // Strip path separators and control chars; collapse oddballs to "_".
-  let n = String(name).replace(/[\x00-\x1f\\/:*?"<>|]/g, "_");
-  if (n === "." || n === "..") n = "file";
-  if (!n) n = "file";
-  if (n.length > 200) n = n.slice(0, 200);
-  return n;
-}
-
-async function handleUpload(req, res, url) {
-  const session = url.searchParams.get("session");
-  if (!session || !SESSION_RE.test(session)) {
-    respondJson(res, 400, { error: "bad session" });
-    return;
-  }
-  const rawName = req.headers["x-filename"];
-  if (typeof rawName !== "string" || !rawName) {
-    respondJson(res, 400, { error: "missing X-Filename" });
-    return;
-  }
-  let decoded;
-  try { decoded = decodeURIComponent(rawName); } catch { decoded = rawName; }
-  const filename = safeBasename(decoded);
-
-  const batchHeader = req.headers["x-batch-id"];
-  const batch = typeof batchHeader === "string" && BATCH_RE.test(batchHeader)
-    ? batchHeader
-    : String(Date.now());
-
-  const dir = join(UPLOAD_ROOT, session, batch);
-  const target = join(dir, filename);
-
-  try {
-    await mkdir(dir, { recursive: true });
-    await pipeline(req, createWriteStream(target));
-  } catch (e) {
-    respondJson(res, 500, { error: String(e?.message ?? e) });
-    return;
-  }
-  respondJson(res, 200, { path: target });
-}
+// POST /api/upload handler — the real route logic lives in src/server/uploadRoute.mjs
+// (extracted BET-1460 on the projectsRoute.mjs pattern; tested in uploadRoute.test.mjs).
+// Injected with the box's upload root (~/.manta-uploads).
+const uploadHandler = createUploadHandler({ uploadRoot: UPLOAD_ROOT });
 
 // Agent → device download: stream a file back to the device as a browser
 // download. Path-traversal guarded with the SAME home-scoped rule /api/peek
@@ -3210,6 +3172,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): desktop main classifies outcomes to fixed copy (unpair.mjs) — raw is a debug aid.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -3385,7 +3348,7 @@ const handleRequest = async (req, res) => {
   }
 
   if (req.method === "POST" && path === "/api/upload") {
-    return handleUpload(req, res, url);
+    return uploadHandler(req, res, url);
   }
 
   if (req.method === "GET" && path === "/api/download") {
@@ -3501,6 +3464,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): schedule opencode tool — relays the message to the model (the card UI reads via /rpc).
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -3621,6 +3585,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): cap runner (capExecutor) + plugins opencode tool — machine consumers.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -3740,6 +3705,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): delegate opencode tool — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -3781,6 +3747,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): plugins opencode tool + Settings plugins list (raw only behind its <details> disclosure).
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -3869,6 +3836,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): forge-rules opencode tool + Settings toggles (raw only behind its <details> disclosure).
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -3940,6 +3908,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): webhook opencode tool — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -3974,6 +3943,7 @@ const handleRequest = async (req, res) => {
         ),
       );
     } catch (e) {
+      // class-2 (BET-1460): forge webhook delivery (/hook/<token>) — machine-to-machine; raw aids redelivery diagnosis.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -4033,6 +4003,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): serve-page opencode tool — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -4070,6 +4041,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): plan-render opencode tool — relays the message to the model.
       respondJson(res, 500, { ok: false, error: String(e?.message ?? e) });
     }
     return;
@@ -4101,6 +4073,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): notify opencode tool — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -4143,6 +4116,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): manta-optimizer plugin hook (policy read) — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -4174,6 +4148,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): manta-optimizer plugin hook (constraints read) — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -4198,6 +4173,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): manta-optimizer plugin hook (counterfactual report) — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -4257,6 +4233,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): progress opencode tool — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -4308,6 +4285,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): peers opencode tools — relay the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -4343,6 +4321,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
       // Errors return a message the model can act on, never a bare 500.
+      // class-2 (BET-1460): app-control opencode tool — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -4361,7 +4340,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/state", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4385,7 +4364,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/pause-resume", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4438,7 +4417,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/health", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4463,7 +4442,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/ledger", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4487,7 +4466,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, 200, { ...render, journal: entries });
       return;
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/profile", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4516,7 +4495,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, 200, { ok: true, ...render });
       return;
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/profile-edit", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4540,7 +4519,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, 200, { ok: true, ...render });
       return;
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/profile-suppress", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4558,7 +4537,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, resDel?.ok ? 200 : 404, resDel ?? { ok: false, error: "not found" });
       return;
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/journal-delete", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4592,7 +4571,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/digest", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4617,7 +4596,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/digest-opened", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4676,7 +4655,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/verdict", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4702,7 +4681,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/tools-connect", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4733,7 +4712,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/tonight", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4761,7 +4740,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, 200, out);
       return;
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/facts", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4785,7 +4764,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, result?.ok ? 200 : 400, result);
       return;
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/facts-correct-pin", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4808,7 +4787,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, 200, await adaptiveCto.toolsView());
       return;
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/tools", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4827,7 +4806,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, result?.ok ? 200 : 400, result);
       return;
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/tools-revoke-unnever", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4864,7 +4843,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/suggest-held", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4882,7 +4861,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/cards", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4931,7 +4910,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/finished", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -4970,7 +4949,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      respondJson(res, 500, { error: String(e?.message ?? e) });
+      respondSafe500(res, "cto/facts-propose", CTO_SAFE_500_MESSAGE, e);
     }
     return;
   }
@@ -5009,6 +4988,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): send-to-cto opencode tool — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -5046,6 +5026,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): cto opencode tool (omnibus dispatch) — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -5078,6 +5059,7 @@ const handleRequest = async (req, res) => {
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
       // Errors return a message the model can act on, never a bare 500.
+      // class-2 (BET-1460): media opencode tools — relay the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -5125,6 +5107,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): widget opencode tool — relays the message to the model.
       respondJson(res, 500, { ok: false, error: String(e?.message ?? e) });
     }
     return;
@@ -5170,6 +5153,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): secrets opencode tool — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -5220,6 +5204,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      // class-2 (BET-1460): secrets opencode tool — relays the message to the model.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
@@ -5295,6 +5280,7 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 200, result);
     } catch (e) {
+      // class-2 (BET-1460): native iOS shell + curl — the shell never surfaces the body; raw aids diagnostics.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;

--- a/src/server/safeApiError.mjs
+++ b/src/server/safeApiError.mjs
@@ -1,0 +1,49 @@
+// safeApiError.mjs — the BET-1460 class-1 safe-500 writer.
+//
+// BET-1454 found /api/projects returning raw exception text (tmux stderr) in
+// its 500 body, and the desktop chat panel rendered it verbatim in the
+// composer banner — internal paths and command output on a user's screen.
+// BET-1458 extracted that handler; BET-1460 generalized the contract across
+// every respondJson(res, 500) site in index.mjs, splitting them by CONSUMER:
+//
+//   class 1 — routes whose 500 body can reach an END USER's screen (the chat
+//             panel's attachment chips, the CTO pane's toasts and load-error
+//             states, the iOS composer): the body carries a SAFE LITERAL and
+//             the underlying error goes to console.warn server-side with a
+//             `[api/<route>]` tag for log shipping. Every class-1 route MUST
+//             write its 500 through respondSafe500 — never respondJson with
+//             String(e?.message ?? e).
+//   class 2 — routes consumed only by an AI tool registrar (a manta-native
+//             opencode tool relays the message straight back to the model as
+//             a tool result — "unauthorized", "unknown action" are the whole
+//             self-correction value), an automation surface (the cap plugin
+//             runner), or an operator surface (Settings renders raw text only
+//             behind a `<details>` disclosure — settingsError.tsx). These
+//             keep the raw body and carry a `class-2 (BET-1460)` marker
+//             comment in index.mjs, asserted by errorBodyContract.test.mjs.
+//
+// Unit-tested in safeApiError.test.mjs; the index.mjs wiring is gated by
+// errorBodyContract.test.mjs.
+
+// Class-1 safe literals. Pinned literally in tests — a wording change is a
+// review-visible event. Keep them human, reason-shaped (the calling UI
+// already prefixes the action, e.g. "Couldn't load the ledger: …").
+export const UPLOAD_SAFE_500_MESSAGE = "Couldn't save the upload on the box.";
+export const CTO_SAFE_500_MESSAGE =
+  "The box's assistant service hit an unexpected error.";
+
+/**
+ * Write a class-1 500: safe human literal in the body, underlying error on
+ * the server-side console.warn.
+ *
+ * @param {import("node:http").ServerResponse} res
+ * @param {string} route  Short route tag for the console line only
+ *                        (e.g. "cto/verdict", "upload"). Never sent.
+ * @param {string} userMessage  The safe literal body (see the constants).
+ * @param {unknown} error  The caught underlying error (Error or thrown value).
+ */
+export function respondSafe500(res, route, userMessage, error) {
+  console.warn(`[api/${route}] 500 → safe body:`, error?.message ?? error);
+  res.writeHead(500, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: userMessage }));
+}

--- a/src/server/safeApiError.test.mjs
+++ b/src/server/safeApiError.test.mjs
@@ -1,0 +1,107 @@
+// Tests for the BET-1460 class-1 safe-500 writer (safeApiError.mjs).
+//
+// Every class-1 route's 500 body is written through respondSafe500 — these
+// tests pin the contract itself:
+//   - status 500 + application/json
+//   - the body carries ONLY the safe human literal (pinned exactly, so a
+//     wording change is a review-visible event)
+//   - the underlying error text NEVER reaches the body
+//   - the underlying error IS carried on console.warn with an `[api/<route>]`
+//     tag (server-side diagnosis for log shipping)
+//   - non-Error throws (strings) don't crash the writer
+//
+// Run via `npm run test:server` (node:test; in-memory, touches no state).
+
+import { test, mock } from "node:test";
+import assert from "node:assert/strict";
+import { Writable } from "node:stream";
+
+import {
+  CTO_SAFE_500_MESSAGE,
+  UPLOAD_SAFE_500_MESSAGE,
+  respondSafe500,
+} from "./safeApiError.mjs";
+
+class FakeRes extends Writable {
+  constructor() {
+    super();
+    this.statusCode = null;
+    this.headers = null;
+    this._chunks = [];
+  }
+  writeHead(status, headers) {
+    this.statusCode = status;
+    this.headers = headers;
+    return this;
+  }
+  get body() {
+    return Buffer.concat(this._chunks).toString("utf8");
+  }
+  _write(chunk, _enc, cb) {
+    this._chunks.push(Buffer.from(chunk));
+    cb();
+  }
+}
+
+// Distinctive "internal" error text — if any fragment of it leaks into the
+// body, a consumer's raw rendering would leak box internals to the user.
+const INTERNAL_MESSAGE =
+  "EACCES: permission denied, open '/home/dev/.manta-outbox/secret-name.bin'";
+
+test("respondSafe500 writes 500 + application/json with EXACTLY the safe literal", () => {
+  const res = new FakeRes();
+  respondSafe500(res, "cto/verdict", CTO_SAFE_500_MESSAGE, new Error(INTERNAL_MESSAGE));
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.headers["content-type"], "application/json");
+  assert.deepEqual(JSON.parse(res.body), { error: CTO_SAFE_500_MESSAGE });
+});
+
+test("the underlying error text never reaches the response body", () => {
+  const res = new FakeRes();
+  respondSafe500(res, "upload", UPLOAD_SAFE_500_MESSAGE, new Error(INTERNAL_MESSAGE));
+  assert.ok(!res.body.includes("EACCES"), "raw errno leaked into the 500 body");
+  assert.ok(!res.body.includes(".manta-outbox"), "raw path leaked into the 500 body");
+  assert.ok(!res.body.includes("secret-name"), "raw filename leaked into the 500 body");
+});
+
+test("the safe literals are pinned literally (wording drift is review-visible)", () => {
+  assert.equal(UPLOAD_SAFE_500_MESSAGE, "Couldn't save the upload on the box.");
+  assert.equal(CTO_SAFE_500_MESSAGE, "The box's assistant service hit an unexpected error.");
+});
+
+test("the underlying error goes to console.warn tagged with the route", () => {
+  const warnSpy = mock.method(console, "warn");
+  try {
+    const err = new Error(INTERNAL_MESSAGE);
+    const res = new FakeRes();
+    respondSafe500(res, "cto/ledger", CTO_SAFE_500_MESSAGE, err);
+    assert.ok(
+      warnSpy.mock.calls.some(
+        (c) =>
+          c.arguments[0] === "[api/cto/ledger] 500 → safe body:" &&
+          c.arguments[1] === INTERNAL_MESSAGE,
+      ),
+      "expected console.warn('[api/cto/ledger] 500 → safe body:', <underlying message>)",
+    );
+  } finally {
+    warnSpy.mock.restore();
+  }
+});
+
+test("a thrown non-Error (string) is handled — warned, never leaked", () => {
+  const warnSpy = mock.method(console, "warn");
+  try {
+    const res = new FakeRes();
+    respondSafe500(res, "upload", UPLOAD_SAFE_500_MESSAGE, "kaboom");
+    assert.equal(res.statusCode, 500);
+    assert.deepEqual(JSON.parse(res.body), { error: UPLOAD_SAFE_500_MESSAGE });
+    assert.ok(
+      warnSpy.mock.calls.some(
+        (c) =>
+          c.arguments[0] === "[api/upload] 500 → safe body:" && c.arguments[1] === "kaboom",
+      ),
+    );
+  } finally {
+    warnSpy.mock.restore();
+  }
+});

--- a/src/server/uploadRoute.mjs
+++ b/src/server/uploadRoute.mjs
@@ -1,0 +1,90 @@
+// uploadRoute.mjs — POST /api/upload route logic (BET-1460).
+//
+// Extracted from index.mjs on the projectsRoute.mjs pattern (BET-1458): the
+// real route logic is unit-testable here. The 500 catch goes through the
+// shared safe-500 writer (safeApiError.mjs) because BOTH consumer surfaces
+// render the response's error text to the end user — the desktop chat
+// panel's attachment chip (hover text on the red chip) and the iOS composer
+// (MantaAPIClient wraps `error` into MantaError.server and shows it). A raw
+// fs/stream message would leak absolute UPLOAD_ROOT paths and EPIPE/ENOSPC
+// output onto the user's screen; the underlying error is logged server-side
+// instead.
+//
+// Contract:
+//   - 200 { path }  — the absolute remote path the bytes were saved to
+//   - 400 { error } — "bad session" (session query missing/invalid) or
+//                     "missing X-Filename" (no usable filename header)
+//   - 500 { error: <UPLOAD_SAFE_500_MESSAGE> } — mkdir/stream failure; the
+//     raw error goes to console.warn with an `[api/upload]` tag.
+//
+// Byte flow: one request per file, raw bytes on the request body, filename +
+// batch id in headers (X-Filename percent-encoded, X-Batch-Id optional). No
+// multipart parser. Batch dirs are swept by startUploadCleanupPoller
+// (src/server/uploads.mjs).
+
+import { mkdir } from "node:fs/promises";
+import { pipeline } from "node:stream/promises";
+import { createWriteStream } from "node:fs";
+import { join } from "node:path";
+import { respondSafe500, UPLOAD_SAFE_500_MESSAGE } from "./safeApiError.mjs";
+
+export const SESSION_RE = /^[A-Za-z0-9._-]+$/;
+export const BATCH_RE = /^[0-9]{6,20}$/;
+
+export function safeBasename(name) {
+  // Strip path separators and control chars; collapse oddballs to "_".
+  let n = String(name).replace(/[\x00-\x1f\\/:*?"<>|]/g, "_");
+  if (n === "." || n === "..") n = "file";
+  if (!n) n = "file";
+  if (n.length > 200) n = n.slice(0, 200);
+  return n;
+}
+
+/**
+ * @param {object} deps
+ * @param {string} deps.uploadRoot  Absolute base dir (~/.manta-uploads).
+ *        Stream/fs implementations are injectable for failure-path tests;
+ *        defaults are the real node implementations.
+ */
+export function createUploadHandler({
+  uploadRoot,
+  mkdirImpl = mkdir,
+  pipelineImpl = pipeline,
+  createWriteStreamImpl = createWriteStream,
+}) {
+  return async function handleUpload(req, res, url) {
+    const session = url.searchParams.get("session");
+    if (!session || !SESSION_RE.test(session)) {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "bad session" }));
+      return;
+    }
+    const rawName = req.headers["x-filename"];
+    if (typeof rawName !== "string" || !rawName) {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "missing X-Filename" }));
+      return;
+    }
+    let decoded;
+    try { decoded = decodeURIComponent(rawName); } catch { decoded = rawName; }
+    const filename = safeBasename(decoded);
+
+    const batchHeader = req.headers["x-batch-id"];
+    const batch = typeof batchHeader === "string" && BATCH_RE.test(batchHeader)
+      ? batchHeader
+      : String(Date.now());
+
+    const dir = join(uploadRoot, session, batch);
+    const target = join(dir, filename);
+
+    try {
+      await mkdirImpl(dir, { recursive: true });
+      await pipelineImpl(req, createWriteStreamImpl(target));
+    } catch (e) {
+      respondSafe500(res, "upload", UPLOAD_SAFE_500_MESSAGE, e);
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ path: target }));
+  };
+}

--- a/src/server/uploadRoute.test.mjs
+++ b/src/server/uploadRoute.test.mjs
@@ -1,0 +1,158 @@
+// Tests for the POST /api/upload route (BET-1460).
+//
+// These drive the REAL handler (src/server/uploadRoute.mjs — the same module
+// index.mjs wires) against a real temp dir; the failure paths inject a
+// rejecting mkdir / pipeline. No re-implemented route mock.
+//
+// Contract pinned:
+//   - 400 "bad session" on a missing/invalid session query
+//   - 400 "missing X-Filename" on an unusable filename header
+//   - 200 { path } on success, with the filename sanitized (no separators)
+//   - failure: 500 whose body is ONLY the safe human message — raw
+//     fs/stream error text (absolute paths, errno output) never reaches the
+//     client body — and the underlying error carried on console.warn.
+
+import { test, mock } from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  BATCH_RE,
+  SESSION_RE,
+  createUploadHandler,
+  safeBasename,
+} from "./uploadRoute.mjs";
+import { UPLOAD_SAFE_500_MESSAGE } from "./safeApiError.mjs";
+
+class FakeRes {
+  constructor() {
+    this.statusCode = null;
+    this.headers = null;
+    this.body = "";
+  }
+  writeHead(status, headers) {
+    this.statusCode = status;
+    this.headers = headers;
+    return this;
+  }
+  end(chunk) {
+    this.body = typeof chunk === "string" ? chunk : String(chunk ?? "");
+  }
+}
+
+function makeReq(body, headers = {}) {
+  const req = Readable.from([Buffer.from(body ?? "")]);
+  req.headers = headers;
+  return req;
+}
+
+function makeUrl(session) {
+  return new URL(`http://x/api/upload${session ? `?session=${encodeURIComponent(session)}` : ""}`);
+}
+
+test("the session/filename regexes are pinned (path-traversal guards)", () => {
+  assert.equal(SESSION_RE.source, "^[A-Za-z0-9._-]+$");
+  assert.equal(BATCH_RE.source, "^[0-9]{6,20}$");
+});
+
+test("safeBasename strips separators and control chars", () => {
+  // Dots are not separators — "../etc/passwd" collapses to a flat name whose
+  // only risk (join()ing upward) is neutralized by the SESSION_RE-guarded
+  // session and the BATCH_RE-guarded batch around it. Pinned as-is.
+  assert.equal(safeBasename("../etc/passwd"), ".._etc_passwd");
+  assert.equal(safeBasename("a/b\\c:d*e?f\"g<h>i|j\u0000k"), "a_b_c_d_e_f_g_h_i_j_k");
+  assert.equal(safeBasename("."), "file");
+  assert.equal(safeBasename(""), "file");
+  assert.equal(safeBasename("x".repeat(300)), "x".repeat(200));
+});
+
+test("400 bad session on a missing/invalid session query", async () => {
+  const handler = createUploadHandler({ uploadRoot: "/tmp/unused" });
+  for (const session of [null, "bad session!", "../escape"]) {
+    const res = new FakeRes();
+    await handler(makeReq("", { "x-filename": "a.txt" }), res, makeUrl(session));
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(JSON.parse(res.body), { error: "bad session" });
+  }
+});
+
+test("400 missing X-Filename on an unusable filename header", async () => {
+  const handler = createUploadHandler({ uploadRoot: "/tmp/unused" });
+  const res = new FakeRes();
+  await handler(makeReq("bytes", {}), res, makeUrl("sess1"));
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(JSON.parse(res.body), { error: "missing X-Filename" });
+});
+
+test("success stores the bytes under <root>/<session>/<batch>/<name> and returns 200 { path }", async () => {
+  const root = await mkdtemp(join(tmpdir(), "manta-upload-test-"));
+  try {
+    const handler = createUploadHandler({ uploadRoot: root });
+    const res = new FakeRes();
+    await handler(
+      makeReq("FILEBYTES", { "x-filename": "report.pdf", "x-batch-id": "123456" }),
+      res,
+      makeUrl("better-ui"),
+    );
+    assert.equal(res.statusCode, 200);
+    const parsed = JSON.parse(res.body);
+    assert.deepEqual(parsed, { path: join(root, "better-ui", "123456", "report.pdf") });
+    assert.equal(await readFile(parsed.path, "utf8"), "FILEBYTES");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("mkdir failure returns 500 with ONLY the safe literal — raw error goes to console.warn", async () => {
+  const warnSpy = mock.method(console, "warn");
+  const rawError = new Error(
+    "EACCES: permission denied, mkdir '/home/dev/.manta-uploads/better-ui'",
+  );
+  try {
+    const handler = createUploadHandler({
+      uploadRoot: "/tmp/unused",
+      mkdirImpl: async () => {
+        throw rawError;
+      },
+    });
+    const res = new FakeRes();
+    await handler(
+      makeReq("bytes", { "x-filename": "a.txt" }),
+      res,
+      makeUrl("sess"),
+    );
+    assert.equal(res.statusCode, 500);
+    assert.equal(res.headers["content-type"], "application/json");
+    // The exact BET-1460 safe body — pinned literally.
+    assert.deepEqual(JSON.parse(res.body), { error: UPLOAD_SAFE_500_MESSAGE });
+    assert.ok(!res.body.includes("EACCES"), "raw errno leaked into the 500 body");
+    assert.ok(!res.body.includes(".manta-uploads"), "raw path leaked into the 500 body");
+    assert.ok(
+      warnSpy.mock.calls.some(
+        (c) =>
+          c.arguments[0] === "[api/upload] 500 → safe body:" &&
+          c.arguments[1] === rawError.message,
+      ),
+      "expected console.warn('[api/upload] 500 → safe body:', <underlying message>)",
+    );
+  } finally {
+    warnSpy.mock.restore();
+  }
+});
+
+test("stream failure returns the same 500 contract", async () => {
+  const handler = createUploadHandler({
+    uploadRoot: "/tmp/unused",
+    pipelineImpl: async () => {
+      throw new Error("stream blew up mid-pipe");
+    },
+  });
+  const res = new FakeRes();
+  await handler(makeReq("bytes", { "x-filename": "a.txt" }), res, makeUrl("sess"));
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(JSON.parse(res.body), { error: UPLOAD_SAFE_500_MESSAGE });
+  assert.ok(!res.body.includes("mid-pipe"), "raw stream error leaked into the body");
+});


### PR DESCRIPTION
## BET-1460 — 500-body contract for the sibling `/api/*` routes

Serializes after BET-1459 (merged). Implements the decided consumer-set contract from the issue.

**Base:** `origin/main @ 59728771`

## The classification (deliverable 1 — full enumeration)

All **46** `respondJson(res, 500)` sites in `src/server/index.mjs` were enumerated and consumer-traced (every site's renderer/tool/automation consumer checked in code, not guessed). Classification:

### Class 1 — raw text can reach an end user's screen → **converted (22 sites)**

| Route(s) | Site(s) | Consumer evidence |
|---|---|---|
| `POST /api/upload` | 2942 | ChatPanel attachment chip renders the error as the red chip's hover text; iOS `MantaAPIClient.upload` wraps `error` into `MantaError.server` and surfaces it in the native composer |
| `GET /api/cto/state` | 4364 | CtoPanel pane (App.tsx GET currently swallowed — converted for family uniformity) |
| `POST /api/cto/pause`/`resume` | 4388 | CtoPanel toast interpolates raw error (`Couldn't resume the CTO: ${e.message}`) |
| `GET /api/cto/health` | 4441 | CtoPanel `reportSettingsLoadError` toast |
| `GET /api/cto/ledger` | 4466 | CtoPanel ledger drill-down toast |
| `GET /api/cto/profile` | 4490 | CtoPanel profile pane (`setLoadError(e.message)` renders raw in-pane) |
| `POST /api/cto/profile/edit` | 4519 | CtoPanel toast `res.error ?? "Edit failed"` |
| `POST /api/cto/profile/suppress` | 4543 | CtoPanel toast `res.error ?? "Couldn't delete"` |
| `POST /api/cto/journal/delete` | 4561 | CtoPanel journal |
| `GET+POST /api/cto/digest` | 4595 | CtoPanel regen toast `Couldn't regenerate the digest: ${r.error}` |
| `POST /api/cto/digest/opened` | 4620 | CtoPanel instrumentation |
| `POST /api/cto/verdict` | 4679 | CtoPanel + the `cto_verdict` opencode tool (its meaningful errors are 400 bodies — untouched) |
| `POST /api/cto/tools/connect` | 4705 | CtoPanel toast `Couldn't record answer: ${r.error}` |
| `GET+POST /api/cto/tonight` | 4736 | CtoPanel tonight-queue verbs (all toast `... : ${r.error}`) |
| `GET /api/cto/facts` + `GET /api/cto/facts/archive` | 4764 | CtoPanel blackboard + archive toast `page.error` |
| `POST /api/cto/facts/correct`/`pin` | 4788 | CtoPanel toasts (`bb-corr-err` / `bb-pin-err`) |
| `GET /api/cto/tools` | 4811 | CtoPanel tool-integrations drill-down |
| `POST /api/cto/tools/revoke`/`unnever` | 4830 | CtoPanel toasts (`ti-rev-err` / `ti-unnever-err`) |
| `GET+POST /api/cto/suggest/held` | 4867 | CtoPanel suggestion toasts (`sugg-fail`, `held-…`) |
| `GET /api/cto/cards` | 4885 | CtoPanel blocker-cards pane |
| `GET /api/cto/finished` | 4934 | CtoPanel just-finished rail |
| `POST /api/cto/facts` | 4973 | CtoPanel decision card + the `cto_fact` tool (gatekeeper verdicts are 400 bodies — untouched) |

Conversion mechanics: all 22 write through the new `respondSafe500(res, route, message, e)` (`src/server/safeApiError.mjs`) — safe literal in the body, underlying error on `console.warn("[api/<route>] 500 → safe body:", …)`. The CTO family shares `CTO_SAFE_500_MESSAGE` ("The box's assistant service hit an unexpected error.") — the calling UIs already prefix the action ("Couldn't load the ledger: …"), so the body is a reason, not a restatement. `/api/upload` got the full `projectsRoute.mjs` extraction (`src/server/uploadRoute.mjs` + `uploadRoute.test.mjs`) since it was already a standalone function. **Deliberate scope choice:** the 21 CTO handlers stay inline in index.mjs (closure-bound over the engine) rather than each being extracted; the 500-write path itself is the unit-tested unit, plus a wiring gate — extracting ~330 lines of glue would add review surface without contract value. Flag if the reviewer wants full per-handler extraction.

### Class 2 — AI tool registrar / automation / operator surface → **kept raw + annotated (24 sites)**

`/auth/revoke` (3213 — desktop main classifies to fixed copy via `unpair.mjs`), `/api/schedule` (3504 — `schedule` tool; the card UI reads via `/rpc`), `/api/cap` (3624 — cap runner + `plugins` tool), `/api/delegate`+`approvals` (3743), `/api/plugins/registry` (3784 — tool + Settings, raw only behind its `<details>` disclosure per BET-419 §D), `/api/forge-rules` (3872 — tool + Settings toggles), `/api/webhook` (3943) and `/hook/<token>` delivery (3977 — forge machine-to-machine), `/api/serve-page` (4036), `/api/plan-render` (4073), `/api/notify` (4104), `/api/optimizer/{policy,constraints,counterfactual}` (4146/4177/4201), `/api/progress` (4260), `/api/peers` (4311), `/api/app-control` (4346), `/api/cto/inbound` (5012 — `send_to_cto` tool), `/api/cto` omnibus (5049 — `cto` tool), `/api/media` (5081), `/api/widgets` (5128), `/api/secrets/provide` (5173) + `/api/secrets` (5223), `/push/register-apns` (5298 — native shell never surfaces the body).

Each carries a `// class-2 (BET-1460): …` marker naming its consumer — asserted by the gate test. Meaningful 400-class bodies ("unknown action `foo`", "unauthorized", gatekeeper verdicts) are untouched on both classes — that's where the model's self-correction lives, and it is preserved.

## Tests (deliverable 2/3)

- `safeApiError.test.mjs` — the writer's contract: exact pinned literals, 500+json, raw error never in the body, `[api/<route>]` warn tag, non-Error throws.
- `uploadRoute.test.mjs` — real handler on a real tmp dir: 400s, success byte-path, sanitized filename, mkdir/stream failure → safe 500 + warn.
- `errorBodyContract.test.mjs` — wiring gate (source-scan, the `ctoSweeperWiring` pattern): every remaining raw 500 in index.mjs must carry the class-2 marker within 3 lines; exactly 21 `respondSafe500(res, "cto/…"` sites; upload extraction wired; AGENTS.md rule present.

## AGENTS.md (deliverable 4)

Rule recorded under "Patterns worth knowing": classify by consumer before writing the catch; class-1 → `respondSafe500` only; class-2 → marker comment; gate test enforces both.

## Verification results

**Files changed:** 7 files, +568/−66 (`AGENTS.md`, `src/server/index.mjs`, + `safeApiError.mjs`, `safeApiError.test.mjs`, `uploadRoute.mjs`, `uploadRoute.test.mjs`, `errorBodyContract.test.mjs`)

- PR branch (`multica/BET-1460-error-body-contract` @ `d7bac8a6`):
  - typecheck: exit 0, no errors. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3840 pass / 0 fail / 0 skip (includes the 16 new tests). log sha256: `e96e876d70541858190ab2f253d0518b82323dd80e8cae55ffbe961a87b3980f`
- Base (`main` @ `59728771`):
  - typecheck: exit 0, no errors. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3824 pass / 0 fail / 0 skip. log sha256: `6c0504c51665b6a3015bcb3ab4654e9da73aea7cff6d24bbceb148383cba14db`
- **Conclusion:** 0 pre-existing failures, 0 new failures. The 16-test delta is this PR's new coverage.

No actionable follow-ups left un-filed: voice routes already return curated per-result errors; Settings' raw-behind-disclosure pattern is the BET-419 §D design, not drift.
