### PR TITLE
BET-1513: a rate-limit self-pause is a 5-minute backoff, not a wedge

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -155,6 +155,20 @@ export const RATE_LIMITS = Object.freeze({
 export const HOUR_MS = 3_600_000;
 export const TICK_INTERVAL_MS = 60_000;
 
+// How long a rate-limit self-pause (exceedRateLimit) backs off before the
+// engine's own tick auto-clears it (BET-1508). The concurrent-* limits trip on
+// a momentary burst of ambient sessions; a pause until a human resumes is the
+// wrong shape for a transient condition — on a busy box the boot→burst→trip
+// sequence left the engine permanently paused, and a manual resume was undone
+// within one tick (the next ambient dispatch re-tripped on top of the
+// still-in-flight sessions). Five minutes gives the burst time to drain; if
+// ambient is still saturated the next begin re-trips and the backoff repeats —
+// which IS the intended backoff semantics. The persisted kill-switch pause
+// (flag file, pause()/hardPause()) is NEVER auto-cleared: selfPaused is false
+// on that path (the flag is authoritative), so the cool-down can only ever
+// clear the in-memory rate-limit pause.
+export const RATE_LIMIT_COOLDOWN_MS = 5 * 60_000;
+
 // The card timer's cadence (BET-1382): it inspects pending asks / health
 // escalations once a minute and promotes any ask past BLOCKER_AFTER_MS into a
 // blocker card. The card threshold itself (10 min) lives in ctoCards.mjs.
@@ -473,6 +487,7 @@ export function createCtoEngine(deps = {}) {
   let thrifty = false;
   let thriftyAtDay = null; // local-day key thrifty was set on (BET-1388 auto-clear)
   let selfPaused = false;
+  let selfPausedAt = null; // when the rate-limit self-pause began (BET-1508 cool-down)
   let enabled = false;
   let heartbeatAt = now();
   let tickHandle = null;
@@ -626,6 +641,29 @@ export function createCtoEngine(deps = {}) {
     if (disposed) return;
     heartbeatAt = now();
     try {
+      // BET-1508: a rate-limit self-pause is a backoff, not a policy. Once the
+      // cool-down has elapsed, clear it and let this same tick re-assess —
+      // the next ambient dispatch re-trips if the burst is still running,
+      // which restarts the backoff instead of wedging the engine. The
+      // persisted kill-switch pause is untouched (selfPaused is false on
+      // that path), so a human Pause always wins.
+      if (selfPaused && selfPausedAt != null && now() - selfPausedAt >= RATE_LIMIT_COOLDOWN_MS) {
+        selfPaused = false;
+        selfPausedAt = null;
+        await ledgerLog({
+          kind: "cto.self_resume",
+          reason: "rate_limit_cooldown_elapsed",
+          source: "engine",
+        });
+        // The trip raised a rate_limit health card; the backoff ending is the
+        // liveness predicate going true again (same shape as onHealthRecovered
+        // on the manual resume path).
+        try {
+          await cards.onHealthRecovered();
+        } catch {
+          /* best-effort */
+        }
+      }
       const { enabled: enabledNow, paused } = await gateContext();
       if (paused) {
         await syncState();
@@ -855,9 +893,12 @@ export function createCtoEngine(deps = {}) {
   }
 
   // Exceeding a rate limit pauses the engine + raises a health warning (§3.3
-  // / §10.6-7).
+  // / §10.6-7). The pause is an in-memory BACKOFF (BET-1508): the tick
+  // auto-clears it once RATE_LIMIT_COOLDOWN_MS has elapsed. It never touches
+  // the kill-switch flag, so it can never override a human's Pause.
   async function exceedRateLimit(limitId) {
     selfPaused = true;
+    selfPausedAt = now();
     await ledgerLog({ kind: "cto.ratelimit_trip", reason: limitId, source: "engine" });
     await recordBlocker("rate_limit", limitId);
     await syncState();

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -305,14 +305,20 @@ test("concurrent delegate cap trips to paused", async () => {
 
 // ----- BET-1508: a rate-limit self-pause is a BACKOFF, not a policy -----
 
-test("BET-1508: the rate-limit self-pause auto-clears after the cool-down and never touches the kill switch", async () => {
-  const h = makeHarness({ ctoEnabled: true });
+// Shared setup: saturate the concurrent-ephemeral cap and take the trip.
+async function tripEphemeralLimit(h) {
   for (let i = 0; i < RATE_LIMITS.concurrentEphemeral; i++) {
     assert.equal((await h.engine.beginEphemeral()).ok, true);
   }
   const sixth = await h.engine.beginEphemeral();
   assert.equal(sixth.ok, false);
+  assert.equal(sixth.error, "rate_limit:concurrentEphemeral");
   assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+}
+
+test("BET-1508: the rate-limit self-pause auto-clears after the cool-down and never touches the kill switch", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  await tripEphemeralLimit(h);
   // The trip raised the rate_limit health escalation…
   assert.equal(h.pendingBlockers.length, 1);
   assert.equal(h.pendingBlockers[0].source, "rate_limit");
@@ -341,7 +347,6 @@ test("BET-1508: the rate-limit self-pause auto-clears after the cool-down and ne
 test("BET-1508: a human kill-switch pause is NEVER auto-cleared by the cool-down", async () => {
   const h = makeHarness({ ctoEnabled: true });
   await h.engine.pause({ reason: "manual" });
-  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
 
   // Well past any cool-down…
   h.clock.ms += RATE_LIMIT_COOLDOWN_MS * 3;

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -283,13 +283,7 @@ test("session-creations-per-hour limit trips to paused + health escalation", asy
 
 test("concurrent ephemeral cap trips to paused", async () => {
   const h = makeHarness({ ctoEnabled: true });
-  for (let i = 0; i < RATE_LIMITS.concurrentEphemeral; i++) {
-    assert.equal((await h.engine.beginEphemeral()).ok, true);
-  }
-  const sixth = await h.engine.beginEphemeral();
-  assert.equal(sixth.ok, false);
-  assert.equal(sixth.error, "rate_limit:concurrentEphemeral");
-  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  await tripEphemeralLimit(h);
 });
 
 test("concurrent delegate cap trips to paused", async () => {

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -13,6 +13,7 @@ import {
   DOT,
   HOUR_MS,
   RATE_LIMITS,
+  RATE_LIMIT_COOLDOWN_MS,
   isRunningCtoRow,
   buildFactsContext,
   defaultGetCounts,
@@ -300,6 +301,57 @@ test("concurrent delegate cap trips to paused", async () => {
   assert.equal(third.ok, false);
   assert.equal(third.error, "rate_limit:concurrentDelegate");
   assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+});
+
+// ----- BET-1508: a rate-limit self-pause is a BACKOFF, not a policy -----
+
+test("BET-1508: the rate-limit self-pause auto-clears after the cool-down and never touches the kill switch", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  for (let i = 0; i < RATE_LIMITS.concurrentEphemeral; i++) {
+    assert.equal((await h.engine.beginEphemeral()).ok, true);
+  }
+  const sixth = await h.engine.beginEphemeral();
+  assert.equal(sixth.ok, false);
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  // The trip raised the rate_limit health escalation…
+  assert.equal(h.pendingBlockers.length, 1);
+  assert.equal(h.pendingBlockers[0].source, "rate_limit");
+
+  // …which stays up through the cool-down itself…
+  h.clock.ms += RATE_LIMIT_COOLDOWN_MS - 1000;
+  await h.engine.tick();
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  assert.equal(h.ledgerRows.some((r) => r.kind === "cto.self_resume"), false);
+
+  // …and auto-clears once it has elapsed: the engine resumes ITSELF, the
+  // backoff is ledgered, and the health escalation resolves.
+  h.clock.ms += 2000;
+  await h.engine.tick();
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  const selfResume = h.ledgerRows.find((r) => r.kind === "cto.self_resume");
+  assert.ok(selfResume, "self_resume ledgered");
+  assert.equal(selfResume.reason, "rate_limit_cooldown_elapsed");
+  assert.equal(h.cardCalls.some((c) => c.fn === "onHealthRecovered"), true);
+
+  // The auto-clear must NOT touch the persisted kill switch: the flag was
+  // never set by the trip, and it is still unset now.
+  assert.equal(h.killSwitchPaused, false);
+});
+
+test("BET-1508: a human kill-switch pause is NEVER auto-cleared by the cool-down", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  await h.engine.pause({ reason: "manual" });
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+
+  // Well past any cool-down…
+  h.clock.ms += RATE_LIMIT_COOLDOWN_MS * 3;
+  await h.engine.tick();
+
+  // …the manual pause (flag file path) still holds: the cool-down only ever
+  // clears the in-memory rate-limit backoff.
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  assert.equal(h.ledgerRows.some((r) => r.kind === "cto.self_resume"), false);
+  assert.equal(h.killSwitchPaused, true);
 });
 
 test("releasing an ephemeral/delegate slot frees the cap", async () => {


### PR DESCRIPTION
## Problem

`exceedRateLimit` set an in-memory `selfPaused` with **no flag file, no `pausedAt`, and no auto-clear**. The `concurrent-*` limits trip on a momentary burst of ambient sessions, so on a busy box the lifecycle was:

```
boot → ambient burst hits 5 concurrent ephemerals → trip → paused forever
```

…until a human resumes. And a manual resume was **undone within one tick** — the next ambient dispatch re-trips on top of the still-in-flight sessions.

Observed live on 2026-09-01: three trips in two hours, each wedging the engine until manually resumed, while event ingestion kept the ledger flowing — so the pane read dead but the box looked busy.

## Fix

The self-pause is now a **backoff**:

- `exceedRateLimit` records when it tripped (`selfPausedAt`).
- The tick auto-clears the self-pause once `RATE_LIMIT_COOLDOWN_MS` (5 min) has elapsed — ledgering `cto.self_resume` and calling `onHealthRecovered` so the `rate_limit` health card resolves with it.
- If ambient is still saturated, the next `beginEphemeral` re-trips and the backoff repeats — which is the intended backoff semantics.

**The persisted kill-switch pause (flag file, via `pause()`/`hardPause()`) is NEVER auto-cleared**: on that path `selfPaused` is false and the flag is authoritative, so the cool-down can only ever clear the in-memory rate-limit backoff. A human Pause always wins.

## Tests

- Trip → paused → cool-down not yet elapsed → still paused, no `self_resume` row.
- Cool-down elapsed → tick → `DOT.ACTIVE`, `cto.self_resume` ledgered, `onHealthRecovered` called, kill switch untouched.
- Human kill-switch pause + 3x cool-down → **still paused**, no auto-clear.

Server suite 3330 pass, typecheck clean.
