### PR TITLE
fix(server): BET-1503 — uncounted ROI pending rows past the horizon no longer churn while their record lives

### DIFF
--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -664,9 +664,10 @@ function monthAccumulator(months, key) {
   };
 }
 
-// Pending rows older than this are dropped (bounded growth; a merge that
-// surfaced 60 days late is beyond the report's honest horizon). BET-1497:
-// the drop is liveness-aware — see retainPendingHorizon.
+// Pending rows older than this are dropped — liveness-aware since BET-1497,
+// on both halves since BET-1503 — see retainPendingHorizon. The horizon
+// bounds growth only for records the store itself retires; a record the
+// store keeps forever (dirty worktree) keeps its row.
 export const ROI_PENDING_RETENTION_MS = 60 * 24 * HOUR_MS;
 
 /**
@@ -687,7 +688,10 @@ export const ROI_PENDING_RETENTION_MS = 60 * 24 * HOUR_MS;
  * `liveIds` is the set of job ids the store actually returned this refresh,
  * or null when the read failed (liveness unknowable → no counted row is
  * evictable). When protection leaves more than `cap` rows, the list exceeds
- * the cap until the store retires the records.
+ * the cap until the store retires the records. BET-1503: with the horizon
+ * no longer churning live uncounted rows, this cap is the remaining growth
+ * bound — an uncounted row it evicts whose record is still stored re-samples
+ * on the next refresh (the re-sampled row lands at the back of the list).
  */
 export function trimPendingCap(rows, { cap = 200, liveIds = null } = {}) {
   if (rows.length <= cap) return rows;
@@ -702,32 +706,39 @@ export function trimPendingCap(rows, { cap = 200, liveIds = null } = {}) {
 }
 
 /**
- * The liveness-aware retention horizon on `roi.pending` (BET-1497). The
- * BET-1466 filter assumed a counted row dropped at the horizon can never be
+ * The liveness-aware retention horizon on `roi.pending` (BET-1497, BET-1503).
+ * The BET-1466 filter assumed a row dropped at the horizon can never be
  * re-counted — true only while the delegate store's sweeper eventually
  * removes every terminal record. It does not: a job that finished with a
  * dirty worktree (`cleanedUp === false`) is kept FOREVER (applyRetention
  * spares it by time and by the 50-terminal-record cap alike). Dropping that
- * job's fingerprint re-opens it to step 1's sampling — the same double-count
- * the BET-1487 cap closed, reached through the retention path and
- * independent of job volume. So the horizon drops:
- *   - an uncounted row past the horizon (re-sampling it merely re-probes a
- *     job that has never been counted — no double count), and
- *   - a counted row past the horizon only once its record is provably gone
- *     from the jobs snapshot — absence is final (job ids are minted once and
- *     the store's sweeper only removes records), and
- *   - never a counted row whose id is still in `liveIds`, nor any counted
- *     row while liveness is unknowable (`liveIds === null` — the store read
- *     failed; the same convention the cap applies).
- * A counted row without a timestamp has no age to retire and is kept, as
- * before. `liveIds` is the set shared with `trimPendingCap` — one snapshot
- * read in step 1 answers both hygiene passes.
+ * job's row re-opens it to step 1's sampling — for a counted row the same
+ * double-count the BET-1487 cap closed, reached through the retention path;
+ * for an uncounted row (BET-1503) pure churn: re-sample → probe → age-out
+ * on every refresh, with the row's `pr`/`prTried` markers lost each cycle —
+ * a definitive no-PR was re-asked of the forge forever. So the horizon
+ * keeps, past the horizon:
+ *   - a row whose record is provably still in the jobs snapshot (counted or
+ *     not), and
+ *   — while liveness is unknowable (`liveIds === null` — the store read
+ *     failed), every row (the same convention the cap applies), and
+ *   - a counted row without a timestamp (no age to retire), as before —
+ *     while an uncounted timestamp-less row gets the same liveness rule.
+ * A row is dropped only once its record is provably gone from the snapshot —
+ * absence is final (job ids are minted once and the store's sweeper only
+ * removes records). Growth is no longer bounded by the horizon alone: rows
+ * whose records the store keeps forever mirror the store's own retention —
+ * the trade BET-1497 already accepted for counted rows; the 200-row cap
+ * stays the last bound. `liveIds` is the set shared with `trimPendingCap` —
+ * one snapshot read in step 1 answers both hygiene passes.
  */
 export function retainPendingHorizon(rows, { cutoff, liveIds = null } = {}) {
   return rows.filter((j) => {
-    if (typeof j.finishedAt !== "number") return j.counted === true;
+    if (typeof j.finishedAt !== "number") {
+      return j.counted === true || liveIds === null || liveIds.has(j.id);
+    }
     if (j.finishedAt >= cutoff) return true;
-    return j.counted === true && (liveIds === null || liveIds.has(j.id));
+    return liveIds === null || liveIds.has(j.id);
   });
 }
 
@@ -1185,18 +1196,19 @@ function validPrRef(ref) {
             if (computed) months[key] = computed;
           }
 
-          // 4. Hygiene: age out stale pending rows. The retention horizon
-          //    applies to BOTH halves (BET-1466: it used to filter only
-          //    counted rows while the never-merged ones — the rows that
-          //    actually accumulate — were kept forever). A counted row is a
-          //    dedupe fingerprint, so dropping one at the horizon requires
-          //    proof its job can never re-sample — and "the store sweeps
-          //    terminal records after 7 days" is not proof: a dirty-worktree
-          //    terminal record is never swept. The drop is liveness-aware
-          //    (BET-1497): a counted row past the horizon survives while its
-          //    record is still in the snapshot read in step 1 (or while the
-          //    read failed and liveness is unknowable) — the same rule the
-          //    cap below applies.
+          // 4. Hygiene: age out stale pending rows. The horizon drop is
+          //    liveness-aware on BOTH halves (BET-1466 first applied the
+          //    horizon to counted rows too, BET-1497 made the counted half
+          //    liveness-aware, BET-1503 the uncounted half): past the
+          //    horizon a row drops only once the snapshot read in step 1
+          //    proves its delegate record gone — "the store sweeps terminal
+          //    records after 7 days" is not proof: a dirty-worktree terminal
+          //    record is never swept, and dropping its row churned the job
+          //    back through re-sample → probe → age-out on every refresh
+          //    (losing the row's pr/prTried markers with each cycle, so a
+          //    definitive no-PR was re-asked of the forge forever). While
+          //    the read failed, liveness is unknowable and nothing drops —
+          //    the same rule the cap below applies.
           const cutoff = t - ROI_PENDING_RETENTION_MS;
           const liveIds = jobsReadOk
             ? new Set(jobs.map((j) => (j && typeof j.id === "string" ? j.id : null)).filter((id) => id !== null))

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -866,11 +866,15 @@ test("trimPendingCap evicts oldest-first but spares counted fingerprints that ca
 // horizon is a still-needed dedupe fingerprint while its delegate record can
 // re-sample (a dirty-worktree terminal record is never swept), so the drop
 // waits for the snapshot to prove the record gone.
-test("retainPendingHorizon ages rows past the horizon but spares counted fingerprints that can still re-sample (BET-1497)", () => {
+// BET-1503: the same liveness rule now covers the UNCOUNTED half — dropping
+// a live uncounted row churned its still-stored job back through re-sample →
+// probe → age-out on every refresh, losing the row's pr/prTried markers with
+// each cycle.
+test("retainPendingHorizon ages rows past the horizon but spares fingerprints — counted or not — that can still re-sample (BET-1497, BET-1503)", () => {
   const stale = MIDNIGHT - ROI_PENDING_RETENTION_MS - 1;
   const cutoff = MIDNIGHT - ROI_PENDING_RETENTION_MS;
   const row = (id, counted, finishedAt = stale) => ({ id, counted, finishedAt });
-  // Fresh rows (both kinds) and a counted row without a timestamp: kept, as before.
+  // Fresh rows (both kinds) and counted rows without a timestamp: kept, as before.
   const fresh = [row("f", false, MIDNIGHT - 1), row("fc", true, MIDNIGHT - 1), row("cn", true, null)];
   assert.deepEqual(
     retainPendingHorizon(fresh, { cutoff, liveIds: new Set() }).map((j) => j.id),
@@ -881,17 +885,34 @@ test("retainPendingHorizon ages rows past the horizon but spares counted fingerp
     retainPendingHorizon([row("u", false), row("c", true)], { cutoff, liveIds: new Set() }).map((j) => j.id),
     [],
   );
-  // Past the horizon with the record STILL in the store: the counted
-  // fingerprint survives; the uncounted row still ages out.
+  // Past the horizon with the record STILL in the store: both kinds survive —
+  // the counted fingerprint (BET-1497) and the uncounted row (BET-1503).
   assert.deepEqual(
-    retainPendingHorizon([row("u", false), row("c", true)], { cutoff, liveIds: new Set(["c"]) }).map((j) => j.id),
-    ["c"],
+    retainPendingHorizon([row("u", false), row("c", true)], { cutoff, liveIds: new Set(["c", "u"]) }).map((j) => j.id),
+    ["u", "c"],
   );
-  // A failed jobs read (liveIds null) keeps the counted fingerprint —
-  // liveness unknowable, the same convention the cap applies.
+  // A live UNCOUNTED row survives even when other ids are in the snapshot —
+  // the rule keys on the row's own id, not on liveness in general.
+  assert.deepEqual(
+    retainPendingHorizon([row("u", false)], { cutoff, liveIds: new Set(["other"]) }).map((j) => j.id),
+    [],
+  );
+  // A failed jobs read (liveIds null) keeps both halves — liveness
+  // unknowable, the same convention the cap applies.
   assert.deepEqual(
     retainPendingHorizon([row("u", false), row("c", true)], { cutoff, liveIds: null }).map((j) => j.id),
-    ["c"],
+    ["u", "c"],
+  );
+  // An uncounted timestamp-less row never had an age to retire; it now gets
+  // the same liveness rule (kept while its record is in the snapshot) instead
+  // of churning, while a counted one is kept unconditionally, as before.
+  assert.deepEqual(
+    retainPendingHorizon([row("un", false, null), row("cn", true, null)], { cutoff, liveIds: new Set(["un"]) }).map((j) => j.id),
+    ["un", "cn"],
+  );
+  assert.deepEqual(
+    retainPendingHorizon([row("un", false, null), row("cn", true, null)], { cutoff, liveIds: new Set() }).map((j) => j.id),
+    ["cn"],
   );
 });
 
@@ -1011,6 +1032,71 @@ test("refreshRoi: a counted row past the horizon survives while its dirty-worktr
   recordLive = false;
   await budget.refreshRoi();
   assert.equal(payload.roi.months[AUG_KEY].merged, 1);
+  assert.equal(payload.roi.pending.length, 0);
+});
+
+// BET-1503: the same churn, on the UNCOUNTED half — a never-merged job whose
+// dirty-worktree record lives forever used to re-sample (row minted) and
+// age-out (row dropped) on every refresh, and each dropped row took its
+// pr/prTried markers with it, so a definitive no-PR was re-asked of the
+// forge indefinitely. The row is now kept while its record is in the
+// snapshot: no churn, no marker loss, and the drop still fires the moment
+// the snapshot proves the record gone.
+test("refreshRoi: an uncounted row past the horizon survives (with its pr markers) while its dirty-worktree record is still in the store (BET-1503)", async () => {
+  let payload = defaultBudgetPayload();
+  payload.roi = {
+    months: {},
+    pending: [
+      // Aged out long ago; the forge already answered "no PR" definitively.
+      // `seeded` is a churn canary: a re-sampled row is minted without it.
+      { id: "old", branch: "cto/old", cwd: "/p", finishedAt: MIDNIGHT - ROI_PENDING_RETENTION_MS - 1, counted: false, prTried: true, seeded: true },
+    ],
+  };
+  const store = { load: async () => payload, save: async (p) => (payload = p) };
+  const job = {
+    id: "old",
+    actor: "cto",
+    status: "done",
+    branch: "cto/old",
+    cwd: "/p",
+    finishedAt: MIDNIGHT - ROI_PENDING_RETENTION_MS - 1,
+    cleanedUp: false, // dirty worktree → the store never sweeps this record
+  };
+  let recordLive = true;
+  const asked = [];
+  const probed = [];
+  const budget = createCtoBudget({
+    store,
+    jobsRead: async () => (recordLive ? [job] : []),
+    gitProbe: async ({ branch }) => {
+      probed.push(branch);
+      return { exists: true, isAncestor: false }; // never merges — stays uncounted
+    },
+    discoverJobPr: async ({ branch }) => {
+      asked.push(branch);
+      return null;
+    },
+    ledgerRead: async () => [],
+    verdictsRead: async () => [],
+    segmentsRead: async () => [],
+    now: () => MIDNIGHT,
+  });
+  await budget.refreshRoi();
+  await budget.refreshRoi();
+  // The row survives both refreshes — no re-sample (its id is still a
+  // fingerprint), no age-out — and its prTried marker rides along, so the
+  // forge is never re-asked a question it already answered definitively.
+  assert.deepEqual(payload.roi.pending.map((j) => j.id), ["old"]);
+  assert.equal(payload.roi.pending[0].prTried, true);
+  assert.equal(payload.roi.pending[0].seeded, true, "the row is never re-minted — no churn");
+  assert.equal(asked.length, 0, "a definitive no-PR is never re-asked while the row survives");
+  // The per-refresh probe waste the issue scoped out remains by design: the
+  // git probe is the only way to notice a late merge.
+  assert.equal(probed.length, 2);
+  // The record is finally swept: absence is final, the row drops, and with
+  // it the churn risk — there is nothing left to re-sample.
+  recordLive = false;
+  await budget.refreshRoi();
   assert.equal(payload.roi.pending.length, 0);
 });
 


### PR DESCRIPTION
## Summary

BET-1503. In `refreshRoi`'s step-4 hygiene, an UNCOUNTED pending row past the 60-day `ROI_PENDING_RETENTION_MS` horizon always aged out — but when its delegate record lives forever (terminal record with `cleanedUp === false`, a dirty worktree, which `applyRetention` never sweeps by time or by the 50-record cap), the row's job re-sampled on the very next refresh, re-probed, aged out again: churn every refresh forever, and each dropped row took its `pr`/`prTried` markers with it, so a definitive no-PR was re-asked of the forge indefinitely.

## Choice: option 1 — same liveness rule as the counted half

Of the two options the issue offered, this takes **keep uncounted rows past the horizon while their id is in the refresh's jobs snapshot (`liveIds`)**, because it dominates option 2 (an eviction cache for `pr`/`prTried`):

- it kills both wastes (the re-sample→probe→age-out churn AND the marker loss) with **no new state** — option 2 needed a bounded cache plus an eviction policy and kept the row-mint churn;
- it is the trade BET-1497 already accepted for counted rows: a past-horizon row whose record the store keeps forever mirrors the store's own retention. Growth is bounded by the 200-row cap (unchanged), which stays the last bound;
- the rule unifies: past the horizon, a row drops only once the snapshot proves its delegate record gone — absence is final (job ids are minted once; the store's sweeper only removes records).

`liveness unknowable` (`liveIds === null` — failed jobs read) keeps every past-horizon row, the same convention the cap applies. The uncounted timestamp-less row (no age to retire) gets the same liveness rule instead of churning — same defect, same function, fixed at the root. The per-refresh git probe on live rows remains by design (it is the only way to notice a late merge) and is asserted as such in the new test.

**Residual (documented, self-healing):** past the 200-row cap, `trimPendingCap` still evicts oldest uncounted rows first — a live uncounted row evicted there re-samples on the next refresh and lands at the back of the list. Only bites with >200 rows. Follow-up filed: BET-1505.

## Tests

- `retainPendingHorizon` unit test updated to the unified rule (BET-1497 + BET-1503): live uncounted kept, dead uncounted dropped, `liveIds null` keeps both halves, no-ts uncounted liveness rule.
- New end-to-end refresh test: a never-merged dirty-worktree record past the horizon survives two refreshes with its `prTried` marker, never re-asks the forge, is never re-minted (canary field), and drops the moment the snapshot proves the record swept.

**Files changed:** 2 — `src/server/ctoBudget.mjs` (horizon rule + docs), `src/server/ctoBudget.test.mjs` (updated unit test + new e2e test).

**Verification results:**
- PR branch (`multica/BET-1503-roi-pending-churn` @ `6113842f`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3871 pass / 0 fail / 0 skip. Failures: none. log sha256: `9bc35730925757ba56d0b8f92698af61ed12d26fbe78445b99c3f31658c3b943`
- Base (`main` @ `b1539f29`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3870 pass / 0 fail / 0 skip. Failures: none. log sha256: `ab4b8a3462fa36ca9a78d6772cc9ef659b39651e31e3568eb86eb963ad9632a4`
- **Conclusion:** 0 new failures, 0 pre-existing. Net +1 test (the new BET-1503 e2e test); one unit test's assertions updated where the old ones contradicted the unified rule.

Base: origin/main @ b1539f29
