### PR TITLE
BET-1513 follow-up: concurrency limits shed the call instead of pausing the engine

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -892,16 +892,30 @@ export function createCtoEngine(deps = {}) {
     }
   }
 
-  // Exceeding a rate limit pauses the engine + raises a health warning (§3.3
-  // / §10.6-7). The pause is an in-memory BACKOFF (BET-1508): the tick
-  // auto-clears it once RATE_LIMIT_COOLDOWN_MS has elapsed. It never touches
-  // the kill-switch flag, so it can never override a human's Pause.
-  async function exceedRateLimit(limitId) {
-    selfPaused = true;
-    selfPausedAt = now();
+  // A tripped rate limit. Two severities (BET-1513 follow-up):
+  //   pause  — the RUNAWAY-shaped limit (sessionCreationsPerHour): a loop is
+  //          creating sessions faster than they finish. The engine pauses all
+  //          work and raises a rate_limit health card; the in-memory pause is
+  //          a BACKOFF auto-cleared by the tick after RATE_LIMIT_COOLDOWN_MS
+  //          (never the kill-switch flag, so a human Pause always wins).
+  //   shed   — the CONCURRENCY limits (concurrentEphemeral/concurrentDelegate):
+  //          "one more ambient call than slots" is a transient condition whose
+  //          correct response is refusing THE CALL — the caller already
+  //          degrades gracefully on {ok:false} — not pausing the whole engine.
+  //          Pausing here wedged busy boxes into a trip→backoff→burst→trip
+  //          oscillation (observed live 2026-09-01: boot → 5 ambient sessions
+  //          → trip → 5-min backoff → self-resume → re-trip 30s later), with
+  //          the dot reading paused most of the time. A shed is ledgered for
+  //          the drill-down; it raises NO needs-you card — routine backoff is
+  //          not something the user must act on.
+  async function exceedRateLimit(limitId, { pause = true } = {}) {
     await ledgerLog({ kind: "cto.ratelimit_trip", reason: limitId, source: "engine" });
-    await recordBlocker("rate_limit", limitId);
-    await syncState();
+    if (pause) {
+      selfPaused = true;
+      selfPausedAt = now();
+      await recordBlocker("rate_limit", limitId);
+      await syncState();
+    }
   }
 
   // ----- Session / job creation gates (§3.3) -----
@@ -947,7 +961,7 @@ export function createCtoEngine(deps = {}) {
       /* a failed cap read must not block ambient work */
     }
     if (track.ephemeral >= rateLimits.concurrentEphemeral) {
-      await exceedRateLimit("concurrentEphemeral");
+      await exceedRateLimit("concurrentEphemeral", { pause: false });
       return { ok: false, error: "rate_limit:concurrentEphemeral" };
     }
     track.recordSessionCreation();
@@ -961,7 +975,7 @@ export function createCtoEngine(deps = {}) {
     if (!enabledNow) return { ok: false, error: "cto_disabled" };
     if (paused) return { ok: false, error: "cto_paused" };
     if (track.delegate >= rateLimits.concurrentDelegate) {
-      await exceedRateLimit("concurrentDelegate");
+      await exceedRateLimit("concurrentDelegate", { pause: false });
       return { ok: false, error: "rate_limit:concurrentDelegate" };
     }
     const release = track.beginDelegate();

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -266,13 +266,7 @@ test("disabled engine refuses to start sessions", async () => {
 
 test("session-creations-per-hour limit trips to paused + health escalation", async () => {
   const h = makeHarness({ ctoEnabled: true });
-  for (let i = 0; i < RATE_LIMITS.sessionCreationsPerHour; i++) {
-    h.engine.rateTracker.recordSessionCreation();
-  }
-  const gate = await h.engine.checkCanCreateSession();
-  assert.equal(gate.ok, false);
-  assert.equal(gate.error, "rate_limit:sessionCreationsPerHour");
-  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  await tripSessionCreationLimit(h);
   const trip = h.ledgerRows.find((r) => r.kind === "cto.ratelimit_trip");
   assert.ok(trip, "rate-limit trip ledgered");
   assert.equal(trip.reason, "sessionCreationsPerHour");
@@ -281,12 +275,19 @@ test("session-creations-per-hour limit trips to paused + health escalation", asy
   assert.equal(h.pendingBlockers[0].source, "rate_limit");
 });
 
-test("concurrent ephemeral cap trips to paused", async () => {
+test("concurrent ephemeral cap SHEDS the call but does not pause the engine", async () => {
   const h = makeHarness({ ctoEnabled: true });
   await tripEphemeralLimit(h);
+  // The rejected caller degrades gracefully; the ENGINE keeps working —
+  // a concurrency blip is a per-call backoff, not a whole-engine pause.
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  assert.equal(h.pendingBlockers.length, 0, "no needs-you card for a routine shed");
+  const trip = h.ledgerRows.find((r) => r.kind === "cto.ratelimit_trip");
+  assert.ok(trip, "the shed is ledgered for the drill-down");
+  assert.equal(trip.reason, "concurrentEphemeral");
 });
 
-test("concurrent delegate cap trips to paused", async () => {
+test("concurrent delegate cap sheds without pausing", async () => {
   const h = makeHarness({ ctoEnabled: true });
   for (let i = 0; i < RATE_LIMITS.concurrentDelegate; i++) {
     assert.equal((await h.engine.beginDelegateJob()).ok, true);
@@ -294,12 +295,13 @@ test("concurrent delegate cap trips to paused", async () => {
   const third = await h.engine.beginDelegateJob();
   assert.equal(third.ok, false);
   assert.equal(third.error, "rate_limit:concurrentDelegate");
-  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  assert.equal(h.pendingBlockers.length, 0);
 });
 
 // ----- BET-1508: a rate-limit self-pause is a BACKOFF, not a policy -----
 
-// Shared setup: saturate the concurrent-ephemeral cap and take the trip.
+// Shared setup: saturate the concurrent-ephemeral cap and take the shed.
 async function tripEphemeralLimit(h) {
   for (let i = 0; i < RATE_LIMITS.concurrentEphemeral; i++) {
     assert.equal((await h.engine.beginEphemeral()).ok, true);
@@ -307,12 +309,23 @@ async function tripEphemeralLimit(h) {
   const sixth = await h.engine.beginEphemeral();
   assert.equal(sixth.ok, false);
   assert.equal(sixth.error, "rate_limit:concurrentEphemeral");
+}
+
+// Shared setup: trip the RUNAWAY limit (the one that pauses) and prove the
+// self-pause shape.
+async function tripSessionCreationLimit(h) {
+  for (let i = 0; i < RATE_LIMITS.sessionCreationsPerHour; i++) {
+    h.engine.rateTracker.recordSessionCreation();
+  }
+  const gate = await h.engine.checkCanCreateSession();
+  assert.equal(gate.ok, false);
+  assert.equal(gate.error, "rate_limit:sessionCreationsPerHour");
   assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
 }
 
 test("BET-1508: the rate-limit self-pause auto-clears after the cool-down and never touches the kill switch", async () => {
   const h = makeHarness({ ctoEnabled: true });
-  await tripEphemeralLimit(h);
+  await tripSessionCreationLimit(h);
   // The trip raised the rate_limit health escalation…
   assert.equal(h.pendingBlockers.length, 1);
   assert.equal(h.pendingBlockers[0].source, "rate_limit");


### PR DESCRIPTION
## Problem

BET-1513 made the rate-limit self-pause a 5-minute backoff. Live on the box it then exposed the deeper flaw: the backoff fired, auto-resumed exactly as built, and the engine **re-tripped 30 seconds later** — boot, 5 ambient sessions, trip, 5-min backoff, self-resume, burst, trip. On a busy box the demand for concurrent ambient sessions is persistently at the cap, so the oscillation left the dot reading "paused" most of the time with a ~1-minute work window per cycle. Better than a permanent wedge, still not working.

## The deeper flaw

For the **concurrency** limits, the per-call rejection IS the backoff. `beginEphemeral`/`beginDelegateJob` already return `{ok:false}` and every caller degrades gracefully (`gated:true` paths) — the additional whole-engine pause was disproportionate punishment for "one more ambient call than slots", and it is what made the wedge.

## Fix

- `concurrentEphemeral` / `concurrentDelegate`: **SHED** — refuse the call, ledger the trip for the drill-down, keep working. No pause, and **no needs-you card**: routine backoff is not something the user must act on (raising one would re-open the card-spam this whole effort closed).
- `sessionCreationsPerHour` keeps pause + health card: a runaway loop creating sessions faster than they finish is the shape that merits stopping the engine, and BET-1513's 5-minute auto-clear backoff still governs it.

## Tests

- The two concurrency tests now assert shed-not-pause: dot stays `ACTIVE`, no `pendingBlockers`, trip ledgered.
- The cool-down tests trip via the session-creations limit, which is now the only self-pausing one.
- Human kill-switch pause is still never auto-cleared.

Server suite 3331 pass, typecheck clean, duplication-gate clean (0 clones in the touched files).
