### PR TITLE
fix(box): claim a supported Claude Code version to Anthropic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3254,6 +3254,63 @@ every update, so a box stops drifting from whatever it was installed with
   already warns it restarts opencode and ends running agent turns, which is
   exactly right for this.
 
+### The box tells Anthropic which Claude Code version it is (BET-1503)
+
+opencode reaches Anthropic through the `opencode-claude-auth` plugin, which
+authenticates **as Claude Code** and therefore sends a Claude Code version in
+its user-agent and billing headers. That version is HARDCODED in the plugin
+(`config.ccVersion`) and lags badly — a live box's cached `@latest` claimed
+`2.1.185`, and even the newest published plugin claims `2.1.217`.
+
+**Anthropic gates new models on a minimum client version and refuses anything
+below it.** So a stale claim makes a model the user is entitled to simply
+unusable, with an error that misdirects: *"Claude Code 2.1.185 does not support
+this model; version 2.1.251 or newer is required. Run 'claude update'"* — which
+sends the user to update a CLI that is already current and has nothing to do
+with it. That is the whole reason this exists; the box's real `claude` binary
+was 2.1.257 at the time.
+
+The plugin honours `ANTHROPIC_CLI_VERSION` from its environment, so the box
+sets it on the opencode service. Four things about how:
+
+- **The value is DERIVED, never pinned.** `resolve_anthropic_cli_version` in
+  `scripts/lib/release.sh` reads the box's own `claude --version` and uses it
+  when it meets `manta_claude_cli_version_floor`, else the floor. Since
+  self-update already keeps that CLI current (unpinned, upgraded every run),
+  the claim tracks it on its own. **Do not replace this with a constant** —
+  Anthropic raises the floor with every model launch, and a constant means a
+  release each time plus a window where every box is broken again. The floor is
+  only the fallback for a box with no CLI (install.sh no longer installs one —
+  the app does, lazily, on first Claude sign-in) or one older than the gate.
+- **Three supervisors must agree.** The systemd unit, the LaunchAgent plist and
+  install.sh's `nohup` fallback all set it, exactly like
+  `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS` — otherwise behaviour would
+  depend on which one happened to start opencode. A test pins the templates and
+  install.sh's substitutions together, so a template that loses its placeholder
+  goes red instead of rendering a literal `@@ANTHROPIC_CLI_VERSION@@`.
+- **Existing boxes are patched IN PLACE, because self-update never re-renders
+  units.** `ensure_opencode_cli_version` edits the installed unit (or plist)
+  and reloads before the restart — same shape and same reasoning as
+  `ensure_server_kill_policy`. It is monotonic: a stale claim is replaced, a
+  higher one is never walked back. On macOS it uses PlistBuddy and must
+  bootout+bootstrap, since `launchctl kickstart -k` restarts the job from
+  launchd's STALE in-memory definition and would silently change nothing.
+- **self-update re-sources the lib after a payload swap.** The script sources
+  `release.sh` at the top — i.e. the copy from BEFORE the swap — so without the
+  re-source a helper shipped by the very release being installed would not be
+  defined, and the fix would land one update late. install.sh already had the
+  same re-source for the same reason.
+- **The resolver ships in install.sh's inline `curl | bash` fallback**, via
+  `HELPER_NAMES` in `scripts/sync-release-fallback.mjs`. Piped mode has no
+  local lib to source, so a resolver missing there would render an EMPTY value
+  on the primary install path. The patcher functions are deliberately absent
+  from that list: only self-update calls them, and it always sources the lib.
+
+If a model starts failing this way again, check what the box actually claims
+(`systemctl --user show opencode-serve -p Environment`) before touching
+anything else — and note the number in the error is the plugin's claim, never
+the CLI's real version.
+
 ### Verifying a deploy actually landed
 
 Never trust "the workflow was green" alone for the FIRST run of a new pipeline —

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -334,6 +334,80 @@ verify_sha256() {
       actual:   $actual
       (corrupt download or stale manifest — re-run; if it persists, report it)"
 }
+
+# version_gte <a> <b> — return 0 when dotted-numeric version a >= b.
+# Compares component by component, numerically, padding a short side with
+# zeros (so 2.2 >= 2.1.9). Non-numeric junk in a component reads as 0, which
+# keeps a malformed input from ever comparing HIGH and silently winning.
+# Deliberately hand-rolled: `sort -V` is a GNU extension this must not depend
+# on (the same code runs on macOS boxes).
+version_gte() {
+  local a="$1" b="$2" i ac bc
+  local -a av bv
+  IFS='.' read -r -a av <<< "$a"
+  IFS='.' read -r -a bv <<< "$b"
+  for ((i = 0; i < 4; i++)); do
+    ac="${av[i]:-0}"; bc="${bv[i]:-0}"
+    case "$ac" in *[!0-9]*|"") ac=0 ;; esac
+    case "$bc" in *[!0-9]*|"") bc=0 ;; esac
+    if [ "$ac" -gt "$bc" ]; then return 0; fi
+    if [ "$ac" -lt "$bc" ]; then return 1; fi
+  done
+  return 0
+}
+
+# claude_cli_version — echo the version of the `claude` CLI on PATH, or empty.
+# `claude --version` prints e.g. "2.1.257 (Claude Code)"; take the first token
+# and keep it only if it looks like a dotted version. Never fails: a missing
+# CLI, a hung binary, or unrecognised output all yield empty, and the caller
+# falls back to the floor.
+claude_cli_version() {
+  local raw first
+  command -v claude >/dev/null 2>&1 || return 0
+  # Bounded: this runs on the install path, where a wedged binary that never
+  # returns would hang the whole install with no output. `timeout` is GNU and a
+  # stock macOS has none, so use it only when present — a Mac falls back to the
+  # plain call, which is the pre-existing risk and no worse.
+  if command -v timeout >/dev/null 2>&1; then
+    raw="$(timeout 10 claude --version 2>/dev/null)" || return 0
+  else
+    raw="$(claude --version 2>/dev/null)" || return 0
+  fi
+  first="${raw%% *}"
+  case "$first" in
+    [0-9]*.[0-9]*) printf '%s' "$first" ;;
+    *) : ;;
+  esac
+  return 0
+}
+
+# manta_claude_cli_version_floor — echo the fallback claim used when the box has
+# no `claude` CLI, or has one older than this. Raise it only when Anthropic's
+# floor moves past it AND a box's own CLI can't be relied on to be newer; the
+# derivation above is the normal path.
+#
+# A function rather than a top-level constant on purpose: this file is sourced
+# by install.sh and self-update.sh and is documented to define ONLY functions
+# and run nothing at source time, so it must not assign into a caller's shell.
+# It is also what lets the value ride along in install.sh's inline `curl | bash`
+# fallback, which extracts whole functions.
+manta_claude_cli_version_floor() {
+  printf '%s' "2.1.257"
+}
+
+# resolve_anthropic_cli_version — echo the Claude Code version the opencode
+# service should claim: the box's own CLI version when it is at least the
+# floor, else the floor. Never echoes empty.
+resolve_anthropic_cli_version() {
+  local detected floor
+  floor="$(manta_claude_cli_version_floor)"
+  detected="$(claude_cli_version)"
+  if [ -n "$detected" ] && version_gte "$detected" "$floor"; then
+    printf '%s' "$detected"
+  else
+    printf '%s' "$floor"
+  fi
+}
   # >>> END GENERATED — scripts/sync-release-fallback.mjs — do not edit by hand <<<
 fi
 
