### PR TITLE
fix(server): scope ci checkable-verify to the statement's branch (BET-1504)

### DIFF
--- a/src/server/ctoFactSurfaces.mjs
+++ b/src/server/ctoFactSurfaces.mjs
@@ -8,7 +8,9 @@
 //           (probe: `git cat-file -e`, which resolves branch names and
 //           commit/short-shas alike through the revision machinery)
 //   ci    → a gh binary AND a usable repo surface (probe polarity checked
-//           against the latest completed run's conclusion)
+//           against the latest completed run's conclusion; a statement that
+//           names a branch scopes the query to that branch — BET-1504 —
+//           otherwise the repo-wide latest run is the evidence)
 //   issue → a multica binary AND a consented issue tool in the §7 registry
 //           ("a consented tool for issue facts" — consent metadata ring)
 // Any other surface (e.g. "version") is unimplemented here → surfaceExists
@@ -109,8 +111,9 @@ export function createFactSurfaces(deps = {}) {
   }
 
   // §6.7 verify probe — called by verifyDue as
-  // { surface, probe, project }. Returns { ok, result }.
-  async function verify({ surface, probe, project } = {}) {
+  // { surface, probe, branch, project }. Returns { ok, result }.
+  // branch (BET-1504) is ci-only scope: null → repo-wide latest run.
+  async function verify({ surface, probe, branch = null, project } = {}) {
     if (surface === "git") {
       const cwds = await readyCwds(project ?? null).catch(() => []);
       if (cwds.length === 0) return { ok: false, result: "no surface" };
@@ -124,7 +127,10 @@ export function createFactSurfaces(deps = {}) {
     if (surface === "ci") {
       const cwds = await readyCwds(project ?? null).catch(() => []);
       if (cwds.length === 0) return { ok: false, result: "no surface" };
-      const conclusion = await ciLatestConclusion(cwds[0]).catch(() => null);
+      // BET-1504: a statement that names a branch ("CI on branch F is green")
+      // must be confirmed by THAT branch's latest run — the repo-wide latest
+      // run never looked at F and cannot confirm (or refute) its state.
+      const conclusion = await ciLatestConclusion(cwds[0], branch ?? null).catch(() => null);
       if (!conclusion) return { ok: false, result: "unavailable" };
       return { ok: ciConclusionMatches(probe, conclusion), result: String(conclusion) };
     }

--- a/src/server/ctoFactSurfaces.test.mjs
+++ b/src/server/ctoFactSurfaces.test.mjs
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 import { COMMIT_SHA_RE, MESSAGE_REF_RE, ciConclusionMatches, createFactSurfaces } from "./ctoFactSurfaces.mjs";
 
 function makeSurfaces(over = {}) {
-  const calls = { surfaceExists: [], verify: [], resolveRef: [] };
+  const calls = { surfaceExists: [], verify: [], resolveRef: [], ciLatest: [] };
   const surfaces = createFactSurfaces({
     cwdsFor: async (project) => (project == null ? ["/repo/a", "/repo/b"] : project === "p1" ? ["/repo/p1"] : []),
     runGit: async (cwd, args) => {
@@ -19,7 +19,10 @@ function makeSurfaces(over = {}) {
     },
     hasBinary: async (name) => ["git", "gh", "multica"].includes(name),
     issueLookup: async (key) => (key === "BET-1" ? { found: true, open: true } : key === "BET-2" ? { found: true, open: false } : null),
-    ciLatestConclusion: async (cwd) => (cwd === "/repo/p1" ? "success" : null),
+    ciLatestConclusion: async (cwd, branch) => {
+      calls.ciLatest.push([cwd, branch]);
+      return cwd === "/repo/p1" ? "success" : null;
+    },
     messageExists: async (id) => (id === "msg_ghost" ? false : id === "msg_ok" ? true : null),
     issueToolConsented: async () => true,
     ...over,
@@ -144,6 +147,30 @@ test("verify ci: probe polarity against the latest completed conclusion", async 
   const gone = await surfaces.verify({ surface: "ci", probe: "green", project: "other" });
   assert.equal(gone.ok, false);
   assert.equal(gone.result, "no surface");
+});
+
+// BET-1504: a statement that names a branch ("CI on branch F is green") must
+// be judged by THAT branch's latest run — the repo-wide latest run never
+// looked at F and cannot confirm (or refute) its state.
+test("verify ci: branch scope threads into ciLatestConclusion (BET-1504)", async () => {
+  const { surfaces, calls } = makeSurfaces();
+  await surfaces.verify({ surface: "ci", probe: "green", branch: "feature/x", project: "p1" });
+  assert.deepEqual(calls.ciLatest.at(-1), ["/repo/p1", "feature/x"], "branch passed to the conclusion seam");
+  // No branch in the probe → null → repo-wide semantics preserved.
+  await surfaces.verify({ surface: "ci", probe: "green", project: "p1" });
+  assert.deepEqual(calls.ciLatest.at(-1), ["/repo/p1", null]);
+});
+
+test("verify ci: a branch-scoped probe is judged by THAT branch's run, not the repo-wide latest (BET-1504)", async () => {
+  // The repo-wide latest completed run is green; branch feature/red's own
+  // latest run is red. "CI on branch feature/red is green" must NOT confirm.
+  const scoped = makeSurfaces({
+    ciLatestConclusion: async (cwd, branch) => (branch === "feature/red" ? "failure" : "success"),
+  }).surfaces;
+  assert.equal((await scoped.verify({ surface: "ci", probe: "green", branch: "feature/red", project: "p1" })).ok, false);
+  assert.equal((await scoped.verify({ surface: "ci", probe: "green", branch: "feature/green", project: "p1" })).ok, true);
+  // No branch → repo-wide latest (green) → confirmed, as before.
+  assert.equal((await scoped.verify({ surface: "ci", probe: "green", project: "p1" })).ok, true);
 });
 
 test("verify issue: open → ok, closed/not-found/unavailable → not ok", async () => {

--- a/src/server/ctoFactSurfacesWiring.test.mjs
+++ b/src/server/ctoFactSurfacesWiring.test.mjs
@@ -78,3 +78,13 @@ test("BET-1409: the factSurfaces bundle is constructed with the real surface dep
   // The message-id leg rides the shared read-only opencode db handle.
   assert.ok(block.includes("getDb()"), "messageExists must ride the opencodeDb handle");
 });
+
+// BET-1504: the ci conclusion seam must accept a branch scope and pass it to
+// `gh run list --branch <name>` — a statement that names a branch is judged
+// by that branch's run, not the repo-wide latest.
+test("BET-1504: the ci conclusion seam scopes gh run list to the statement's branch", () => {
+  const block = depsBlock(indexSource, "ciLatestConclusion:");
+  assert.ok(block.length > 0, "ciLatestConclusion block found in index.mjs");
+  assert.ok(block.includes("branch"), "ciLatestConclusion must take a branch parameter");
+  assert.ok(block.includes('"--branch"'), "gh run list must support --branch scoping");
+});

--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -549,12 +549,49 @@ export function enforceCap(activeFacts, { cap = CAP_ACTIVE, nowMs, halfLives, we
   return { facts, displaced };
 }
 
+// BET-1504: filler words that can sit where a branch name would — capturing
+// one would scope the CI probe to a branch that is not a branch ("CI green
+// on the latest run" must stay repo-wide, not probe a branch named "the").
+const CI_BRANCH_STOPWORDS = new Set([
+  "the", "a", "an", "this", "that", "these", "those", "every", "each", "all", "any", "some", "no", "another", "other",
+  "it", "its", "our", "their", "his", "her", "my", "your", "one", "both", "either", "neither",
+  "is", "was", "are", "were", "be", "been", "being", "has", "have", "had", "will", "would", "should", "could",
+  "can", "may", "might", "must", "shall", "do", "does", "did", "not", "still", "yet", "again",
+  "in", "on", "at", "to", "for", "with", "from", "by", "of", "as", "into", "onto", "over", "under", "after",
+  "before", "during", "since", "until", "about", "across", "against", "along", "among", "around", "because",
+  "but", "and", "or", "so", "if", "then", "than", "when", "while", "just", "very", "now",
+]);
+
+// Branch token for a CI statement — first non-filler capture wins:
+//   "branch <name>"  ("CI on branch feature/x is green")
+//   "CI on <name>"   ("CI on feature/x is green")
+//   "<status> on <name>" ("CI is green on main")
+// No branch-looking token → null → the CI surface keeps repo-wide semantics.
+function ciBranchOf(s) {
+  const patterns = [
+    /\bbranch\s+([A-Za-z0-9_\-.\/]+)\b/i,
+    /\bCI\s+on\s+([A-Za-z0-9_\-.\/]+)\b/i,
+    /\b(?:green|passing|passed|failed|failing|broken)\s+on\s+([A-Za-z0-9_\-.\/]+)\b/i,
+  ];
+  for (const re of patterns) {
+    const m = s.match(re);
+    if (!m) continue;
+    const token = m[1].replace(/[._\-\/]+$/, "");
+    if (token && !CI_BRANCH_STOPWORDS.has(token.toLowerCase())) return token;
+  }
+  return null;
+}
+
 export function matchCheckable(statement) {
   const s = String(statement ?? "");
+  // CI first (BET-1504): a CI statement that names a branch must reach the
+  // ci surface with that branch — not fall through to the bare branch rule
+  // below, whose git-existence probe confirms "CI on F is green" the moment
+  // branch F merely exists, CI state never consulted.
+  const ci = s.match(/\bCI\b[\s\S]*?\b(green|passing|passed|failed|failing|broken)\b/i);
+  if (ci) return { kind: "ci", surface: "ci", probe: ci[1].toLowerCase(), branch: ciBranchOf(s) };
   const branch = s.match(/\bbranch\s+([A-Za-z0-9_\-.\/]+)\b/i);
   if (branch) return { kind: "branch", surface: "git", probe: branch[1] };
-  const ci = s.match(/\bCI\b[\s\S]*?\b(green|passing|passed|failed|failing|broken)\b/i);
-  if (ci) return { kind: "ci", surface: "ci", probe: ci[1].toLowerCase() };
   const issue = s.match(/\b([A-Z][A-Z0-9]+-\d+)\b/);
   if (issue) return { kind: "issue", surface: "issue", probe: issue[1] };
   const ver = s.match(/\bversion\s+(\d+(?:\.\d+){1,3})\b/i);
@@ -575,7 +612,12 @@ export async function maybeStampCheckable(fact, { surfaceExists = async () => fa
     exists = false;
   }
   if (!exists) return fact;
-  return { ...fact, checkable: { probe: match.probe, last_checked: 0, result: null } };
+  // BET-1504: ci probes may carry branch scope (probe stays the status word —
+  // facts stamped before this change have no branch field and keep verifying
+  // repo-wide). Absent → the stamp keeps the old shape.
+  const stamp = { probe: match.probe, last_checked: 0, result: null };
+  if (match.branch) stamp.branch = match.branch;
+  return { ...fact, checkable: stamp };
 }
 
 export function median(arr) {
@@ -921,7 +963,13 @@ export function createFactsEngine(deps = {}) {
         try {
           // BET-1409: verify receives the project so the real §6.7 surfaces
           // can resolve the probe's cwd (git worktree / CI repo scope).
-          const r = await verify({ surface: matchCheckable(f.statement)?.surface, probe: f.checkable.probe, project: proj });
+          // BET-1504: ci probes carry optional branch scope from the stamp.
+          const r = await verify({
+            surface: matchCheckable(f.statement)?.surface,
+            probe: f.checkable.probe,
+            branch: f.checkable.branch ?? null,
+            project: proj,
+          });
           ok = r?.ok === true;
           result = r?.result ?? null;
         } catch {

--- a/src/server/ctoFacts.test.mjs
+++ b/src/server/ctoFacts.test.mjs
@@ -343,10 +343,32 @@ test("enforceCap displaces the lowest-retention fact over the cap", () => {
 });
 
 test("matchCheckable recognizes branch/ci/issue probes", () => {
-  assert.deepEqual(matchCheckable("CI is green on main"), { kind: "ci", surface: "ci", probe: "green" });
+  assert.deepEqual(matchCheckable("CI is green on main"), { kind: "ci", surface: "ci", probe: "green", branch: "main" });
   assert.deepEqual(matchCheckable("branch fix/foo merged"), { kind: "branch", surface: "git", probe: "fix/foo" });
   assert.deepEqual(matchCheckable("BET-1234 is open"), { kind: "issue", surface: "issue", probe: "BET-1234" });
   assert.equal(matchCheckable("arbitrary thought"), null);
+});
+
+// BET-1504: a CI statement that names a branch scopes the ci probe to it
+// instead of falling through to the git branch-existence rule or losing the
+// branch entirely (repo-wide latest run).
+test("matchCheckable: ci statements capture their branch scope (BET-1504)", () => {
+  assert.deepEqual(matchCheckable("CI on branch feature/x is green"), { kind: "ci", surface: "ci", probe: "green", branch: "feature/x" });
+  assert.deepEqual(matchCheckable("CI on feature/x is green"), { kind: "ci", surface: "ci", probe: "green", branch: "feature/x" });
+  assert.deepEqual(matchCheckable("CI on branch F is broken"), { kind: "ci", surface: "ci", probe: "broken", branch: "F" });
+  // Trailing punctuation is not part of the branch token.
+  assert.deepEqual(matchCheckable("CI green on main."), { kind: "ci", surface: "ci", probe: "green", branch: "main" });
+  // No branch context → ci probe with null branch (repo-wide semantics kept).
+  assert.deepEqual(matchCheckable("CI is green"), { kind: "ci", surface: "ci", probe: "green", branch: null });
+  assert.deepEqual(matchCheckable("CI green"), { kind: "ci", surface: "ci", probe: "green", branch: null });
+  // Fillers are never branch tokens ("CI green on the latest run" stays repo-wide).
+  assert.deepEqual(matchCheckable("CI on the latest run is green"), { kind: "ci", surface: "ci", probe: "green", branch: null });
+  assert.deepEqual(matchCheckable("CI is green on the feature branch."), { kind: "ci", surface: "ci", probe: "green", branch: null });
+  // Ordering: CI + branch beats the bare branch rule — a git cat-file check
+  // would confirm "CI on F is green" the moment branch F merely exists.
+  assert.equal(matchCheckable("branch feature/x exists and CI is green").surface, "ci");
+  // Bare branch statements (no CI status) still route to git untouched.
+  assert.deepEqual(matchCheckable("branch fix/foo merged"), { kind: "branch", surface: "git", probe: "fix/foo" });
 });
 
 test("median works on even/odd/empty", () => {
@@ -455,6 +477,36 @@ test("checkable: pump and verifyDue pass the project ctx to the surface seams", 
   assert.ok(seenVerify.length >= 1, "verify consulted on the cycle");
   assert.equal(seenVerify[0].project, "alpha", "verify receives the project");
   assert.equal(seenVerify[0].surface, "git");
+});
+
+// BET-1504: ci probes may carry branch scope from the statement — the stamp
+// records it and verifyDue threads it into the verify seam. Facts without a
+// branch (and pre-BET-1504 stamps) verify with branch: null → repo-wide.
+test("checkable: ci branch scope is stamped and threaded to verify (BET-1504)", async () => {
+  const seenVerify = [];
+  const { engine } = makeEngine({
+    surfaceExists: async (s) => s === "ci",
+    verify: async (args) => {
+      seenVerify.push(args);
+      return { ok: true };
+    },
+  });
+  await engine.submitProposal({ proposalId: "cb", project: "alpha", kind: "status", statement: "CI on branch feature/x is green", refs: ["r1"] });
+  await engine.pump();
+  await engine.submitProposal({ proposalId: "cn", project: "alpha", kind: "status", statement: "CI is green", refs: ["r2"] });
+  await engine.pump();
+  const staged = (await engine.listFacts("alpha"));
+  const f = staged.find((x) => x.statement === "CI on branch feature/x is green");
+  const g = staged.find((x) => x.statement === "CI is green");
+  assert.equal(f.checkable.probe, "green");
+  assert.equal(f.checkable.branch, "feature/x", "branch scope stamped from the statement");
+  assert.equal(g.checkable.probe, "green");
+  assert.equal(g.checkable.branch, undefined, "no branch in the statement → old stamp shape");
+  await engine.verifyDue();
+  assert.equal(seenVerify.length, 2, "verify consulted once per checkable fact");
+  const byBranch = new Map(seenVerify.map((v) => [v.branch ?? "none", v]));
+  assert.deepEqual(byBranch.get("feature/x"), { surface: "ci", probe: "green", branch: "feature/x", project: "alpha" });
+  assert.deepEqual(byBranch.get("none"), { surface: "ci", probe: "green", branch: null, project: "alpha" });
 });
 
 test("touchFacts bumps last_accessed + access_count on retrieval", async () => {

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -2072,8 +2072,15 @@ const factSurfaces = createFactSurfaces({
   },
   // Latest COMPLETED workflow run's conclusion in the repo at cwd (newest
   // first). No completed run (fresh repo, gh error) → null → "unavailable".
-  ciLatestConclusion: async (cwd) => {
-    const { stdout } = await promisify(execFile)("gh", ["run", "list", "--limit", "10", "--json", "conclusion,status"], {
+  // BET-1504: branch (from the statement's ci probe) scopes the query to that
+  // branch's runs — `gh run list --branch <name>`; null keeps the repo-wide
+  // latest-run semantics (§6.7 opportunism: no branch in the statement → no
+  // branch filter).
+  ciLatestConclusion: async (cwd, branch = null) => {
+    const args = ["run", "list", "--limit", "10", "--json", "conclusion,status"];
+    const b = String(branch ?? "").trim();
+    if (b) args.push("--branch", b);
+    const { stdout } = await promisify(execFile)("gh", args, {
       cwd,
       timeout: 15000,
     });


### PR DESCRIPTION
## CI checkable-verify now honors the statement's branch

Two false-confirmation paths fixed in the §6.7 CI verify seam:

1. **"CI on branch F is green" was verified by branch *existence*, not CI.** `matchCheckable`'s bare-branch rule ran before the CI rule, so a CI statement naming a branch got stamped as a git probe (`git cat-file -e F`) — confirmed the moment branch F existed, CI never consulted.
2. **Bare CI statements verified against the repo-wide latest run.** A fact could be confirmed on a run that never looked at the statement's subject — the wrong-value risk the issue filed, feeding §6.6 sender-reliability counters on bad evidence.

**The fix** (`Base: origin/main @ 23366e6c`, PR: https://github.com/antoinedc/MantaUI/pull/1488):

- `matchCheckable` CI arm now runs first and captures branch scope (`ciBranchOf`: `CI on branch X`, `CI on X`, `<status> on X`, stopword-filtered, trailing punctuation stripped) → `{ surface: "ci", probe: <status>, branch: <string|null> }`.
- `maybeStampCheckable` records `checkable.branch` only when present (pre-BET-1504 stamps, and statements without a branch, keep the old shape and verify repo-wide — §6.7 opportunism preserved).
- `verifyDue` threads `branch` into the `verify()` seam; the `factSurfaces` ci leg passes it to `ciLatestConclusion(cwd, branch)`; the wiring appends `--branch <name>` to `gh run list`.

**Files changed:** 6 — `src/server/ctoFacts.mjs`, `src/server/ctoFactSurfaces.mjs`, `src/server/index.mjs`, + 3 test files (5 new test blocks: branch-capture forms incl. stopword/punctuation/ordering edges, stamp+verifyDue threading, `ciLatestConclusion` branch threading, and the core polarity regression — branch-red probe not confirmed by the repo-wide green run).

**Verification results:**
- PR branch (`multica/BET-1504-ci-branch-verify` @ `16108a55`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, 3909 vitest pass / 7 skip; node:test 3856 pass / 0 fail. Failures: none. log sha256: `c80b58b8f64d6a9a8504ab14a8b6e82200bbc80dca29ef68d460d9c902d3cb14`
- Base (`main` @ `23366e6c`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, 3909 vitest pass / 7 skip; node:test 3851 pass / 0 fail. Failures: none. log sha256: `6d3f880a0c8cde12730b3ceb23934e393e533e2d0079fef2a18c6037ead56590`
- **Conclusion:** 0 pre-existing failures, 0 new failures; 5 new passing test blocks added by this PR (3851 → 3856 node:test).

**Known heuristic (documented in code):** branch capture is stopword-filtered pattern matching on prose — an unusual noun phrase ("the CI branch pipeline is green") can be read as a branch. Failure mode is a no-evidence failed check (gatekeeper supersession), never a false confirm.

Follow-ups filed (parked, low): BET-1508 (legacy bare-branch rule lacks the trailing-punctuation strip the new helper has), BET-1509 (`CtoFactRow.checkable` typed `string | null` but the server sends the object — latent, no renderer consumer yet).
