### PR TITLE
fix(server): persist verify probe detail in checkable.result (BET-1505)

### DIFF
--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -977,7 +977,10 @@ export function createFactsEngine(deps = {}) {
           result = "verify error";
         }
         checked += 1;
-        working[i] = { ...f, checkable: { ...f.checkable, last_checked: t, result: ok ? "ok" : "failed" } };
+        // BET-1505: keep the probe's own detail ("closed", "not-found", the CI
+        // conclusion, "verify error", …) — "ok"/"failed" are only the fallback
+        // when the probe returned no detail. §10.5 renders this verbatim.
+        working[i] = { ...f, checkable: { ...f.checkable, last_checked: t, result: ok ? (result ?? "ok") : (result ?? "failed") } };
         failed.push({ f: working[i], ok });
         if (ok) {
           changed = true;
@@ -1003,7 +1006,9 @@ export function createFactsEngine(deps = {}) {
         );
         const idxOld = working.findIndex((x) => x.id === f.id);
         if (idxOld >= 0) {
-          working[idxOld] = { ...working[idxOld], checkable: { ...(working[idxOld].checkable ?? {}), last_checked: t, result: "failed" } };
+          // BET-1505: preserve the probe's detail recorded in the check pass
+          // above — don't clobber it back to the bare "failed" literal.
+          working[idxOld] = { ...working[idxOld], checkable: { ...(working[idxOld].checkable ?? {}), last_checked: t, result: f.checkable?.result ?? "failed" } };
         }
         if (!res.reject && res.action === "supersede" && res.facts) {
           const present = await presenceCheck();

--- a/src/server/ctoFacts.test.mjs
+++ b/src/server/ctoFacts.test.mjs
@@ -509,6 +509,50 @@ test("checkable: ci branch scope is stamped and threaded to verify (BET-1504)", 
   assert.deepEqual(byBranch.get("none"), { surface: "ci", probe: "green", branch: null, project: "alpha" });
 });
 
+// BET-1505: the probe's own detail survives into checkable.result — a user
+// auditing the blackboard (§10.5) must be able to tell a closed issue from an
+// unavailable CLI from a missing branch, not just see the bare "failed".
+test("checkable: verify persists the probe's detail into checkable.result (BET-1505)", async () => {
+  const results = {
+    "MUL-1": { ok: false, result: "closed" },
+    "MUL-2": { ok: true, result: "green" },
+    "MUL-3": { ok: false, result: "not-found" },
+    "MUL-4": { ok: true },
+    "MUL-5": { ok: false },
+  };
+  const { engine, facts } = makeEngine({
+    surfaceExists: async (s) => s === "issue",
+    verify: async (args) => {
+      if (args.probe === "MUL-6") throw new Error("cli unavailable");
+      return results[args.probe] ?? { ok: false, result: "not-found" };
+    },
+  });
+  const probes = ["MUL-1", "MUL-2", "MUL-3", "MUL-4", "MUL-5", "MUL-6"];
+  for (const [i, id] of probes.entries()) {
+    await engine.submitProposal({ proposalId: `bd${i}`, project: "alpha", kind: "status", statement: `issue ${id} is blocking`, refs: [`r${i}`] });
+  }
+  await engine.pump();
+  await engine.verifyDue();
+  const stored = (await facts.load("alpha")).facts;
+  const detailOf = (probe) =>
+    stored.filter((x) => x.statement === `issue ${probe} is blocking` && x.checkable).map((x) => x.checkable.result);
+  assert.deepEqual(detailOf("MUL-1"), ["closed"], "failed probe keeps its detail");
+  assert.deepEqual(detailOf("MUL-2"), ["green"], "passing probe keeps its detail");
+  assert.deepEqual(detailOf("MUL-3"), ["not-found"], "seam-provided detail recorded");
+  assert.deepEqual(detailOf("MUL-4"), ["ok"], "passing probe without detail falls back to ok");
+  assert.deepEqual(detailOf("MUL-5"), ["failed"], "failing probe without detail falls back to failed");
+  assert.deepEqual(detailOf("MUL-6"), ["verify error"], "thrown verify records the error detail");
+  // §10.5 drill-down: factViewRow passes checkable through as-is, so the
+  // render surfaces the detail verbatim on active and superseded rows alike.
+  const render = composeFactsRender({ facts: stored, projects: ["alpha"], nowMs: 1000 * D, project: "alpha" });
+  const rowResult = (probe) =>
+    [...render.active, ...render.superseded]
+      .filter((r) => r.statement === `issue ${probe} is blocking` && r.checkable)
+      .map((r) => r.checkable.result);
+  assert.deepEqual(rowResult("MUL-1"), ["closed"]);
+  assert.deepEqual(rowResult("MUL-2"), ["green"]);
+});
+
 test("touchFacts bumps last_accessed + access_count on retrieval", async () => {
   const { engine, facts } = makeEngine();
   await engine.submitProposal({ proposalId: "ta", project: "alpha", kind: "status", statement: "touched", refs: ["r1"] });


### PR DESCRIPTION
## BET-1505 — verifyDue discards the verify probe's detail

`verifyDue` read the verify seam's `result` detail ("closed", "not-found", the CI conclusion, "verify error", …) into a local variable and threw it away, storing only the literal `ok ? "ok" : "failed"` into `checkable.result`. The §10.5 drill-down therefore showed "failed" with no reason — a user auditing the blackboard could not tell a closed issue from an unavailable CLI from a missing branch.

**Fix (src/server/ctoFacts.mjs, both `checkable.result` write sites in `verifyDue`):**
- Check pass: `result: ok ? (result ?? "ok") : (result ?? "failed")` — the probe's detail wins; the bare literals are only the fallback when the seam returns no detail. The thrown-verify path keeps its richer `"verify error"` detail.
- Supersede pass: preserve the detail recorded in the check pass (`f.checkable?.result ?? "failed"`) instead of clobbering it back to the bare `"failed"` literal.

**Render (§10.5):** `factViewRow` already passes `checkable` through verbatim, so `composeFactsRender` surfaces the detail as-is — pinned by the new test's render assertions. No render change needed.

Behavior-neutral for the verify/supersede machinery itself (`ok` still drives everything).

**Tests:** new `checkable: verify persists the probe's detail into checkable.result (BET-1505)` covers failed+detail, passed+detail, no-detail fallbacks ("ok"/"failed"), thrown-verify ("verify error"), and the §10.5 render surfacing.

Duplicate-site audit: `grep "result:" ctoFacts.mjs` — exactly two `checkable.result` writers existed (both in `verifyDue`), both fixed; the stamp initializer (`result: null`) unchanged.

**Files changed:** 2 — `src/server/ctoFacts.mjs` (+7/−2 incl. comments), `src/server/ctoFacts.test.mjs` (+46).

**Verification results:**
- PR branch (`multica/BET-1505-verify-detail` @ `e9752ea5`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0. vitest: 199 files, 3909 pass / 7 skip / 0 fail. node:test: 3876 pass / 0 fail. log sha256: `c6cadec6dff446c4860d39b5b3af4dc9e4280e47295e5e71bbdb7c7e737e420d`
- Base (`main` @ `b768476b`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0. vitest: 199 files, 3909 pass / 7 skip / 0 fail. node:test: 3875 pass / 0 fail. log sha256: `b4f3ccf7ccb83b6a8713fce93fb6f7b1b8f13b6f50ffaa74c7be00c3a206ebb0`
- **Conclusion:** 0 new failures, 0 pre-existing. The +1 node:test on the PR branch is the new BET-1505 test.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Base: origin/main @ b768476b