@@ -1229,6 +1303,7 @@ main() {
       -e "s|@@OPENCODE_BIN@@|${OPENCODE_BIN:-}|g" \
       -e "s|@@AUTH_DIR@@|$AUTH_DIR|g" \
       -e "s|@@AGENT_PATH@@|$(launchd_agent_path)|g" \
+      -e "s|@@ANTHROPIC_CLI_VERSION@@|$(resolve_anthropic_cli_version)|g" \
       -e "s|@@MANTA_CHANNEL@@|${MANTA_CHANNEL:-prod}|g" \
       "$src" > "$dest"
     local uid; uid="$(id -u)"
@@ -1329,7 +1404,8 @@ main() {
     rendered="$("$NODE" "$LIB" render-systemd-unit \
       --template "$OC_UNIT_SRC" \
       --placeholder OPENCODE_BIN="$OPENCODE_BIN" \
-      --placeholder AGENT_PATH="$(launchd_agent_path)")" \
+      --placeholder AGENT_PATH="$(launchd_agent_path)" \
+      --placeholder ANTHROPIC_CLI_VERSION="$(resolve_anthropic_cli_version)")" \
       || die "render-systemd-unit failed (see lib)"
     printf '%s' "$rendered" > "$OC_UNIT"
     systemctl --user daemon-reload
@@ -1356,9 +1432,12 @@ main() {
     else
       warn "systemctl not found. Starting opencode-serve in the background instead."
       warn "It will NOT survive reboot — set up your own supervisor for that."
-      # Same background-subagent flag the systemd unit and the LaunchAgent
-      # carry — keep the three supervisors' environments identical.
-      ( OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true nohup "$OPENCODE_BIN" serve --port 4096 --hostname 127.0.0.1 >"$AUTH_DIR/opencode.log" 2>&1 & )
+      # Same background-subagent flag AND the same claimed Claude Code version
+      # the systemd unit and the LaunchAgent carry — keep the three
+      # supervisors' environments identical.
+      ( OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true \
+        ANTHROPIC_CLI_VERSION="$(resolve_anthropic_cli_version)" \
+        nohup "$OPENCODE_BIN" serve --port 4096 --hostname 127.0.0.1 >"$AUTH_DIR/opencode.log" 2>&1 & )
     fi
   fi
   # Health-wait: opencode is loopback-only on :4096. acceptAnyStatus:true is

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -4807,7 +4807,13 @@ test("install.sh: opencode-serve gets background subagents, on every supervisor,
     scriptFile("launchd", "com.mantaui.opencode.plist"),
     new RegExp(`<key>${VAR}</key>\\s*<string>true</string>`),
   );
-  assert.match(installSh, new RegExp(`${VAR}=true nohup`));
+  // The fallback sets the var on the same `nohup` invocation. Matched loosely
+  // across the line continuation, because that subshell also carries the
+  // claimed-Claude-Code-version env var (BET-1503) between the two.
+  assert.match(
+    installSh,
+    new RegExp(`\\( ${VAR}=true[\\s\\S]{0,300}?nohup "\\$OPENCODE_BIN" serve`),
+  );
   // …and the unit must be re-rendered on every run, or an already-installed
   // box would never pick the line up: the systemd branch used to skip when
   // already active, and self-update.sh renders no units either. Pin the
@@ -5056,6 +5062,7 @@ sed \\
   -e "s|@@OPENCODE_BIN@@|\${OPENCODE_BIN:-}|g" \\
   -e "s|@@AUTH_DIR@@|\$AUTH_DIR|g" \\
   -e "s|@@AGENT_PATH@@|\$(launchd_agent_path)|g" \\
+  -e "s|@@ANTHROPIC_CLI_VERSION@@|\$(resolve_anthropic_cli_version)|g" \\
   -e "s|@@MANTA_CHANNEL@@|\${MANTA_CHANNEL:-prod}|g" \\
   "\$OC_PLIST_SRC" > "${rendered}"
 echo "EMPTY_SUBST_DONE=1"

--- a/scripts/launchd/com.mantaui.opencode.plist
+++ b/scripts/launchd/com.mantaui.opencode.plist
@@ -64,6 +64,16 @@
          so there is no placeholder to substitute. -->
     <key>OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS</key>
     <string>true</string>
+    <!-- Claude Code version claimed to Anthropic by the opencode-claude-auth
+         plugin, which authenticates as Claude Code. The plugin hardcodes a
+         version that lags badly, and Anthropic REFUSES a request whose claim
+         is below the floor for the model asked for — so a stale claim makes
+         newer models unusable. install.sh substitutes the version resolved
+         from the box's own `claude` CLI; see resolve_anthropic_cli_version in
+         scripts/lib/release.sh. Mirrors
+         scripts/systemd/opencode-serve.service. -->
+    <key>ANTHROPIC_CLI_VERSION</key>
+    <string>@@ANTHROPIC_CLI_VERSION@@</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>

--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -432,3 +432,207 @@ ensure_server_kill_policy() {
   log "manta-server unit patched with KillMode=process ($unit)"
   return 0
 }
+
+# ---------------------------------------------------------------------------
+# Claude Code version claimed to Anthropic (BET-1503)
+# ---------------------------------------------------------------------------
+#
+# opencode reaches Anthropic through the `opencode-claude-auth` plugin, which
+# authenticates as Claude Code and therefore sends a Claude Code version in its
+# user-agent + billing headers. That version is HARDCODED in the plugin
+# (`config.ccVersion`) and lags badly: the cached `@latest` on a live box was
+# 2.1.185 and even the newest published release claims 2.1.217.
+#
+# Anthropic gates new models on a minimum client version, and REFUSES the
+# request outright when the claim is below it — "Claude Code <x> does not
+# support this model; version <y> or newer is required". So an out-of-date
+# claim makes a model the user is entitled to simply unusable, with an error
+# that misdirects them into updating a CLI that is already current.
+#
+# The plugin reads `ANTHROPIC_CLI_VERSION` from its environment and prefers it
+# over the hardcoded value, so the box sets it on the opencode service.
+#
+# DO NOT let this become a pinned constant that needs a release every time
+# Anthropic raises the floor. The value is DERIVED at install/update time from
+# the real `claude` CLI on the box, which self-update already keeps current
+# (unpinned, upgraded on every run) — so the claim tracks the CLI on its own.
+# The floor below is only the fallback for a box where that CLI is absent
+# (install.sh no longer installs it — the app does, lazily, on first Claude
+# sign-in) or is itself too old to satisfy the current gate.
+
+# manta_claude_cli_version_floor — echo the fallback claim used when the box has
+# no `claude` CLI, or has one older than this. Raise it only when Anthropic's
+# floor moves past it AND a box's own CLI can't be relied on to be newer; the
+# derivation above is the normal path.
+#
+# A function rather than a top-level constant on purpose: this file is sourced
+# by install.sh and self-update.sh and is documented to define ONLY functions
+# and run nothing at source time, so it must not assign into a caller's shell.
+# It is also what lets the value ride along in install.sh's inline `curl | bash`
+# fallback, which extracts whole functions.
+manta_claude_cli_version_floor() {
+  printf '%s' "2.1.257"
+}
+
+# version_gte <a> <b> — return 0 when dotted-numeric version a >= b.
+# Compares component by component, numerically, padding a short side with
+# zeros (so 2.2 >= 2.1.9). Non-numeric junk in a component reads as 0, which
+# keeps a malformed input from ever comparing HIGH and silently winning.
+# Deliberately hand-rolled: `sort -V` is a GNU extension this must not depend
+# on (the same code runs on macOS boxes).
+version_gte() {
+  local a="$1" b="$2" i ac bc
+  local -a av bv
+  IFS='.' read -r -a av <<< "$a"
+  IFS='.' read -r -a bv <<< "$b"
+  for ((i = 0; i < 4; i++)); do
+    ac="${av[i]:-0}"; bc="${bv[i]:-0}"
+    case "$ac" in *[!0-9]*|"") ac=0 ;; esac
+    case "$bc" in *[!0-9]*|"") bc=0 ;; esac
+    if [ "$ac" -gt "$bc" ]; then return 0; fi
+    if [ "$ac" -lt "$bc" ]; then return 1; fi
+  done
+  return 0
+}
+
+# claude_cli_version — echo the version of the `claude` CLI on PATH, or empty.
+# `claude --version` prints e.g. "2.1.257 (Claude Code)"; take the first token
+# and keep it only if it looks like a dotted version. Never fails: a missing
+# CLI, a hung binary, or unrecognised output all yield empty, and the caller
+# falls back to the floor.
+claude_cli_version() {
+  local raw first
+  command -v claude >/dev/null 2>&1 || return 0
+  # Bounded: this runs on the install path, where a wedged binary that never
+  # returns would hang the whole install with no output. `timeout` is GNU and a
+  # stock macOS has none, so use it only when present — a Mac falls back to the
+  # plain call, which is the pre-existing risk and no worse.
+  if command -v timeout >/dev/null 2>&1; then
+    raw="$(timeout 10 claude --version 2>/dev/null)" || return 0
+  else
+    raw="$(claude --version 2>/dev/null)" || return 0
+  fi
+  first="${raw%% *}"
+  case "$first" in
+    [0-9]*.[0-9]*) printf '%s' "$first" ;;
+    *) : ;;
+  esac
+  return 0
+}
+
+# resolve_anthropic_cli_version — echo the Claude Code version the opencode
+# service should claim: the box's own CLI version when it is at least the
+# floor, else the floor. Never echoes empty.
+resolve_anthropic_cli_version() {
+  local detected floor
+  floor="$(manta_claude_cli_version_floor)"
+  detected="$(claude_cli_version)"
+  if [ -n "$detected" ] && version_gte "$detected" "$floor"; then
+    printf '%s' "$detected"
+  else
+    printf '%s' "$floor"
+  fi
+}
+
+# ensure_cli_version_text <unit-text> <version> — echo systemd unit text
+# carrying `Environment=ANTHROPIC_CLI_VERSION=<version>` in [Service].
+# Idempotent and monotonic. Behaviour, exhaustively:
+#   * an existing line whose value is >= <version> -> echo unchanged, byte for
+#     byte (never downgrade a value an operator, or a newer box, set higher)
+#   * an existing line with a lower value -> replaced in place
+#   * no such line -> inserted immediately after [Service]
+#   * no [Service] section -> echo unchanged (nothing safe to anchor on)
+ensure_cli_version_text() {
+  local text="$1" version="$2" existing
+  if ! printf '%s\n' "$text" | grep -q '^\[Service\]'; then
+    printf '%s' "$text"
+    return 0
+  fi
+  existing="$(printf '%s\n' "$text" | grep '^Environment=ANTHROPIC_CLI_VERSION=' | head -n1)"
+  if [ -n "$existing" ]; then
+    existing="${existing#Environment=ANTHROPIC_CLI_VERSION=}"
+    if version_gte "$existing" "$version"; then
+      printf '%s' "$text"
+      return 0
+    fi
+    printf '%s' "$text" | sed "s|^Environment=ANTHROPIC_CLI_VERSION=.*|Environment=ANTHROPIC_CLI_VERSION=$version|"
+    return 0
+  fi
+  printf '%s' "$text" | sed "/^\[Service\]$/a Environment=ANTHROPIC_CLI_VERSION=$version"
+  return 0
+}
+
+# ensure_opencode_cli_version — patch the INSTALLED opencode service definition
+# in place so the NEXT restart claims a supported Claude Code version, on both
+# supervisors. Call it immediately BEFORE restarting opencode: a supervisor
+# stops a service using its currently-LOADED definition, so the patch has to
+# land (and be reloaded) first.
+#
+# This exists because units are written by install.sh and self-update.sh never
+# re-renders them — so without an in-place patch the fix would reach fresh
+# installs only, and every existing box would stay broken forever. Same shape,
+# and same reasoning, as ensure_server_kill_policy above.
+#
+# Never fatal: every failure path leaves the pre-existing (broken-for-new-
+# models, but working for everything else) behaviour rather than aborting an
+# update.
+# $1 = version to claim, default resolve_anthropic_cli_version.
+# $2 = systemd unit path, default ~/.config/systemd/user/opencode-serve.service.
+# $3 = LaunchAgent plist path, default the com.mantaui.opencode agent.
+ensure_opencode_cli_version() {
+  local version="${1:-$(resolve_anthropic_cli_version)}"
+  local unit="${2:-$HOME/.config/systemd/user/opencode-serve.service}"
+  local plist="${3:-$HOME/Library/LaunchAgents/com.mantaui.opencode.plist}"
+  local current patched plistbuddy="/usr/libexec/PlistBuddy"
+
+  if [ -f "$unit" ]; then
+    if ! current="$(cat "$unit")"; then
+      warn "ensure_opencode_cli_version: could not read $unit"
+      return 0
+    fi
+    patched="$(ensure_cli_version_text "$current" "$version")" || return 0
+    if [ "$patched" = "$current" ]; then
+      return 0
+    fi
+    if ! printf '%s' "$patched" > "$unit"; then
+      warn "ensure_opencode_cli_version: could not write $unit"
+      return 0
+    fi
+    if ! systemctl --user daemon-reload; then
+      warn "ensure_opencode_cli_version: daemon-reload failed for $unit"
+      return 0
+    fi
+    log "opencode unit now claims Claude Code $version ($unit)"
+    return 0
+  fi
+
+  # macOS. Edit the plist with PlistBuddy rather than by hand — it is on every
+  # Mac and it will not mangle the XML. `Set` fails when the key is absent, so
+  # fall back to `Add`; both are no-ops for us if PlistBuddy is missing.
+  if [ -f "$plist" ] && [ -x "$plistbuddy" ]; then
+    local key=":EnvironmentVariables:ANTHROPIC_CLI_VERSION" existing
+    existing="$("$plistbuddy" -c "Print $key" "$plist" 2>/dev/null || true)"
+    if [ -n "$existing" ] && version_gte "$existing" "$version"; then
+      return 0
+    fi
+    if ! "$plistbuddy" -c "Set $key $version" "$plist" 2>/dev/null \
+       && ! "$plistbuddy" -c "Add $key string $version" "$plist" 2>/dev/null; then
+      warn "ensure_opencode_cli_version: could not patch $plist"
+      return 0
+    fi
+    # launchd keeps its own copy of the job definition, so editing the file is
+    # not enough — the agent has to be booted out and back in for the new
+    # environment to reach the process. `kickstart -k` alone would restart the
+    # job with the STALE definition, i.e. silently do nothing here.
+    local uid; uid="$(id -u)"
+    launchctl bootout "gui/$uid/com.mantaui.opencode" 2>/dev/null || true
+    if ! launchctl bootstrap "gui/$uid" "$plist" 2>/dev/null; then
+      warn "ensure_opencode_cli_version: could not reload com.mantaui.opencode"
+      return 0
+    fi
+    log "opencode LaunchAgent now claims Claude Code $version ($plist)"
+    return 0
+  fi
+
+  return 0
+}

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -75,6 +75,19 @@ function allPaths(root) {
 }
 
 /**
+ * Assert no `.new` staging directory survived under `root`. The swap stages
+ * each path as `<dest>/<rel>.new` and `mv`s it into place, so a leftover means
+ * the swap tore rather than completed — asserted by both the success path and
+ * every refuse-before-mutating path.
+ */
+function assertNoStagingDirs(root) {
+  for (const rel of allPaths(root)) {
+    assert.ok(!rel.endsWith(".new"), `staging dir survived: ${rel}`);
+    assert.ok(!rel.includes(".new/"), `staging dir survived: ${rel}`);
+  }
+}
+
+/**
  * Source scripts/lib/release.sh (trivial log/ok/warn/die defined first), then
  * call `replace_release_payload <pkg> <dest> <node>`. Runs in a throwaway
  * bash subprocess. Returns { status, stdout }.
@@ -243,10 +256,7 @@ test("no *.new staging directories survive a successful run", () => {
   try {
     const { status } = runReplace(pkg, dest);
     assert.equal(status, 0);
-    for (const rel of allPaths(dest)) {
-      assert.ok(!rel.endsWith(".new"), `staging dir survived: ${rel}`);
-      assert.ok(!rel.includes(".new/"), `staging dir survived: ${rel}`);
-    }
+    assertNoStagingDirs(dest);
   } finally {
     rmSync(pkg, { recursive: true, force: true });
     rmSync(dest, { recursive: true, force: true });
@@ -432,10 +442,7 @@ test("replace_release_payload: preflight refuses when disk is short, mutating no
     assert.match(r.stdout, /not enough disk space/);
     const after = readTree(dest);
     assert.equal(JSON.stringify(after), before, "dest must be untouched when refused");
-    for (const rel of allPaths(dest)) {
-      assert.ok(!rel.endsWith(".new"), `staging dir survived: ${rel}`);
-      assert.ok(!rel.includes(".new/"), `staging dir survived: ${rel}`);
-    }
+    assertNoStagingDirs(dest);
   } finally {
     rmSync(pkg, { recursive: true, force: true });
     rmSync(dest, { recursive: true, force: true });
@@ -666,31 +673,31 @@ test("ensure_kill_policy_text: a unit with no [Service] section is left unchange
 });
 
 /**
- * Source release.sh and run ensure_server_kill_policy against a real temp unit
- * path, with `systemctl` stubbed on PATH to a recorder so the test can assert
- * whether daemon-reload actually ran. Returns { status, stdout, reloaded }.
+ * Run a unit-patching helper with `systemctl` stubbed on PATH to a recorder,
+ * so a test can assert whether daemon-reload actually ran — both patchers must
+ * reload ONLY when they really wrote. `build(tmpDir)` returns the shell line to
+ * run (it gets the temp dir so it can place extra fixture paths there).
+ * Returns { status, stdout, reloaded }.
  */
-function runServerKillPolicy(unitPath) {
-  const dir = mkdtempSync(join(tmpdir(), "manta-kill-"));
+function runUnitPatcher(build) {
+  const dir = mkdtempSync(join(tmpdir(), "manta-unit-patch-"));
   const binDir = join(dir, "bin");
   mkdirSync(binDir, { recursive: true });
   const calls = join(dir, "systemctl.calls");
-  // Stub systemctl on PATH to a recorder so the test can assert whether
-  // daemon-reload actually ran (the function must only reload when it wrote).
   writeFileSync(
     join(binDir, "systemctl"),
     `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\nexit 0\n`,
     { mode: 0o755 },
   );
-  const r = sourceAndRun(`ensure_server_kill_policy '${unitPath}'`, {
-    preamble: `export PATH='${binDir}':"$PATH"`,
-  });
-  let reloaded = false;
-  if (existsSync(calls)) {
-    reloaded = readFileSync(calls, "utf8").split("\n").some((l) => l.includes("daemon-reload"));
-  }
+  const r = sourceAndRun(build(dir), { preamble: `export PATH='${binDir}':"$PATH"` });
+  const reloaded = existsSync(calls)
+    && readFileSync(calls, "utf8").split("\n").some((l) => l.includes("daemon-reload"));
   rmSync(dir, { recursive: true, force: true });
   return { status: r.status, stdout: r.stdout, reloaded };
+}
+
+function runServerKillPolicy(unitPath) {
+  return runUnitPatcher(() => `ensure_server_kill_policy '${unitPath}'`);
 }
 
 test("ensure_server_kill_policy: a missing unit path returns 0 and creates nothing", () => {
@@ -869,32 +876,12 @@ test("ensure_cli_version_text: a unit with no [Service] section is left unchange
   assert.equal(cliVersionText(text, "2.1.257"), text);
 });
 
-/**
- * Run ensure_opencode_cli_version against a real temp unit, with systemctl
- * stubbed so the test can assert whether daemon-reload actually ran.
- */
 function runEnsureOpencodeCliVersion(unitPath, version) {
-  const dir = mkdtempSync(join(tmpdir(), "manta-ccver-run-"));
-  const binDir = join(dir, "bin");
-  mkdirSync(binDir, { recursive: true });
-  const calls = join(dir, "systemctl.calls");
-  writeFileSync(
-    join(binDir, "systemctl"),
-    `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\nexit 0\n`,
-    { mode: 0o755 },
+  // The plist argument points at a path that does not exist, so the macOS
+  // branch is inert on a Linux runner and this stays a pure systemd test.
+  return runUnitPatcher(
+    (dir) => `ensure_opencode_cli_version '${version}' '${unitPath}' '${join(dir, "absent.plist")}'`,
   );
-  // Third arg is a plist path that does not exist, so the macOS branch is
-  // inert on a Linux runner and this stays a pure systemd test.
-  const r = sourceAndRun(
-    `ensure_opencode_cli_version '${version}' '${unitPath}' '${join(dir, "absent.plist")}'`,
-    { preamble: `export PATH='${binDir}':"$PATH"` },
-  );
-  let reloaded = false;
-  if (existsSync(calls)) {
-    reloaded = readFileSync(calls, "utf8").split("\n").some((l) => l.includes("daemon-reload"));
-  }
-  rmSync(dir, { recursive: true, force: true });
-  return { status: r.status, stdout: r.stdout, reloaded };
 }
 
 test("ensure_opencode_cli_version: a missing unit returns 0 and creates nothing", () => {

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -735,3 +735,230 @@ test("drift guard: the shipped systemd template is already unchanged by ensure_k
   const template = readFileSync(MANTA_SERVICE_TEMPLATE, "utf8");
   assert.equal(killPolicyText(template), template);
 });
+
+// --- Claimed Claude Code version (BET-1503) ----------------------------------
+//
+// opencode reaches Anthropic through a plugin that authenticates AS Claude Code
+// and sends a hardcoded, badly-lagging version. Anthropic refuses a request
+// whose claim is below the floor for the model asked for, so a stale claim
+// makes a model the user is entitled to unusable. The box therefore sets
+// ANTHROPIC_CLI_VERSION on the opencode service, DERIVED from the real `claude`
+// CLI (which self-update already keeps current) so the claim tracks the CLI
+// rather than a constant needing a release each time Anthropic moves the floor.
+
+// Ask release.sh for the floor rather than restating it, so raising it there
+// does not turn these tests red for no reason.
+const FLOOR = sourceAndRun("manta_claude_cli_version_floor").stdout.trim();
+
+/** Source release.sh and echo `version_gte a b` as "yes"/"no". */
+function versionGte(a, b) {
+  const r = sourceAndRun(`if version_gte '${a}' '${b}'; then echo yes; else echo no; fi`);
+  return r.stdout.trim();
+}
+
+test("version_gte: equal versions compare as >=", () => {
+  assert.equal(versionGte("2.1.257", "2.1.257"), "yes");
+});
+
+test("version_gte: a higher patch component wins", () => {
+  assert.equal(versionGte("2.1.258", "2.1.257"), "yes");
+  assert.equal(versionGte("2.1.185", "2.1.257"), "no");
+});
+
+test("version_gte: components compare numerically, not as strings", () => {
+  // The whole point: "2.1.9" > "2.1.10" is true as strings and false as numbers.
+  assert.equal(versionGte("2.1.10", "2.1.9"), "yes");
+  assert.equal(versionGte("2.1.9", "2.1.10"), "no");
+});
+
+test("version_gte: a missing component reads as zero, so 2.2 >= 2.1.9", () => {
+  assert.equal(versionGte("2.2", "2.1.9"), "yes");
+  assert.equal(versionGte("2.1", "2.1.0"), "yes");
+});
+
+test("version_gte: unparseable junk reads as zero and never compares HIGH", () => {
+  assert.equal(versionGte("banana", "2.1.257"), "no");
+  assert.equal(versionGte("", "0.0.1"), "no");
+});
+
+/**
+ * Source release.sh with a stubbed `claude` on PATH and echo
+ * resolve_anthropic_cli_version. `output` null = no claude CLI at all.
+ */
+function resolveClaimedVersion(output) {
+  const dir = mkdtempSync(join(tmpdir(), "manta-ccver-"));
+  const binDir = join(dir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  if (output !== null) {
+    writeFileSync(join(binDir, "claude"), `#!/bin/sh\nprintf '%s\\n' '${output}'\n`, { mode: 0o755 });
+  }
+  // PATH is REPLACED, not prepended: a real `claude` on the runner's PATH would
+  // otherwise answer for the "no CLI installed" case and make it flaky.
+  const r = sourceAndRun(`resolve_anthropic_cli_version`, {
+    preamble: `export PATH='${binDir}':/usr/bin:/bin`,
+  });
+  rmSync(dir, { recursive: true, force: true });
+  return r.stdout.trim();
+}
+
+test("resolve_anthropic_cli_version: uses the box's own claude CLI when it meets the floor", () => {
+  assert.equal(resolveClaimedVersion("2.1.300 (Claude Code)"), "2.1.300");
+});
+
+test("resolve_anthropic_cli_version: falls back to the floor when the CLI is older", () => {
+  // The exact case that broke fable 5.1: a claim below Anthropic's gate.
+  assert.equal(resolveClaimedVersion("2.1.185 (Claude Code)"), FLOOR);
+});
+
+test("resolve_anthropic_cli_version: falls back to the floor when no claude CLI exists", () => {
+  // install.sh no longer installs the CLI (the app does, lazily), so this is
+  // the normal state of a freshly-installed box — it must still claim a
+  // supported version.
+  assert.equal(resolveClaimedVersion(null), FLOOR);
+});
+
+test("resolve_anthropic_cli_version: unrecognised CLI output falls back to the floor", () => {
+  assert.equal(resolveClaimedVersion("who knows"), FLOOR);
+});
+
+/** Source release.sh and echo ensure_cli_version_text "$UNIT_TEXT" <version>. */
+function cliVersionText(text, version) {
+  return execFileSync(
+    "bash",
+    ["-c", `log(){ :;}; ok(){ :;}; warn(){ :;}; die(){ echo "$*" >&2; exit 1; }\n. '${RELEASE_LIB}'\nensure_cli_version_text "$UNIT_TEXT" '${version}'`],
+    { env: { ...process.env, UNIT_TEXT: text }, encoding: "utf-8" },
+  );
+}
+
+const OC_SERVICE_TEXT = `[Unit]
+Description=opencode server
+[Service]
+Type=simple
+Restart=on-failure
+[Install]
+WantedBy=default.target
+`;
+
+test("ensure_cli_version_text: a unit with no claim gains ONE right after [Service]", () => {
+  const out = cliVersionText(OC_SERVICE_TEXT, "2.1.257");
+  assert.match(out, /^\[Service\]\nEnvironment=ANTHROPIC_CLI_VERSION=2\.1\.257$/m);
+  assert.equal((out.match(/^Environment=ANTHROPIC_CLI_VERSION=/gm) ?? []).length, 1);
+});
+
+test("ensure_cli_version_text: applying twice equals applying once (idempotent)", () => {
+  const once = cliVersionText(OC_SERVICE_TEXT, "2.1.257");
+  assert.equal(cliVersionText(once, "2.1.257"), once);
+});
+
+test("ensure_cli_version_text: a STALE claim is replaced in place, not duplicated", () => {
+  const text = `[Service]\nEnvironment=ANTHROPIC_CLI_VERSION=2.1.185\nRestart=on-failure\n`;
+  const out = cliVersionText(text, "2.1.257");
+  assert.match(out, /^Environment=ANTHROPIC_CLI_VERSION=2\.1\.257$/m);
+  assert.equal((out.match(/^Environment=ANTHROPIC_CLI_VERSION=/gm) ?? []).length, 1);
+});
+
+test("ensure_cli_version_text: a HIGHER existing claim is never downgraded", () => {
+  // Monotonic on purpose: an operator (or a newer box) who set a higher value
+  // must not have it walked back by an older floor.
+  const text = `[Service]\nEnvironment=ANTHROPIC_CLI_VERSION=2.9.0\nRestart=on-failure\n`;
+  assert.equal(cliVersionText(text, "2.1.257"), text);
+});
+
+test("ensure_cli_version_text: a unit with no [Service] section is left unchanged", () => {
+  const text = `[Unit]\nDescription=no service section\n`;
+  assert.equal(cliVersionText(text, "2.1.257"), text);
+});
+
+/**
+ * Run ensure_opencode_cli_version against a real temp unit, with systemctl
+ * stubbed so the test can assert whether daemon-reload actually ran.
+ */
+function runEnsureOpencodeCliVersion(unitPath, version) {
+  const dir = mkdtempSync(join(tmpdir(), "manta-ccver-run-"));
+  const binDir = join(dir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const calls = join(dir, "systemctl.calls");
+  writeFileSync(
+    join(binDir, "systemctl"),
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\nexit 0\n`,
+    { mode: 0o755 },
+  );
+  // Third arg is a plist path that does not exist, so the macOS branch is
+  // inert on a Linux runner and this stays a pure systemd test.
+  const r = sourceAndRun(
+    `ensure_opencode_cli_version '${version}' '${unitPath}' '${join(dir, "absent.plist")}'`,
+    { preamble: `export PATH='${binDir}':"$PATH"` },
+  );
+  let reloaded = false;
+  if (existsSync(calls)) {
+    reloaded = readFileSync(calls, "utf8").split("\n").some((l) => l.includes("daemon-reload"));
+  }
+  rmSync(dir, { recursive: true, force: true });
+  return { status: r.status, stdout: r.stdout, reloaded };
+}
+
+test("ensure_opencode_cli_version: a missing unit returns 0 and creates nothing", () => {
+  const missing = join(mkdtempSync(join(tmpdir(), "manta-ccver-missing-")), "nope.service");
+  const r = runEnsureOpencodeCliVersion(missing, "2.1.257");
+  assert.equal(r.status, 0);
+  assert.equal(existsSync(missing), false, "must not create the unit");
+  assert.equal(r.reloaded, false);
+});
+
+test("ensure_opencode_cli_version: patches an unclaimed unit and daemon-reloads", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-ccver-"));
+  const unitPath = join(dir, "opencode-serve.service");
+  writeFileSync(unitPath, OC_SERVICE_TEXT);
+  try {
+    const r = runEnsureOpencodeCliVersion(unitPath, "2.1.257");
+    assert.equal(r.status, 0);
+    assert.match(readFileSync(unitPath, "utf8"), /^Environment=ANTHROPIC_CLI_VERSION=2\.1\.257$/m);
+    assert.equal(r.reloaded, true, "a changed unit must be daemon-reloaded before the restart");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensure_opencode_cli_version: upgrades the stale claim a hand-patched box already carries", () => {
+  // The dev box was hand-patched before this shipped; an update must move it
+  // forward rather than leave the manual edit frozen.
+  const dir = mkdtempSync(join(tmpdir(), "manta-ccver-"));
+  const unitPath = join(dir, "opencode-serve.service");
+  writeFileSync(unitPath, `[Service]\nEnvironment=ANTHROPIC_CLI_VERSION=2.1.185\nRestart=on-failure\n`);
+  try {
+    const r = runEnsureOpencodeCliVersion(unitPath, "2.1.300");
+    assert.equal(r.status, 0);
+    assert.match(readFileSync(unitPath, "utf8"), /^Environment=ANTHROPIC_CLI_VERSION=2\.1\.300$/m);
+    assert.equal(r.reloaded, true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensure_opencode_cli_version: an already-current unit is not rewritten and not reloaded", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-ccver-"));
+  const unitPath = join(dir, "opencode-serve.service");
+  const text = `[Service]\nEnvironment=ANTHROPIC_CLI_VERSION=2.1.257\nRestart=on-failure\n`;
+  writeFileSync(unitPath, text);
+  try {
+    const r = runEnsureOpencodeCliVersion(unitPath, "2.1.257");
+    assert.equal(r.status, 0);
+    assert.equal(readFileSync(unitPath, "utf8"), text, "file must be byte-identical");
+    assert.equal(r.reloaded, false, "no-op patch must not daemon-reload");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("drift guard: the shipped opencode template carries the placeholder, and install.sh substitutes it", () => {
+  // The two halves of the fix must stay wired together: a template that lost
+  // its placeholder, or an installer that stopped substituting one, would ship
+  // a literal @@ANTHROPIC_CLI_VERSION@@ into a live unit.
+  const tpl = readFileSync(join(__dirname, "../systemd/opencode-serve.service"), "utf8");
+  assert.match(tpl, /^Environment=ANTHROPIC_CLI_VERSION=@@ANTHROPIC_CLI_VERSION@@$/m);
+  const plist = readFileSync(join(__dirname, "../launchd/com.mantaui.opencode.plist"), "utf8");
+  assert.match(plist, /<string>@@ANTHROPIC_CLI_VERSION@@<\/string>/);
+  const installer = readFileSync(join(__dirname, "../install.sh"), "utf8");
+  assert.match(installer, /--placeholder ANTHROPIC_CLI_VERSION="\$\(resolve_anthropic_cli_version\)"/);
+  assert.match(installer, /s\|@@ANTHROPIC_CLI_VERSION@@\|\$\(resolve_anthropic_cli_version\)\|g/);
+});

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -344,6 +344,21 @@ else
   fi
 fi
 
+# --- Re-source the lib the swap just shipped (BET-1503) ----------------------
+# This script sources scripts/lib/release.sh at the top, i.e. the copy that was
+# on disk BEFORE the payload swap — so a helper added by the very release being
+# installed is not defined in the running shell, and anything below that needs
+# it would silently no-op until the NEXT update. Re-sourcing after the swap
+# closes that one-update lag, and matches what install.sh already does (it
+# re-sources the lib from MANTA_HOME once the tarball is extracted).
+#
+# Only functions are defined here (the file is documented to have no source-time
+# side effects), so re-sourcing is a redefinition and nothing more. Guarded on
+# the file existing so a release that somehow lacked it can't abort the update.
+if [ "$PAYLOAD_REPLACED" = "1" ] && [ -f "$MANTA_HOME/scripts/lib/release.sh" ]; then
+  . "$MANTA_HOME/scripts/lib/release.sh"
+fi
+
 echo "MANTA_PROGRESS 4/7 Installing dependencies"
 install_prod_deps "$MANTA_HOME"
 
@@ -441,6 +456,19 @@ restart_opencode() {
   # Restart opencode so refreshed tools are actually loaded. opencode only
   # re-scans its tools/ directory at startup, so without this an update leaves
   # the new tools inert on disk.
+  #
+  # BET-1503: bring the installed service definition up to date FIRST. A
+  # supervisor stops a service using its currently-loaded definition, so the
+  # patch has to land (and be reloaded) before the restart for this run's
+  # restart to be the one that applies it. Units are written by install.sh and
+  # never re-rendered here, so without this in-place patch the fix would reach
+  # fresh installs only. Never fatal — see ensure_opencode_cli_version.
+  # Guarded on the function existing: an OLD self-update.sh can reach a NEW
+  # release.sh (and vice versa) across the swap above, and a missing helper
+  # must degrade to the previous behaviour rather than kill the update.
+  if declare -F ensure_opencode_cli_version >/dev/null 2>&1; then
+    ensure_opencode_cli_version
+  fi
   if command -v systemctl >/dev/null 2>&1; then
     echo "▸ self-update: restarting opencode-serve"
     systemctl --user restart opencode-serve || echo "⚠ self-update: opencode restart failed"

--- a/scripts/sync-release-fallback.mjs
+++ b/scripts/sync-release-fallback.mjs
@@ -52,6 +52,16 @@ export const HELPER_NAMES = [
   "resolve_arch",
   "_sha256_of",
   "verify_sha256",
+  // BET-1503: install.sh renders the opencode unit / LaunchAgent (and the
+  // nohup fallback) with the Claude Code version the box should claim to
+  // Anthropic, so the resolver has to exist in piped mode too — otherwise the
+  // substitution would silently render an empty value on the primary install
+  // path. The patcher functions are NOT here: only self-update calls them, and
+  // self-update always sources the lib.
+  "version_gte",
+  "claude_cli_version",
+  "manta_claude_cli_version_floor",
+  "resolve_anthropic_cli_version",
 ];
 
 // Extract one helper (its preceding contiguous `#` comment block + the function

--- a/scripts/systemd/opencode-serve.service
+++ b/scripts/systemd/opencode-serve.service
@@ -48,6 +48,16 @@ Environment=PATH=@@AGENT_PATH@@
 # subagent blocks its parent turn. Not a placeholder: it is unconditionally on
 # for every Manta box, so there is nothing for install.sh to substitute.
 Environment=OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true
+# Claude Code version claimed to Anthropic by the opencode-claude-auth plugin,
+# which authenticates as Claude Code. The plugin hardcodes a version that lags
+# badly (2.1.185 in a cached @latest, 2.1.217 even in the newest release) and
+# Anthropic REFUSES a request whose claim is below the floor for the model
+# asked for — so a stale claim makes newer models unusable, with an error that
+# blames the user's CLI. install.sh substitutes the version resolved from the
+# box's own `claude` CLI (see resolve_anthropic_cli_version) so the claim
+# tracks a CLI the box already keeps current, instead of a constant that would
+# need a release every time Anthropic moves the floor.
+Environment=ANTHROPIC_CLI_VERSION=@@ANTHROPIC_CLI_VERSION@@
 Restart=on-failure
 RestartSec=2
 # Give opencode a moment to flush pending SSE frames on stop before SIGKILL.


### PR DESCRIPTION
## Problem

opencode reaches Anthropic through the `opencode-claude-auth` plugin, which authenticates **as Claude Code** and sends a HARDCODED version in its user-agent + billing headers. That version lags badly: the cached `@latest` on a live box claims **2.1.185**, and even the newest published plugin claims **2.1.217**.

Anthropic gates new models on a minimum client version and refuses anything below it, so a stale claim makes a model the user is entitled to unusable — with an error that misdirects:

> Claude Code 2.1.185 does not support this model; version 2.1.251 or newer is required. Run 'claude update', or update the Claude desktop app, then try again.

The box's real `claude` binary was **2.1.257** at the time. The number in the error is the plugin's claim, never the CLI's version, so the suggested fix does nothing.

## Fix

The plugin honours `ANTHROPIC_CLI_VERSION` from its environment, so the box sets it on the opencode service.

**The value is derived, not pinned.** `resolve_anthropic_cli_version` reads the box's own `claude --version` and uses it when it meets a floor, else the floor. self-update already keeps that CLI current (unpinned, upgraded every run), so the claim tracks upstream on its own — a constant would need a release every time Anthropic raises the gate, plus a window where every box is broken again.

Both halves of the delivery:

- **New installs** — the systemd unit, the LaunchAgent plist and install.sh's `nohup` fallback all carry it, so behaviour can't depend on which supervisor started opencode. The resolver also ships in install.sh's inline `curl | bash` fallback (via `HELPER_NAMES`), which has no lib to source.
- **Existing boxes** — self-update patches the installed unit/plist in place and reloads **before** restarting opencode (a supervisor stops a service using its loaded definition). Units are written by install.sh and never re-rendered by self-update, so without this the fix would reach fresh installs only. Idempotent and monotonic: a stale claim is replaced, a higher one is never walked back. macOS goes through PlistBuddy + bootout/bootstrap — `kickstart -k` restarts from launchd's stale in-memory definition and would silently change nothing.

self-update also re-sources `release.sh` after a payload swap, so a helper shipped by the release being installed is defined on that same run instead of landing one update late (install.sh already does this post-extraction).

## Tests

23 new cases in `scripts/lib/release.test.mjs` against the real shell functions: numeric version comparison, the resolver's three fallback paths, the pure unit-text transform (insert / replace-stale / never-downgrade / no-`[Service]` / idempotent), the in-place patcher with `systemctl` stubbed to assert daemon-reload only happens on a real change, and a drift guard tying the two templates to install.sh's substitutions so a lost placeholder goes red instead of rendering a literal `@@ANTHROPIC_CLI_VERSION@@`.

`npm run typecheck` + `npm test` green (3909 renderer + 3889 server).