### PR TITLE
BET-1516: blockers into the pipeline + inbox card liveness predicates

### DIFF
--- a/docs/opencode-tools/send-to-cto.ts
+++ b/docs/opencode-tools/send-to-cto.ts
@@ -94,6 +94,13 @@ export const send_to_cto = tool({
       .string()
       .optional()
       .describe("Optional short title for the surfaced notification. Defaults to the sender's session label."),
+    condition: z
+      .string()
+      .optional()
+      .describe(
+        "For blockers: a checkable condition the note is blocked on (e.g. 'CI on F is broken'). " +
+          "The CTO re-verifies it on its card ticks and auto-resolves the blocker when the named state no longer holds.",
+      ),
   },
   async execute(args, context) {
     const result = await call("POST", "/api/cto/inbound", {
@@ -104,6 +111,7 @@ export const send_to_cto = tool({
       refs: args.refs,
       tag: args.tag,
       title: args.title,
+      condition: args.condition,
     });
     const blocker = result.parked && args.kind !== "fyi" && args.kind !== "finding" &&
       args.kind !== "handoff" && args.kind !== "anomaly" && (args.kind === "blocker" || !args.kind);

--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -1170,6 +1170,10 @@ export function createCtoInbound({
       tag,
       sender,
       title: typeof payload?.title === "string" && payload.title ? payload.title : undefined,
+      // BET-1516 (§10.3 predicate 2): the note may NAME a checkable condition
+      // ("when the plan or note names one") — carried to the ask/card so the
+      // §6.7 surface verify can auto-retract the blocker when it goes gone.
+      condition: typeof payload?.condition === "string" && payload.condition ? payload.condition : undefined,
       ts,
       read: false,
       count: 1,

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -112,6 +112,140 @@ export function splitContentlessOpenCards(cards) {
   return { keep, dropped };
 }
 
+// BET-1516: engine-state.json marker key for the one-time prune of the
+// orphaned `concurrentEphemeral` health card. BET-1513 made the concurrency
+// limit trips shed (pause:false) — they no longer call recordBlocker — so a
+// `pendingBlockers` entry or an open health card carrying one of these
+// reasons predates that change and is pure residue: re-upserted by every
+// tick forever, never closable by hand without folding the whole rate_limit
+// group. Same idempotency contract as CONTENTLESS_CARD_PRUNE_KEY.
+export const SHED_CARD_PRUNE_KEY = "shedCardPrune";
+export const SHED_RATE_LIMIT_REASONS = Object.freeze([
+  "concurrentEphemeral",
+  "concurrentDelegate",
+]);
+
+// Pure split for the BET-1516 one-time prune: drop ONLY open HEALTH cards
+// whose sourceId is the rate_limit group and whose body is one of the shed
+// reasons (BET-1513: shed trips never recordBlocker again, so any such card
+// today is residue, not a live signal). Non-open / malformed / other cards
+// are left exactly where they are.
+export function splitOrphanedShedCards(cards) {
+  const rows = Array.isArray(cards) ? cards : [];
+  const keep = [];
+  const dropped = [];
+  for (const c of rows) {
+    const isOrphan =
+      c &&
+      c.state === "open" &&
+      c.variant === "blocker" &&
+      c.sourceKind === HEALTH_SOURCE_KIND &&
+      c.sourceId === "rate_limit" &&
+      SHED_RATE_LIMIT_REASONS.includes(c.body);
+    if (isOrphan) dropped.push(c);
+    else keep.push(c);
+  }
+  return { keep, dropped };
+}
+
+// ----- Pending-findings queue rows (BET-1516 / §9.1) -----
+//
+// A blocker enters the pipeline on the next engine tick via the findings.json
+// queue (the §9.2-v2 bypass removed: the note used to ride into evidence only
+// at a rollup-close breakpoint). Two producers, one row shape:
+//   - an inbox blocker note, queued at note arrival (source "inbox")
+//   - a worker ask promoted past the 10-min threshold (source "ask")
+// The ENGINE's drain turns each row into a high-salience evidence row on the
+// A1 ledger — for inbox notes the exact row shape drainInbox writes — and
+// marks the source note read so the breakpoint drain never double-folds it.
+// Pure builders; these shapes are the producer↔consumer contract.
+
+export function findingFromInboxNote(entry, { ts = Date.now() } = {}) {
+  if (!entry || typeof entry !== "object") return null;
+  return {
+    source: "inbox",
+    ts,
+    // The inbox entry id — the drain's dedupe marker against drainInbox (it
+    // marks this note read after the ledger row fires).
+    noteId: typeof entry.id === "string" ? entry.id : undefined,
+    noteKind: "blocker",
+    message: entry.message,
+    title: entry.title,
+    tag: entry.tag ?? undefined,
+    refs: Array.isArray(entry.refs) ? entry.refs : [],
+    sender: entry.sender && typeof entry.sender === "object" ? entry.sender : undefined,
+    // A note may NAME a checkable condition (§10.3 predicate 2 — "when the
+    // plan or note names one"). Carried to the ask/card for the liveness pass.
+    condition: typeof entry.condition === "string" && entry.condition ? entry.condition : undefined,
+  };
+}
+
+export function findingFromPromotedAsk(ask, { ts = Date.now() } = {}) {
+  if (!ask || typeof ask !== "object") return null;
+  return {
+    source: "ask",
+    ts,
+    sourceKind: ask.sourceKind,
+    sourceId: ask.sourceId,
+    sessionID: ask.sessionID ?? ask.noteSessionID ?? undefined,
+    message: ask.body,
+    title: blockerTitle(ask.sourceKind, ask.title),
+    refs: Array.isArray(ask.refs) ? ask.refs : [],
+  };
+}
+
+// §10.3 predicate 2 classifier (pure): a §6.7 surface verify result against
+// the condition the note named. GONE when the verify definitively shows the
+// named state no longer holds. "no surface"/"unavailable" mean "no opinion"
+// — a probe that cannot see the surface must never resolve the card. Caller
+// passes the match from matchCheckable (null → no opinion).
+export function isConditionGoneResult(match, verifyResult) {
+  if (!match) return null;
+  if (!verifyResult || typeof verifyResult !== "object") return null;
+  if (verifyResult.ok !== false) return false;
+  const result = String(verifyResult.result ?? "");
+  return result !== "no surface" && result !== "unavailable";
+}
+
+// §10.3 inbox-card liveness (BET-1516, pure): evaluate the three predicates
+// against one open inbox-sourced blocker card. Returns `null` (all predicates
+// hold / no opinion — the card stays) or `{reason}` naming the one that went
+// false. Evaluation order is deterministic: the TTL stamp (sync, cheapest),
+// then the named condition, then the sender session. When the exact TTL stamp
+// is absent (a pre-1516 card), the blocker retention window counted from the
+// card's carried-forward first report is the bound — stricter than the note's
+// real expiry, never a card outliving its note.
+export async function inboxCardLivenessGone(card, { nowMs, hasSession = null, conditionGone = null } = {}) {
+  if (!card || card.state !== "open" || card.variant !== "blocker") return null;
+  const ttlBound = Number.isFinite(card.noteExpires)
+    ? card.noteExpires
+    : Number.isFinite(card.pendingSince)
+      ? card.pendingSince + INBOX_TTL_MS.blocker
+      : null;
+  if (ttlBound != null && nowMs > ttlBound) {
+    return { reason: "inbox note expired" };
+  }
+  if (typeof conditionGone === "function" && typeof card.noteCondition === "string" && card.noteCondition) {
+    let gone = null;
+    try {
+      gone = await conditionGone(card.noteCondition);
+    } catch {
+      gone = null;
+    }
+    if (gone === true) return { reason: "condition gone" };
+  }
+  if (typeof hasSession === "function" && typeof card.noteSessionID === "string" && card.noteSessionID) {
+    let exists = null;
+    try {
+      exists = await hasSession(card.noteSessionID);
+    } catch {
+      exists = null;
+    }
+    if (exists === false) return { reason: "sender session gone" };
+  }
+  return null;
+}
+
 // §10.6-7 probe-auth-failure card copy (3 consecutive auth failures — the
 // runner's AUTH_FAIL_ESCALATE). `secretKey` is the vault KEY NAME (not a
 // value) when the spec declared one — naming the exact key the user should
@@ -340,6 +474,20 @@ export function createCtoCards(deps = {}) {
     // registry's persisted half (engine-state.json `pendingAsks`) — one
     // writer, one mutex, one consume-and-prune shape for both queues.
     patchEngineState: patchEngineStatePatch = null,
+    // BET-1516 (§9.1): the pending-findings queue writer — the engine injects
+    // a bound append into findings.json. Both blocker entry points route
+    // through it (inbox notes at arrival, worker asks at promotion), and the
+    // engine's card tick drains the queue into the A1 ledger. Default null
+    // (a no-op) so standalone/test usage without the engine keeps working.
+    queueFinding = null,
+    // BET-1516 (§10.3 predicate 1): does an opencode session exist? The
+    // engine injects the box's sessionExists (404 → false, transient → true).
+    // Default null — the predicate is skipped when no checker is wired.
+    hasSession = null,
+    // BET-1516 (§10.3 predicate 2): is the condition a note named now GONE?
+    // Returns true (gone) / false (holds) / null (no opinion). The engine
+    // injects the §6.7 matcher + surface verify. Default null — skipped.
+    conditionGone = null,
   } = deps;
 
   // In-flight worker asks: key (sessionID, or sourceId for sessionless inbox
@@ -371,16 +519,45 @@ export function createCtoCards(deps = {}) {
     }
   }
 
-  async function onInboxBlocker({ message, title, refs = [], tag, sessionID, ts = now() } = {}) {
+  async function queueInboxFinding(row) {
+    if (typeof queueFinding !== "function") return;
+    try {
+      await queueFinding(row);
+    } catch (e) {
+      console.warn("[cto] finding queue append failed:", e?.message ?? e);
+    }
+  }
+
+  // Source (3): a `blocker` inbox note (BET-1397 / spec §4.4). This is the ONE
+  // notification path for inbox notes: fires the blocking-tier notify through
+  // the injected router exactly once, and registers a pending blocker so the
+  // card timer (promoteDue) promotes it at > 10 min like any ask. Read-only on
+  // the inbox itself — the inbound funnel already persisted the entry.
+  // Grouping layer 2: the sender session's workspace, when it is tmux-stamped.
+  // Never throws and never blocks the card path — an unresolvable sender just
+  // falls through to the slug layer.
+  //
+  // BET-1516 (§9.1): the note ALSO enters the pipeline — the finding row is
+  // queued (findings.json) and the engine's card tick turns it into evidence
+  // within a minute; the notification itself is untouched (its own timer).
+  // The sender session id is now threaded through (`sender.sessionID` is what
+  // the funnel sends; a top-level sessionID stays accepted for tests) — it
+  // routes the notification, keys the ask row, and feeds the card's
+  // sender-session liveness predicate.
+  async function onInboxBlocker({ message, title, refs = [], tag, sender, sessionID, ts = now(), id, expires, condition } = {}) {
     const text = typeof message === "string" ? message.trim() : "";
     if (!text) return { changed: false, notified: false };
+    const noteSessionID =
+      (sender && typeof sender.sessionID === "string" && sender.sessionID) ||
+      (typeof sessionID === "string" && sessionID ? sessionID : undefined) ||
+      undefined;
     // Blocking-tier notification — exactly one, via the shared router.
     try {
       await fireNotify({
         message: text,
         title: typeof title === "string" && title ? title : undefined,
         urgent: true,
-        sessionID: typeof sessionID === "string" ? sessionID : undefined,
+        sessionID: noteSessionID,
       });
     } catch (e) {
       console.warn("[cto] inbox blocker notify failed:", e?.message ?? e);
@@ -389,9 +566,15 @@ export function createCtoCards(deps = {}) {
     // is keyed by the note's CONDITION (inboxGroupKey), not its prose, so a
     // watchdog restating the same condition every tick upserts one card
     // instead of minting a new one per tick.
-    const project = await resolveNoteProject(sessionID);
+    const project = await resolveNoteProject(noteSessionID);
     const groupKey = inboxGroupKey({ tag, title, message: text, project });
     const sourceId = stableCardId(INBOX_SOURCE_KIND, groupKey);
+    // §10.3 predicate inputs ride the ask row: the note's identity, its TTL
+    // stamp (refreshed by every restatement — a card can never outlive the
+    // note that raised it), the sender session, and any named condition.
+    const noteExpires = Number.isFinite(expires) ? expires : undefined;
+    const noteCondition =
+      typeof condition === "string" && condition ? condition : undefined;
     await registerAsk({
       sourceKind: INBOX_SOURCE_KIND,
       sourceId,
@@ -400,12 +583,24 @@ export function createCtoCards(deps = {}) {
       // per-tick duplication the group key just closed. `askKeyOf` falls back
       // to sourceId, which IS the condition.
       sessionID: undefined,
-      noteSessionID: typeof sessionID === "string" ? sessionID : undefined,
+      noteSessionID,
+      noteId: typeof id === "string" ? id : undefined,
+      noteExpires,
+      noteCondition,
       title: typeof title === "string" ? title : undefined,
       body: text,
       refs: Array.isArray(refs) ? refs : [],
       askedAt: ts,
     });
+    // §9.1: the blocker enters the pipeline on the next engine tick — queue
+    // the finding AFTER the notify (the notification is the immediate timer,
+    // the pipeline entry rides the queue). Best-effort by contract.
+    await queueInboxFinding(
+      findingFromInboxNote(
+        { id, kind: "blocker", message: text, title, tag, refs, sender: { ...sender, sessionID: noteSessionID }, condition: noteCondition },
+        { ts },
+      ),
+    );
     return { changed: true, notified: true, groupKey };
   }
 
@@ -476,7 +671,15 @@ export function createCtoCards(deps = {}) {
     };
   }
 
-  function buildBlockerCard({ id, sourceKind, sourceId, sessionID, title, body, refs, pendingSince, created }) {
+  function buildBlockerCard({ id, sourceKind, sourceId, sessionID, title, body, refs, pendingSince, created, noteId, noteExpires, noteSessionID, noteCondition }) {
+    // §10.3 liveness inputs (BET-1516): set ONLY when present so a card that
+    // lacks them (worker-ask sourced, or a pre-1516 legacy rebuild) converges
+    // byte-identically instead of churning on undefined keys.
+    const noteFields = {};
+    if (noteId != null) noteFields.noteId = noteId;
+    if (Number.isFinite(noteExpires)) noteFields.noteExpires = noteExpires;
+    if (noteSessionID != null) noteFields.noteSessionID = noteSessionID;
+    if (noteCondition != null) noteFields.noteCondition = noteCondition;
     return {
       id,
       variant: "blocker",
@@ -491,6 +694,7 @@ export function createCtoCards(deps = {}) {
       created,
       updatedAt: created,
       state: "open",
+      ...noteFields,
     };
   }
 
@@ -505,7 +709,7 @@ export function createCtoCards(deps = {}) {
   // patchStore mutex, so a writer derived from a stale snapshot can no longer
   // erase a concurrent writer's card (reached from fire-and-forget call
   // sites — promoteDue timers, bus handlers — which used to race).
-  async function upsertBlocker({ sourceKind, sourceId, sessionID, title, body, refs, ts = now(), pendingSince = ts }) {
+  async function upsertBlocker({ sourceKind, sourceId, sessionID, title, body, refs, ts = now(), pendingSince = ts, noteId, noteExpires, noteSessionID, noteCondition }) {
     const id = stableCardId(sourceKind, sourceId);
     let changed = false;
     let isNew = false;
@@ -530,6 +734,10 @@ export function createCtoCards(deps = {}) {
         refs,
         pendingSince: since,
         created,
+        noteId,
+        noteExpires,
+        noteSessionID,
+        noteCondition,
       });
       cardRefs = card.refs;
       // BET-1463 (defect 2): a byte-identical rebuild is not a change — an
@@ -704,9 +912,17 @@ export function createCtoCards(deps = {}) {
         refs: Array.isArray(ask.refs) && ask.refs.length ? ask.refs : fallbackRef ? [fallbackRef] : [],
         ts: nowMs,
         pendingSince: ask.askedAt,
+        noteId: ask.noteId,
+        noteExpires: ask.noteExpires,
+        noteSessionID: ask.noteSessionID,
+        noteCondition: ask.noteCondition,
       });
       changed = changed || r.changed;
       if (r.isNew) promoted += 1;
+      // BET-1516 (§9.1): an ask past the §10.3 threshold enters the pipeline
+      // too — the finding is queued at promotion, and the engine's card tick
+      // turns it into evidence within a minute. Best-effort by contract.
+      await queueInboxFinding(findingFromPromotedAsk(ask, { ts: nowMs }));
       consumedKeys.push(askKeyOf(ask));
     }
     if (consumedKeys.length) await removePendingAskRows(consumedKeys);
@@ -801,6 +1017,108 @@ export function createCtoCards(deps = {}) {
       }
     }
     return { pruned, marked };
+  }
+
+  // BET-1516: the orphaned `concurrentEphemeral` health card. BET-1513 made
+  // the concurrency-limit trips shed (pause:false) — they stopped calling
+  // recordBlocker, but an entry predating that change could still sit in
+  // engine-state.json `pendingBlockers` and re-upsert its "Health check" card
+  // on every tick, forever and unresolvable (closeOpenCard drops the WHOLE
+  // rate_limit group, taking legit sessionCreationsPerHour entries with it —
+  // which is why resolution-by-hand was never the fix). One-time, marker-
+  // guarded prune with the same contract as pruneLegacyOpenCards: drop the
+  // orphaned open cards, drop + stamp the shed pendingBlockers entries, write
+  // one card.resolved ledger row per dropped card, stamp the marker only
+  // after the writes succeeded. `{pruned, droppedEntries, marked}` for tests.
+  async function pruneOrphanedShedCards({ ts = now() } = {}) {
+    let meta = {};
+    try {
+      meta = (await engineState.load()) ?? {};
+    } catch {
+      meta = {};
+    }
+    if (meta?.[SHED_CARD_PRUNE_KEY]?.pruned === true) {
+      return { pruned: 0, droppedEntries: 0, marked: false };
+    }
+    let pruned = 0;
+    const droppedCards = [];
+    await patchStore(cardStore, (fresh) => {
+      const cards = Array.isArray(fresh?.cards) ? fresh.cards : [];
+      const { keep, dropped } = splitOrphanedShedCards(cards);
+      pruned = dropped.length;
+      droppedCards.push(...dropped);
+      return dropped.length ? { cards: keep } : {};
+    });
+    let droppedEntries = 0;
+    if (typeof patchEngineStatePatch === "function") {
+      try {
+        await patchEngineStatePatch((fresh) => {
+          const pending = Array.isArray(fresh?.pendingBlockers) ? fresh.pendingBlockers : [];
+          const next = pending.filter(
+            (b) =>
+              !(
+                b &&
+                b.resolved !== true &&
+                b.source === "rate_limit" &&
+                SHED_RATE_LIMIT_REASONS.includes(b.reason)
+              ),
+          );
+          droppedEntries = pending.length - next.length;
+          return droppedEntries ? { pendingBlockers: next } : {};
+        });
+      } catch {
+        /* best-effort — the card prune above already made the board clean */
+      }
+    }
+    for (const card of droppedCards) {
+      await ledgerAppend({
+        kind: CARD_RESOLVED,
+        cardId: card.id,
+        variant: card.variant,
+        sourceKind: card.sourceKind,
+        refs: card.refs,
+        reason: "orphaned shed card — concurrency trips stopped carding (BET-1513)",
+        ts,
+      });
+    }
+    let marked = false;
+    if (typeof patchEngineStatePatch === "function") {
+      try {
+        await patchEngineStatePatch((fresh) => ({
+          [SHED_CARD_PRUNE_KEY]: {
+            ...(fresh?.[SHED_CARD_PRUNE_KEY] || {}),
+            pruned: true,
+            at: ts,
+          },
+        }));
+        marked = true;
+      } catch {
+        /* best-effort — an unstamped marker just re-prunes a clean store next boot */
+      }
+    }
+    return { pruned, droppedEntries, marked };
+  }
+
+  // BET-1516 (§10.3): the card-tick liveness pass for inbox-sourced blocker
+  // cards. Three predicates — sender session gone, a named condition that
+  // went gone, the inbox note's own TTL — auto-retract the card as `resolved`
+  // (CARD_RESOLVED, never a verdict). POST /api/cto/verdict remains an
+  // independent third path; a predicate resolution is additive. Skipped
+  // entirely when no seam is wired (standalone/test usage): an unevaluatable
+  // predicate is a no-op, never a false resolution.
+  async function checkInboxLiveness({ nowMs = now() } = {}) {
+    const { cards } = await openCards();
+    const open = cards.filter(
+      (c) => c?.state === "open" && c?.variant === "blocker" && c?.sourceKind === INBOX_SOURCE_KIND,
+    );
+    let changed = false;
+    for (const card of open) {
+      const gone = await inboxCardLivenessGone(card, { nowMs, hasSession, conditionGone });
+      if (gone) {
+        changed = (await resolveById(card.id, { reason: gone.reason, ts: nowMs })).changed || changed;
+      }
+    }
+    return { changed };
   }
 
   // Source (2): read the watchdog's blocker-card requests that A2 already
@@ -1074,9 +1392,11 @@ export function createCtoCards(deps = {}) {
     onInboxBlocker,
     seedPendingAsks,
     pruneLegacyOpenCards,
+    pruneOrphanedShedCards,
     promoteDue,
     ingestHealthEscalations,
     onHealthRecovered,
+    checkInboxLiveness,
     upsertBlocker,
     resolveById,
     dismissById,

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -519,7 +519,7 @@ export function createCtoCards(deps = {}) {
     }
   }
 
-  async function queueInboxFinding(row) {
+  async function enqueueFinding(row) {
     if (typeof queueFinding !== "function") return;
     try {
       await queueFinding(row);
@@ -595,7 +595,7 @@ export function createCtoCards(deps = {}) {
     // §9.1: the blocker enters the pipeline on the next engine tick — queue
     // the finding AFTER the notify (the notification is the immediate timer,
     // the pipeline entry rides the queue). Best-effort by contract.
-    await queueInboxFinding(
+    await enqueueFinding(
       findingFromInboxNote(
         { id, kind: "blocker", message: text, title, tag, refs, sender: { ...sender, sessionID: noteSessionID }, condition: noteCondition },
         { ts },
@@ -922,7 +922,7 @@ export function createCtoCards(deps = {}) {
       // BET-1516 (§9.1): an ask past the §10.3 threshold enters the pipeline
       // too — the finding is queued at promotion, and the engine's card tick
       // turns it into evidence within a minute. Best-effort by contract.
-      await queueInboxFinding(findingFromPromotedAsk(ask, { ts: nowMs }));
+      await enqueueFinding(findingFromPromotedAsk(ask, { ts: nowMs }));
       consumedKeys.push(askKeyOf(ask));
     }
     if (consumedKeys.length) await removePendingAskRows(consumedKeys);

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -152,18 +152,37 @@ export function splitOrphanedShedCards(cards) {
 //
 // A blocker enters the pipeline on the next engine tick via the findings.json
 // queue (the §9.2-v2 bypass removed: the note used to ride into evidence only
-// at a rollup-close breakpoint). Two producers, one row shape:
+// at a rollup-close breakpoint). Three producers, one row shape:
 //   - an inbox blocker note, queued at note arrival (source "inbox")
 //   - a worker ask promoted past the 10-min threshold (source "ask")
-// The ENGINE's drain turns each row into a high-salience evidence row on the
-// A1 ledger — for inbox notes the exact row shape drainInbox writes — and
-// marks the source note read so the breakpoint drain never double-folds it.
-// Pure builders; these shapes are the producer↔consumer contract.
+//   - a health escalation ingested from the watchdog (source "health")
+// Every row carries the normalized core the pipeline consumes downstream:
+//   {source, sourceKind, sourceId, ts, message, title, refs, pendingSince}
+// where `sourceId` is the stable card identity (the exact key the card
+// writer groups by), and producer-specific fields ride alongside (note
+// identity + sender for inbox; sessionID for asks; nothing extra for
+// health). The ENGINE's drain turns each row into a high-salience evidence
+// row on the A1 ledger — for inbox notes the exact row shape drainInbox
+// writes — and marks the source note read so the breakpoint drain never
+// double-folds it. Pure builders; these shapes are the producer↔consumer
+// contract.
 
-export function findingFromInboxNote(entry, { ts = Date.now() } = {}) {
+// The drain's ledger-kind mapping, in ONE pure place so the producers and
+// the engine's drain cannot drift: an ask folds as `ask.<sourceKind>`, a
+// health escalation as `health.blocker`, an inbox note as
+// `inbox.<noteKind>` (the shape drainInbox already wrote).
+export function findingLedgerKind(row) {
+  if (row?.source === "ask") return `ask.${row?.sourceKind ?? "blocker"}`;
+  if (row?.source === "health") return `health.blocker`;
+  return `inbox.${row?.noteKind ?? "blocker"}`;
+}
+
+export function findingFromInboxNote(entry, { ts = Date.now(), sourceId, project } = {}) {
   if (!entry || typeof entry !== "object") return null;
   return {
     source: "inbox",
+    sourceKind: INBOX_SOURCE_KIND,
+    sourceId: typeof sourceId === "string" && sourceId ? sourceId : undefined,
     ts,
     // The inbox entry id — the drain's dedupe marker against drainInbox (it
     // marks this note read after the ledger row fires).
@@ -174,6 +193,9 @@ export function findingFromInboxNote(entry, { ts = Date.now() } = {}) {
     tag: entry.tag ?? undefined,
     refs: Array.isArray(entry.refs) ? entry.refs : [],
     sender: entry.sender && typeof entry.sender === "object" ? entry.sender : undefined,
+    project: typeof project === "string" && project ? project : undefined,
+    // The note just arrived, so it has been outstanding since exactly now.
+    pendingSince: ts,
     // A note may NAME a checkable condition (§10.3 predicate 2 — "when the
     // plan or note names one"). Carried to the ask/card for the liveness pass.
     condition: typeof entry.condition === "string" && entry.condition ? entry.condition : undefined,
@@ -184,13 +206,36 @@ export function findingFromPromotedAsk(ask, { ts = Date.now() } = {}) {
   if (!ask || typeof ask !== "object") return null;
   return {
     source: "ask",
-    ts,
     sourceKind: ask.sourceKind,
     sourceId: ask.sourceId,
+    ts,
     sessionID: ask.sessionID ?? ask.noteSessionID ?? undefined,
     message: ask.body,
     title: blockerTitle(ask.sourceKind, ask.title),
     refs: Array.isArray(ask.refs) ? ask.refs : [],
+    pendingSince: Number.isFinite(ask.askedAt) ? ask.askedAt : undefined,
+  };
+}
+
+// Source (2b): a health escalation (the watchdog's `pendingBlockers` entry,
+// ingested + grouped by ingestHealthEscalations). One finding per escalation
+// event — each pendingBlockers entry is stamped consumed after ingest, so a
+// re-trip is a new event and produces a new row; the card upserts in place.
+// `group` is the ingestHealthEscalations Map value; `key` the healthGroupKey
+// (also the card's sourceId) and `sourceId` its stable card id form.
+export function findingFromHealthGroup(group, { key, sourceId, ts = Date.now() } = {}) {
+  if (!group || typeof group !== "object") return null;
+  return {
+    source: "health",
+    sourceKind: HEALTH_SOURCE_KIND,
+    sourceId: typeof key === "string" ? key : undefined,
+    stableCardId: typeof sourceId === "string" ? sourceId : undefined,
+    ts,
+    message: blockerBody(HEALTH_SOURCE_KIND, group.latest?.reason),
+    title: blockerTitle(HEALTH_SOURCE_KIND),
+    refs: [],
+    pendingSince: Number.isFinite(group.minTs) ? group.minTs : undefined,
+    tag: typeof key === "string" ? key : undefined,
   };
 }
 
@@ -598,7 +643,7 @@ export function createCtoCards(deps = {}) {
     await enqueueFinding(
       findingFromInboxNote(
         { id, kind: "blocker", message: text, title, tag, refs, sender: { ...sender, sessionID: noteSessionID }, condition: noteCondition },
-        { ts },
+        { ts, sourceId, project },
       ),
     );
     return { changed: true, notified: true, groupKey };
@@ -1171,6 +1216,12 @@ export function createCtoCards(deps = {}) {
         });
         changed = changed || r.changed;
         consumedIds.push(...group.ids);
+        // BET-1516 (§9.1): the third blocker source enters the pipeline too —
+        // one normalized finding per escalation event. Each pendingBlockers
+        // entry is stamped consumed below (never reprocessed), so a re-trip of
+        // the same condition is a NEW event and enqueues a NEW row while the
+        // card above still upserts in place. Best-effort by contract.
+        await enqueueFinding(findingFromHealthGroup(group, { key, ts }));
       }
     }
     // BET-1463 (defect 1): every entry ingested above gets stamped `resolved:

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -857,6 +857,12 @@ test("BET-1516: an inbox blocker note queues a finding (source inbox) carrying t
   assert.equal(h.findings.length, 1);
   const row = h.findings[0];
   assert.equal(row.source, "inbox");
+  // The normalized core every producer row carries: the stable card identity
+  // the pipeline keys downstream decisions on + the outstanding-since stamp.
+  assert.equal(row.sourceKind, "inbox");
+  assert.equal(row.sourceId, stableCardId("inbox", inboxGroupKey({ tag: "ci", title: "CI broken", message: "build is red", project: undefined })));
+  assert.equal(row.pendingSince, h.clock.ms);
+  assert.equal(row.project, undefined, "no session-info seam wired in this harness");
   assert.equal(row.noteId, "note-1");
   assert.equal(row.noteKind, "blocker");
   assert.equal(row.message, "build is red");
@@ -890,6 +896,53 @@ test("BET-1516: a promoted worker ask queues a finding (source ask) at promotion
   assert.equal(row.sessionID, "s1");
   assert.equal(row.message, "Pick one?");
   assert.equal(row.title, "Question waiting");
+  assert.equal(row.pendingSince, 1_000_000, "outstanding since the ask was asked");
+});
+
+test("BET-1516: an inbox blocker note queues the third finding (source health) identity fields — project resolves through the session-info seam", async () => {
+  const h = makeHarness({ fireNotify: true, getSessionInfo: async () => ({ project: "better-ui" }) });
+  await h.cards.onInboxBlocker({
+    message: "build is red",
+    title: "CI broken",
+    tag: "ci",
+    id: "note-1",
+    sender: { sessionID: "ses-9", name: "worker" },
+    ts: h.clock.ms,
+  });
+  assert.equal(h.findings.length, 1);
+  assert.equal(h.findings[0].project, "better-ui", "the sender session's project travels with the row");
+});
+
+test("BET-1516: a health escalation queues the third finding (source health) — one per escalation event, consumed entries never re-queue", async () => {
+  const h = makeHarness({
+    pendingBlockers: [
+      { id: "b1", source: "watchdog", reason: "ambient spend 5 > 4x expected", ts: 400, resolved: false },
+      { id: "b2", source: "watchdog", reason: "ambient spend 7 > 4x expected", ts: 900, resolved: false },
+      { id: "b3", source: "rate_limit", reason: "sessionCreationsPerHour", ts: 800, resolved: false },
+    ],
+  });
+
+  await h.cards.ingestHealthEscalations();
+  // Two condition groups (watchdog, rate_limit) → exactly two findings, the
+  // same one-row-per-escalation contract the other two producers follow.
+  assert.equal(h.findings.length, 2);
+  const watchdog = h.findings.find((f) => f.sourceId === "watchdog");
+  const rateLimit = h.findings.find((f) => f.sourceId === "rate_limit");
+  assert.ok(watchdog && rateLimit, "one row per healthGroupKey (the card identity)");
+  // The normalized core — the same shape the inbox/ask producers emit.
+  assert.equal(watchdog.source, "health");
+  assert.equal(watchdog.sourceKind, HEALTH_SOURCE_KIND);
+  assert.equal(watchdog.message, "ambient spend 7 > 4x expected", "the most recent reason travels");
+  assert.equal(watchdog.title, "Health check");
+  assert.equal(watchdog.pendingSince, 400, "earliest outstanding trip in the group");
+  assert.deepEqual(watchdog.refs, []);
+  assert.equal(watchdog.ts, h.clock.ms);
+  // The card path is untouched: one open health card per group.
+  assert.equal(h.store().cards.filter((c) => c.state === "open").length, 2);
+  // Each entry is consumed on ingest (never reprocessed) — a later tick
+  // cannot re-enqueue a finding from the same escalation.
+  await h.cards.ingestHealthEscalations();
+  assert.equal(h.findings.length, 2);
 });
 
 test("BET-1516: a promoted inbox ask refreshes the card's note fields (TTL stamp travels to the card)", async () => {

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -12,10 +12,12 @@ import {
   askResolveInfo,
   askStartInfo,
   createCtoCards,
+  inboxCardLivenessGone,
   inboxGroupKey,
   isAskResolveEvent,
   isAskStartEvent,
   senderSlug,
+  splitOrphanedShedCards,
   stableCardId,
 } from "./ctoCards.mjs";
 import { INBOX_TTL_MS } from "./ctoStores.mjs";
@@ -26,11 +28,14 @@ import { INBOX_TTL_MS } from "./ctoStores.mjs";
 // (a static patch object, or a `(fresh) => patch` function; a key set to
 // `undefined` deletes it) but without its mutex — fine for these
 // single-threaded, sequential-await tests.
-function makeHarness({ pendingBlockers = [], fireNotify = false, getSessionInfo = null } = {}) {
+function makeHarness({ pendingBlockers = [], fireNotify = false, getSessionInfo = null, hasSession = null, conditionGone = null } = {}) {
   const clock = { ms: 1_000_000 };
   let cardPayload = { v: 1, cards: [] };
   const ledgerRows = [];
   const notified = [];
+  // BET-1516: the pending-findings queue capture (the engine's queueFinding
+  // seam in production is a bound append to findings.json).
+  const findings = [];
   let engineState = { v: 1, pendingBlockers: [...pendingBlockers] };
   const patchCalls = [];
 
@@ -50,6 +55,11 @@ function makeHarness({ pendingBlockers = [], fireNotify = false, getSessionInfo 
     ledger: { append: async (row) => ledgerRows.push(row) },
     ...(fireNotify ? { fireNotify: async (a) => notified.push(a) } : {}),
     ...(getSessionInfo ? { getSessionInfo } : {}),
+    ...(hasSession ? { hasSession } : {}),
+    ...(conditionGone ? { conditionGone } : {}),
+    // The engine wires queueFinding on the live box; here every harness
+    // captures (the queue path is core behavior now, not optional).
+    queueFinding: async (row) => findings.push(row),
     now: () => clock.ms,
     patchEngineState: async (mutation) => {
       patchCalls.push(mutation);
@@ -70,6 +80,7 @@ function makeHarness({ pendingBlockers = [], fireNotify = false, getSessionInfo 
     clock,
     ledgerRows,
     notified,
+    findings,
     patchCalls,
     store: () => cardPayload,
     engineStateSnapshot: () => engineState,
@@ -825,4 +836,239 @@ test("BET-1407: seedPendingAsks with no persisted registry is a pure no-op (no e
   const seeded = await h.cards.seedPendingAsks();
   assert.deepEqual(seeded, { seeded: 0, dropped: 0 });
   assert.equal(h.patchCalls.length, patchesBefore);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1516 — blockers into the pipeline (§9.1) + inbox-card liveness (§10.3).
+// ---------------------------------------------------------------------------
+
+test("BET-1516: an inbox blocker note queues a finding (source inbox) carrying the note identity + sender", async () => {
+  const h = makeHarness({ fireNotify: true });
+  await h.cards.onInboxBlocker({
+    message: "build is red",
+    title: "CI broken",
+    refs: ["BET-777"],
+    tag: "ci",
+    id: "note-1",
+    expires: 9_999_999,
+    sender: { sessionID: "ses-9", name: "worker" },
+    ts: h.clock.ms,
+  });
+  assert.equal(h.findings.length, 1);
+  const row = h.findings[0];
+  assert.equal(row.source, "inbox");
+  assert.equal(row.noteId, "note-1");
+  assert.equal(row.noteKind, "blocker");
+  assert.equal(row.message, "build is red");
+  assert.equal(row.title, "CI broken");
+  assert.equal(row.tag, "ci");
+  assert.deepEqual(row.refs, ["BET-777"]);
+  assert.deepEqual(row.sender, { sessionID: "ses-9", name: "worker" });
+  assert.equal(row.ts, h.clock.ms);
+  // The notify still fired exactly once (the immediate timer is untouched),
+  // and now routes by the sender's session id (the funnel sends it nested).
+  assert.equal(h.notified.length, 1);
+  assert.equal(h.notified[0].sessionID, "ses-9");
+  // The ask row carries the §10.3 predicate inputs.
+  const ask = h.engineStateSnapshot().pendingAsks[0];
+  assert.equal(ask.noteSessionID, "ses-9");
+  assert.equal(ask.noteId, "note-1");
+  assert.equal(ask.noteExpires, 9_999_999);
+});
+
+test("BET-1516: a promoted worker ask queues a finding (source ask) at promotion", async () => {
+  const h = makeHarness();
+  await h.cards.onAskStart({ sourceKind: "question", sourceId: "que_1", sessionID: "s1", body: "Pick one?", ts: h.clock.ms });
+  assert.equal(h.findings.length, 0, "the ask enters the pipeline only past the threshold");
+  h.advance(BLOCKER_AFTER_MS + 60_000);
+  await h.cards.promoteDue();
+  assert.equal(h.findings.length, 1);
+  const row = h.findings[0];
+  assert.equal(row.source, "ask");
+  assert.equal(row.sourceKind, "question");
+  assert.equal(row.sourceId, "que_1");
+  assert.equal(row.sessionID, "s1");
+  assert.equal(row.message, "Pick one?");
+  assert.equal(row.title, "Question waiting");
+});
+
+test("BET-1516: a promoted inbox ask refreshes the card's note fields (TTL stamp travels to the card)", async () => {
+  const h = makeHarness();
+  await h.cards.onInboxBlocker({
+    message: "deploy failed",
+    tag: "deploy",
+    id: "note-1",
+    expires: h.clock.ms + 1_000,
+    sender: { sessionID: "s7", name: "w" },
+    ts: h.clock.ms,
+  });
+  h.advance(BLOCKER_AFTER_MS + 60_000);
+  await h.cards.promoteDue();
+  const card = h.store().cards.find((c) => c.state === "open");
+  assert.equal(card.sourceKind, "inbox");
+  assert.equal(card.noteId, "note-1");
+  assert.equal(card.noteSessionID, "s7");
+  assert.equal(card.noteExpires, 1_000_000 + 1_000);
+});
+
+test("BET-1516 liveness: an inbox card whose note TTL passed auto-resolves as `resolved` (never a verdict)", async () => {
+  const h = makeHarness();
+  await h.cards.onInboxBlocker({ message: "deploy failed", tag: "deploy", id: "note-1", expires: h.clock.ms + 5_000, ts: h.clock.ms });
+  h.advance(BLOCKER_AFTER_MS + 60_000);
+  await h.cards.promoteDue();
+  assert.equal(openCardCount(h), 1);
+  h.advance(6_000);
+  const r = await h.cards.checkInboxLiveness();
+  assert.equal(r.changed, true);
+  assert.equal(openCardCount(h), 0);
+  const resolved = h.ledgerRows.filter((x) => x.kind === CARD_RESOLVED);
+  assert.equal(resolved.length, 1);
+  assert.equal(resolved[0].reason, "inbox note expired");
+});
+
+test("BET-1516 liveness: a pre-1516 card without a TTL stamp bounds by pendingSince + the blocker retention window", async () => {
+  const h = makeHarness();
+  const t0 = h.clock.ms;
+  h.setCardPayload({
+    v: 1,
+    cards: [
+      {
+        id: "legacy",
+        variant: "blocker",
+        state: "open",
+        title: "old",
+        body: "old",
+        refs: [],
+        sourceKind: "inbox",
+        sourceId: "old",
+        pendingSince: t0 - INBOX_TTL_MS.blocker - 1,
+      },
+    ],
+  });
+  const r = await h.cards.checkInboxLiveness();
+  assert.equal(r.changed, true);
+  assert.equal(openCardCount(h), 0);
+  assert.equal(h.ledgerRows.find((x) => x.kind === CARD_RESOLVED)?.reason, "inbox note expired");
+});
+
+test("BET-1516 liveness: sender session gone auto-resolves; a live session or a transient check keeps the card", async () => {
+  const h = makeHarness({ hasSession: async (sid) => (sid === "dead" ? false : true) });
+  h.setCardPayload({
+    v: 1,
+    cards: [
+      { id: "a", variant: "blocker", state: "open", sourceKind: "inbox", refs: [], noteSessionID: "dead" },
+      { id: "b", variant: "blocker", state: "open", sourceKind: "inbox", refs: [], noteSessionID: "alive" },
+      { id: "c", variant: "blocker", state: "open", sourceKind: "inbox", refs: [], noteSessionID: "flaky" },
+    ],
+  });
+  // A flaky checker throwing is "no opinion" — the card survives.
+  const r = await h.cards.checkInboxLiveness({
+    hasSession: async (sid) => {
+      if (sid === "flaky") throw new Error("transient");
+      return sid !== "dead";
+    },
+  });
+  assert.equal(r.changed, true);
+  const remaining = h.store().cards.filter((c) => c.state === "open").map((c) => c.id);
+  assert.deepEqual(remaining.sort(), ["b", "c"]);
+  assert.equal(h.ledgerRows.find((x) => x.kind === CARD_RESOLVED)?.reason, "sender session gone");
+});
+
+test("BET-1516 liveness: a named condition that went gone auto-resolves; no-surface is a no-opinion keep", async () => {
+  const h = makeHarness({ conditionGone: async (condition) => (condition === "CI on F broken" ? true : condition === "surface down" ? null : false) });
+  h.setCardPayload({
+    v: 1,
+    cards: [
+      { id: "g", variant: "blocker", state: "open", sourceKind: "inbox", refs: [], noteCondition: "CI on F broken" },
+      { id: "k", variant: "blocker", state: "open", sourceKind: "inbox", refs: [], noteCondition: "CI on F still broken" },
+      { id: "n", variant: "blocker", state: "open", sourceKind: "inbox", refs: [], noteCondition: "surface down" },
+      { id: "u", variant: "blocker", state: "open", sourceKind: "inbox", refs: [] },
+    ],
+  });
+  const r = await h.cards.checkInboxLiveness();
+  assert.equal(r.changed, true);
+  const remaining = h.store().cards.filter((c) => c.state === "open").map((c) => c.id);
+  assert.deepEqual(remaining.sort(), ["k", "n", "u"]);
+  assert.equal(h.ledgerRows.find((x) => x.kind === CARD_RESOLVED)?.reason, "condition gone");
+});
+
+test("BET-1516 liveness: worker-ask and health cards are out of scope for the inbox predicates", async () => {
+  const h = makeHarness({ hasSession: async () => false });
+  h.setCardPayload({
+    v: 1,
+    cards: [
+      { id: "w", variant: "blocker", state: "open", sourceKind: "question", sessionID: "s1", refs: [], noteSessionID: "s1" },
+      { id: "h", variant: "blocker", state: "open", sourceKind: "health", refs: [], noteExpires: h.clock.ms - 10_000 },
+    ],
+  });
+  const r = await h.cards.checkInboxLiveness();
+  assert.equal(r.changed, false);
+  assert.equal(openCardCount(h), 2);
+});
+
+test("BET-1516 liveness: inboxCardLivenessGone is pure and deterministic (TTL wins first, session/condition next)", async () => {
+  const nowMs = 10_000;
+  assert.equal(await inboxCardLivenessGone({ state: "open", variant: "blocker", noteExpires: nowMs }, { nowMs }), null);
+  assert.deepEqual(
+    await inboxCardLivenessGone({ state: "open", variant: "blocker", noteExpires: nowMs - 1 }, { nowMs }),
+    { reason: "inbox note expired" },
+  );
+  // A non-open / non-blocker row is never evaluated.
+  assert.equal(await inboxCardLivenessGone({ state: "resolved", variant: "blocker" }, { nowMs }), null);
+  assert.equal(await inboxCardLivenessGone({ state: "open", variant: "decision" }, { nowMs }), null);
+  // No TTL stamp + no pendingSince + no seams → no opinion (the card stays).
+  assert.equal(await inboxCardLivenessGone({ state: "open", variant: "blocker" }, { nowMs }), null);
+  // Order: with everything gone at once, the sync TTL reason wins.
+  assert.deepEqual(
+    await inboxCardLivenessGone(
+      { state: "open", variant: "blocker", noteExpires: nowMs - 1, noteCondition: "x", noteSessionID: "s" },
+      { nowMs, hasSession: async () => false, conditionGone: async () => true },
+    ),
+    { reason: "inbox note expired" },
+  );
+});
+
+test("BET-1516: splitOrphanedShedCards drops only open health rate_limit cards carrying a shed reason", () => {
+  const orphan = { id: "x", variant: "blocker", state: "open", sourceKind: "health", sourceId: "rate_limit", body: "concurrentEphemeral" };
+  const live = { id: "y", variant: "blocker", state: "open", sourceKind: "health", sourceId: "rate_limit", body: "sessionCreationsPerHour" };
+  const closed = { id: "z", variant: "blocker", state: "resolved", sourceKind: "health", sourceId: "rate_limit", body: "concurrentEphemeral" };
+  const other = { id: "w", variant: "blocker", state: "open", sourceKind: "inbox", sourceId: "rate_limit", body: "concurrentEphemeral" };
+  const { keep, dropped } = splitOrphanedShedCards([orphan, live, closed, other]);
+  assert.deepEqual(dropped, [orphan]);
+  assert.deepEqual(keep, [live, closed, other]);
+  // The delegate shed reason is equally orphaned.
+  const delegate = { id: "d", variant: "blocker", state: "open", sourceKind: "health", sourceId: "rate_limit", body: "concurrentDelegate" };
+  assert.deepEqual(splitOrphanedShedCards([delegate]).dropped, [delegate]);
+});
+
+test("BET-1516: pruneOrphanedShedCards removes the orphaned card + shed entries, ledger-resolves, and stamps the marker", async () => {
+  const h = makeHarness({
+    pendingBlockers: [
+      { id: "b1", kind: "blocker", source: "rate_limit", reason: "concurrentEphemeral", ts: 1 },
+      { id: "b2", kind: "blocker", source: "rate_limit", reason: "sessionCreationsPerHour", ts: 2 },
+      { id: "b3", kind: "blocker", source: "rate_limit", reason: "concurrentEphemeral", ts: 3, resolved: true },
+    ],
+  });
+  h.setCardPayload({
+    v: 1,
+    cards: [
+      { id: "orphan", variant: "blocker", state: "open", sourceKind: "health", sourceId: "rate_limit", body: "concurrentEphemeral", refs: [] },
+    ],
+  });
+  const r = await h.cards.pruneOrphanedShedCards();
+  assert.equal(r.pruned, 1);
+  assert.equal(r.droppedEntries, 1);
+  assert.equal(r.marked, true);
+  assert.equal(openCardCount(h), 0);
+  // The legit entry (and the already-resolved one) survive untouched.
+  assert.deepEqual(
+    h.engineStateSnapshot().pendingBlockers.map((b) => b.id),
+    ["b2", "b3"],
+  );
+  const resolved = h.ledgerRows.filter((x) => x.kind === CARD_RESOLVED);
+  assert.equal(resolved.length, 1);
+  assert.match(resolved[0].reason, /BET-1513/);
+  // A second run is a pure no-op (marker-guarded).
+  const r2 = await h.cards.pruneOrphanedShedCards();
+  assert.deepEqual(r2, { pruned: 0, droppedEntries: 0, marked: false });
 });

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -52,6 +52,7 @@ import {
   segmentsStore,
   rollupsStore,
   inboxStore,
+  findingsStore,
   verdictsStore,
   watchersStore,
   factsArchiveStore,
@@ -96,6 +97,7 @@ import {
   askQuestionText,
   createCtoCards,
   isAskResolveEvent,
+  isConditionGoneResult,
 } from "./ctoCards.mjs";
 import { createProbes } from "./ctoProbes.mjs";
 import { createSegmenter, segmentEventKind } from "./ctoSegments.mjs";
@@ -105,7 +107,7 @@ import {
   ROLLUP_LEVELS,
   windowFor as rollupWindowFor,
 } from "./ctoRollups.mjs";
-import { buildFactProposal, createFactsEngine, VERIFY_CYCLE_MS, senderKey, senderReliability } from "./ctoFacts.mjs";
+import { buildFactProposal, createFactsEngine, matchCheckable, VERIFY_CYCLE_MS, senderKey, senderReliability } from "./ctoFacts.mjs";
 import { formatFactsBlock, estimateTokens } from "./ctoSessions.mjs";
 import {
   ambientCapUsd as budgetAmbientCapUsd,
@@ -333,6 +335,8 @@ export function createCtoEngine(deps = {}) {
     trust: trustStore,
     cards: cardsStore,
     inbox: inboxStore,
+    // BET-1516 (§9.1): the pending-findings queue (blockers → pipeline).
+    findings: findingsStore,
     verdicts: verdictsStore,
     budget: budgetStore,
     watchers: watchersStore,
@@ -378,6 +382,11 @@ export function createCtoEngine(deps = {}) {
     // engine-state writers share one process-wide mutex. Inject a bound
     // instance rather than letting ctoCards.mjs import patchEngineState
     // itself — same seam pattern as getSessionInfo/getDesktopPresence.
+    // BET-1516 (§10.3): the box's session-existence check (oc.sessionExists —
+    // definitive 404 → false, transient → true) for the inbox cards'
+    // sender-session liveness predicate. Default null → the predicate is
+    // skipped (no checker wired = no opinion, never a false resolution).
+    hasSession = null,
     cards = createCtoCards({
       fireNotify: cardFireNotify,
       cardStore: bundle.cards,
@@ -388,6 +397,15 @@ export function createCtoEngine(deps = {}) {
       // BELOW `cards` in this same binding, so naming it directly here is a
       // TDZ error. The arrow body runs long after destructuring settles.
       getSessionInfo: (sid) => getSessionInfo(sid),
+      // BET-1516 (§9.1): the pending-findings queue writer — blocker notes
+      // (at arrival) and worker asks (past the 10-min threshold) wait here to
+      // enter the pipeline on the next engine tick (drainFindings, card tick).
+      queueFinding: (finding) => queueFindingRow(finding),
+      // §10.3 liveness seams, same TDZ-safe thunk pattern as getSessionInfo:
+      // hasSession is destructured above, conditionGone classifies via the
+      // §6.7 matcher + factVerify (both destructured later in this binding).
+      hasSession: (sid) => hasSession(sid),
+      conditionGone: async (condition) => conditionGoneFromCondition(condition, factVerify),
       // The engine's clock is authoritative for the cards module too — one
       // now for promoteDue thresholds AND the BET-1407 seed's retention
       // bound (a test's fake clock must not make every persisted ask look
@@ -435,6 +453,10 @@ export function createCtoEngine(deps = {}) {
     // BET-1397 CTO inbox (§4.4): the durable inbox.json store + seam, so drain
     // is unit-testable without touching the real fs. Defaults to the real store.
     inbox = null,
+    // BET-1516 (§9.1): the pending-findings queue (findings.json) — blockers
+    // enter the pipeline on the next engine tick. Defaults to the real store;
+    // tests inject a bundle memory store.
+    findings = null,
     // BET-1391 verdict ledger (§9.5): optional pre-built verdicts store (else
     // the shared `verdicts.json` store). The verdict engine + facts sink are
     // constructed below from it.
@@ -525,6 +547,42 @@ export function createCtoEngine(deps = {}) {
       await ledger.append({ actor: ACTOR, ts: now(), ...entry });
     } catch {
       /* best-effort */
+    }
+  }
+
+  // BET-1516 (§9.1): append one finding to the pending-findings queue — the
+  // durable handoff between the HTTP funnel (inbox blocker notes) / the card
+  // timer (worker asks past the §10.3 threshold) and the engine's card tick
+  // drain. Best-effort: a queue failure never takes the funnel down (the
+  // note itself already persisted to the inbox, which remains the fallback
+  // breakpoint path).
+  async function queueFindingRow(finding) {
+    const store = findings ?? bundle.findings;
+    if (!store) return;
+    try {
+      await patchStore(store, (fresh) => ({
+        findings: [...(Array.isArray(fresh?.findings) ? fresh.findings : []), finding],
+      }));
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // BET-1516 (§10.3 predicate 2): is the condition a note named now GONE?
+  // Reuses the §6.7 machinery exactly: matchCheckable picks the surface +
+  // probe (null → no opinion), factVerify (the same seam the facts engine
+  // uses — index.mjs wires it to the real surface verifier) checks the named
+  // state now. isConditionGoneResult classifies: a definitive negative is
+  // "gone"; "no surface"/"unavailable" is a no-opinion null, never a false
+  // resolution.
+  async function conditionGoneFromCondition(condition, verify) {
+    const match = matchCheckable(condition);
+    if (!match) return null;
+    try {
+      const r = await verify({ surface: match.surface, probe: match.probe, branch: match.branch ?? undefined });
+      return isConditionGoneResult(match, r);
+    } catch {
+      return null;
     }
   }
 
@@ -774,11 +832,17 @@ export function createCtoEngine(deps = {}) {
   // "needs you" surface (spec §10.3, §9.2), not autonomous CTO work, so it
   // keeps serving even when the engine's timers are stopped (§10.6-5's
   // "event ingestion keeps running" spirit). Stopped only on dispose.
+  // BET-1516: it is also the engine tick that (a) drains the pending-findings
+  // queue into the pipeline — blockers enter evidence ≤ 1 min after arrival,
+  // even on a paused engine, and (b) runs the §10.3 inbox-card liveness pass
+  // (sender session gone / condition gone / inbox TTL → auto-resolve).
   async function cardTick() {
     if (disposed) return;
     try {
       await cards.promoteDue();
       await cards.ingestHealthEscalations();
+      await drainFindings();
+      await cards.checkInboxLiveness();
       await syncState();
     } catch {
       /* never throw into the poller */
@@ -2217,6 +2281,86 @@ export function createCtoEngine(deps = {}) {
     }
   }
 
+  // BET-1516 (§9.1): the pending-findings drain — the "blockers enter the
+  // pipeline on the next engine tick (≤ 1 min)" half. The card tick calls
+  // this every pass (it runs even while paused, so a blocker reported to a
+  // paused engine still enters the pipeline within a minute); the
+  // notification itself stays the funnel's immediate path (separate timer).
+  //
+  // Each queued finding becomes a high-salience evidence row on the A1
+  // ledger — for inbox notes byte-shape-identical to what the breakpoint
+  // drain (drainInbox) writes — and the source inbox note is marked read so
+  // the breakpoint drain never double-folds it. Ordering: the ledger rows +
+  // queue clear commit in ONE patch first (the queue row is the recovery
+  // marker — a crash before the clear re-drains next tick), then the inbox
+  // mark-read lands. Never orphaned, at worst a duplicated evidence row.
+  async function drainFindings() {
+    const store = findings ?? bundle.findings;
+    if (!store) return { drained: 0 };
+    try {
+      let drained = 0;
+      const noteIds = [];
+      // 1) Ledger rows + clear the queue in ONE patch (crash-safe: rows fire
+      // before the clear commits, so a crash can only duplicate — converge on
+      // the next tick).
+      await patchStore(store, async (fresh) => {
+        const rows = Array.isArray(fresh?.findings) ? fresh.findings : [];
+        if (rows.length === 0) return {};
+        drained = rows.length;
+        // Per-sender reliability (Beta mean, §6.4 / B1); unseen senders
+        // default to neutral (1) — the same weighting drainInbox applies.
+        let rel = {};
+        try {
+          rel = (await getFactsEngine().getState())?.senderReliability ?? {};
+        } catch {
+          rel = {};
+        }
+        for (const row of rows) {
+          const senderSessionID = row?.sender?.sessionID ?? row?.sessionID ?? undefined;
+          const weight = senderReliability(
+            rel[senderKey(row?.sender ?? { sessionID: senderSessionID })] ?? {},
+          );
+          const refs = Array.isArray(row?.refs) ? row.refs.slice() : [];
+          if (senderSessionID) refs.push(senderSessionID);
+          void ledgerLog({
+            channel: CHANNEL_EVENT,
+            sessionID: senderSessionID ?? undefined,
+            kind: row?.source === "ask" ? `ask.${row?.sourceKind ?? "blocker"}` : `inbox.${row?.noteKind ?? "blocker"}`,
+            salience: "high",
+            senderReliability: weight,
+            refs,
+            message: row?.message,
+            tag: row?.tag,
+          });
+          if (row?.source === "inbox" && typeof row?.noteId === "string") noteIds.push(row.noteId);
+        }
+        return { findings: [] };
+      });
+      // 2) Mark the source notes read (dedupe guard against drainInbox).
+      // AFTER the ledger patch above, so this never orphans a finding: a
+      // crash before the clear commits just re-drains the queue next tick.
+      if (noteIds.length) {
+        await patchStore(inbox ?? bundle.inbox, (fresh) => {
+          const entries = Array.isArray(fresh?.entries) ? fresh.entries : [];
+          const idSet = new Set(noteIds);
+          let touched = false;
+          const next = entries.map((e) => {
+            if (e && !e.read && idSet.has(e.id)) {
+              touched = true;
+              return { ...e, read: true };
+            }
+            return e;
+          });
+          return touched ? { entries: next } : {};
+        });
+      }
+      return { drained };
+    } catch {
+      /* findings drain is best-effort — never takes the engine down */
+      return { drained: 0 };
+    }
+  }
+
   // Event ingestion — the ONE thing that keeps running while paused (§10.6-5).
   // Driven from index.mjs's event pump (not a timer); the engine is just
   // another consumer (§4.1). Consumes the opencode stream into normalized
@@ -2380,6 +2524,17 @@ export function createCtoEngine(deps = {}) {
     if (typeof cards?.pruneLegacyOpenCards === "function") {
       try {
         await cards.pruneLegacyOpenCards();
+      } catch {
+        /* best-effort */
+      }
+    }
+    // BET-1516: one-time prune of the orphaned `concurrentEphemeral` health
+    // card + its shed pendingBlockers entries (BET-1513 stopped the trips from
+    // carding; the residue re-upserted itself every tick). Same marker-guarded
+    // best-effort contract as the prune above.
+    if (typeof cards?.pruneOrphanedShedCards === "function") {
+      try {
+        await cards.pruneOrphanedShedCards();
       } catch {
         /* best-effort */
       }
@@ -2604,6 +2759,11 @@ export function createCtoEngine(deps = {}) {
     tierAllowsFeature: async (feature) => budgetTierAllows(await tierGet(), feature),
     observeEvent,
     drainInbox,
+    // BET-1516 (§9.1): the pending-findings drain — exposed for tests and for
+    // index.mjs's debug surface, same seam as drainInbox. `cardTick` rides
+    // along (the pass that drains findings + runs the §10.3 liveness pass).
+    drainFindings,
+    cardTick,
     getPresence,
     getState,
     readLedger,

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -96,6 +96,7 @@ import {
   askResolveInfo,
   askQuestionText,
   createCtoCards,
+  findingLedgerKind,
   isAskResolveEvent,
   isConditionGoneResult,
 } from "./ctoCards.mjs";
@@ -2325,7 +2326,9 @@ export function createCtoEngine(deps = {}) {
           void ledgerLog({
             channel: CHANNEL_EVENT,
             sessionID: senderSessionID ?? undefined,
-            kind: row?.source === "ask" ? `ask.${row?.sourceKind ?? "blocker"}` : `inbox.${row?.noteKind ?? "blocker"}`,
+            // BET-1516: ONE pure mapping for all three producers (inbox / ask /
+            // health) — `ask.<sourceKind>` / `health.blocker` / `inbox.<noteKind>`.
+            kind: findingLedgerKind(row),
             salience: "high",
             senderReliability: weight,
             refs,

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -1313,6 +1313,25 @@ test("BET-1472: a watcher.hit row WITH a project still becomes a candidate carry
 // BET-1516 — the pending-findings drain (blockers enter the pipeline, §9.1)
 // ---------------------------------------------------------------------------
 
+// The shared engine scaffold for the drain/cardTick tests in this section:
+// memory stores, captured ledger, fake clock, neutral sender reliability.
+// `clock` and `ledgerRows` are passed in by reference so the test keeps
+// asserting on its own handles; extra deps (e.g. `cards: {}` to fake the
+// cards manager in the pure drain tests) merge on top via `overrides`.
+function makeFindingsEngine({ clock, ledgerRows, ...overrides } = {}) {
+  const stores = makeMemoryStores();
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true }),
+    stores,
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    facts: { getState: async () => ({ senderReliability: {} }) },
+    now: () => clock.ms,
+    publish: () => {},
+    ...overrides,
+  });
+  return { engine, stores };
+}
+
 test("drainFindings turns queued inbox findings into high-salience B1-weighted evidence and marks the note read", async () => {
   const clock = { ms: 1_000_000 };
   const ledgerRows = [];
@@ -1367,21 +1386,12 @@ test("drainFindings turns queued inbox findings into high-salience B1-weighted e
 test("drainFindings maps a promoted ask finding to an ask.<sourceKind> evidence row and leaves the inbox alone", async () => {
   const clock = { ms: 2_000_000 };
   const ledgerRows = [];
-  const stores = makeMemoryStores();
+  const { engine, stores } = makeFindingsEngine({ clock, ledgerRows, cards: {} });
   await stores.findings.save({
     v: 1,
     findings: [
       { source: "ask", ts: clock.ms, sourceKind: "permission", sourceId: "perm_1", sessionID: "s2", message: "Allow rm -rf?", title: "Permission needed", refs: [] },
     ],
-  });
-  const engine = createCtoEngine({
-    configGet: async () => ({ ctoEnabled: true }),
-    stores,
-    ledger: { append: async (row) => ledgerRows.push(row) },
-    cards: {},
-    facts: { getState: async () => ({ senderReliability: {} }) },
-    now: () => clock.ms,
-    publish: () => {},
   });
   const r = await engine.drainFindings();
   assert.equal(r.drained, 1);
@@ -1399,21 +1409,12 @@ test("drainFindings maps a promoted ask finding to an ask.<sourceKind> evidence 
 test("drainFindings maps a health escalation finding to a health.blocker evidence row (third producer, §9.1)", async () => {
   const clock = { ms: 3_000_000 };
   const ledgerRows = [];
-  const stores = makeMemoryStores();
+  const { engine, stores } = makeFindingsEngine({ clock, ledgerRows, cards: {} });
   await stores.findings.save({
     v: 1,
     findings: [
       { source: "health", sourceKind: "health", sourceId: "watchdog", ts: clock.ms, message: "ambient spend 7 > 4x expected", title: "Health check", refs: [], pendingSince: clock.ms - 500, tag: "watchdog" },
     ],
-  });
-  const engine = createCtoEngine({
-    configGet: async () => ({ ctoEnabled: true }),
-    stores,
-    ledger: { append: async (row) => ledgerRows.push(row) },
-    cards: {},
-    facts: { getState: async () => ({ senderReliability: {} }) },
-    now: () => clock.ms,
-    publish: () => {},
   });
   const r = await engine.drainFindings();
   assert.equal(r.drained, 1);
@@ -1432,15 +1433,7 @@ test("drainFindings maps a health escalation finding to a health.blocker evidenc
 test("cardTick enqueues the third blocker source (health escalation) and folds it into evidence on the same tick", async () => {
   const clock = { ms: 1_000_000 };
   const ledgerRows = [];
-  const stores = makeMemoryStores();
-  const engine = createCtoEngine({
-    configGet: async () => ({ ctoEnabled: true }),
-    stores,
-    ledger: { append: async (row) => ledgerRows.push(row) },
-    facts: { getState: async () => ({ senderReliability: {} }) },
-    now: () => clock.ms,
-    publish: () => {},
-  });
+  const { engine, stores } = makeFindingsEngine({ clock, ledgerRows });
   // The watchdog wrote a pendingBlockers entry (the recordBlocker shape).
   await stores.engineState.save({
     v: 1,
@@ -1464,15 +1457,7 @@ test("cardTick enqueues the third blocker source (health escalation) and folds i
 test("cardTick drains the queue and runs the inbox-card liveness pass; a promoted ask enters the pipeline on the next tick", async () => {
   const clock = { ms: 1_000_000 };
   const ledgerRows = [];
-  const stores = makeMemoryStores();
-  const engine = createCtoEngine({
-    configGet: async () => ({ ctoEnabled: true }),
-    stores,
-    ledger: { append: async (row) => ledgerRows.push(row) },
-    facts: { getState: async () => ({ senderReliability: {} }) },
-    now: () => clock.ms,
-    publish: () => {},
-  });
+  const { engine, stores } = makeFindingsEngine({ clock, ledgerRows });
   // A worker ask registered through the REAL cards manager (not a fake) —
   // the engine's own cards wiring must queue the finding at promotion, and
   // the SAME tick's drain consumes it into the pipeline: one pass,

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -22,8 +22,8 @@ import { createSegmenter } from "./ctoSegments.mjs";
 import { startOfDay } from "./ctoRollups.mjs";
 import { createFactsEngine } from "./ctoFacts.mjs";
 import { windowFor } from "./ctoRollups.mjs";
-import { BLOCKER_AFTER_MS, CONTENTLESS_CARD_PRUNE_KEY, createCtoCards } from "./ctoCards.mjs";
-import { inboxStore, sweepInbox } from "./ctoStores.mjs";
+import { BLOCKER_AFTER_MS, CONTENTLESS_CARD_PRUNE_KEY, createCtoCards, splitOrphanedShedCards } from "./ctoCards.mjs";
+import { inboxStore, sweepInbox, INBOX_TTL_MS } from "./ctoStores.mjs";
 import { createCtoInbound } from "./cto.mjs";
 import { WATCHER_HIT_KIND, WATCHER_HIT_SALIENCE, EVENT_PATTERN, RATE_THRESHOLD, USAGE_BURN } from "./ctoWatchers.mjs";
 
@@ -1307,4 +1307,151 @@ test("BET-1472: a watcher.hit row WITH a project still becomes a candidate carry
   assert.equal(out[0].name, "Hostable hit");
   assert.equal(out[0].project, "better-ui");
   assert.deepEqual(out[0].refs, ["m:1"]);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1516 — the pending-findings drain (blockers enter the pipeline, §9.1)
+// ---------------------------------------------------------------------------
+
+test("drainFindings turns queued inbox findings into high-salience B1-weighted evidence and marks the note read", async () => {
+  const clock = { ms: 1_000_000 };
+  const ledgerRows = [];
+  const stores = makeMemoryStores();
+  // The inbox note the finding came from: still unread, so the breakpoint
+  // drain (drainInbox) would fold it too — the mark-read below is what keeps
+  // the pipeline from double-counting the same blocker.
+  await stores.inbox.save({
+    v: 1,
+    entries: [{ id: "note-1", kind: "blocker", message: "deploy failed", refs: ["BET-9"], sender: { sessionID: "s1" }, tag: "deploy", read: false, count: 1, expires: clock.ms + 1000 }],
+  });
+  await stores.findings.save({
+    v: 1,
+    findings: [
+      { source: "inbox", ts: clock.ms, noteId: "note-1", noteKind: "blocker", message: "deploy failed", title: "Deploy", tag: "deploy", refs: ["BET-9"], sender: { sessionID: "s1", name: "w" } },
+    ],
+  });
+  const rel = { "session:s1": { confirmed: 3, rejected: 0 } };
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true }),
+    stores,
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    cards: {},
+    facts: { getState: async () => ({ senderReliability: rel }) },
+    now: () => clock.ms,
+    publish: () => {},
+  });
+
+  const r = await engine.drainFindings();
+  assert.equal(r.drained, 1);
+
+  // The queue is empty after the drain.
+  assert.deepEqual((await stores.findings.load()).findings, []);
+  // The source note is marked read — drainInbox will not re-fold it.
+  assert.equal((await stores.inbox.load()).entries[0].read, true);
+
+  // One high-salience evidence row, byte-shape-identical to what drainInbox
+  // writes for the same note (incl. the B1 weight of the sending session).
+  const rows = ledgerRows.filter((row) => row.kind === "inbox.blocker");
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].salience, "high");
+  assert.ok(Math.abs(rows[0].senderReliability - 4 / 5) < 1e-9, "3/0 confirmed → Beta mean (1+3)/(1+3+0+1) = 4/5");
+  assert.deepEqual(rows[0].refs, ["BET-9", "s1"]);
+  assert.equal(rows[0].tag, "deploy");
+  assert.equal(rows[0].sessionID, "s1");
+
+  // The breakpoint drain no longer sees it (already read).
+  const after = await engine.drainInbox();
+  assert.equal(after.drained, 0);
+});
+
+test("drainFindings maps a promoted ask finding to an ask.<sourceKind> evidence row and leaves the inbox alone", async () => {
+  const clock = { ms: 2_000_000 };
+  const ledgerRows = [];
+  const stores = makeMemoryStores();
+  await stores.findings.save({
+    v: 1,
+    findings: [
+      { source: "ask", ts: clock.ms, sourceKind: "permission", sourceId: "perm_1", sessionID: "s2", message: "Allow rm -rf?", title: "Permission needed", refs: [] },
+    ],
+  });
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true }),
+    stores,
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    cards: {},
+    facts: { getState: async () => ({ senderReliability: {} }) },
+    now: () => clock.ms,
+    publish: () => {},
+  });
+  const r = await engine.drainFindings();
+  assert.equal(r.drained, 1);
+  const row = ledgerRows.find((x) => x.kind === "ask.permission");
+  assert.ok(row, "the ask's pipeline entry is an ask.* evidence row");
+  assert.equal(row.salience, "high");
+  assert.equal(row.sessionID, "s2");
+  assert.equal(row.message, "Allow rm -rf?");
+  assert.equal(row.tag, undefined);
+  // Neutral sender (no reliability history) and no note to mark read.
+  assert.ok(Math.abs(row.senderReliability - 1 / 2) < 1e-9);
+  assert.deepEqual((await stores.inbox.load()).entries, []);
+});
+
+test("cardTick drains the queue and runs the inbox-card liveness pass; a promoted ask enters the pipeline on the next tick", async () => {
+  const clock = { ms: 1_000_000 };
+  const ledgerRows = [];
+  const stores = makeMemoryStores();
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true }),
+    stores,
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    facts: { getState: async () => ({ senderReliability: {} }) },
+    now: () => clock.ms,
+    publish: () => {},
+  });
+  // A worker ask registered through the REAL cards manager (not a fake) —
+  // the engine's own cards wiring must queue the finding at promotion, and
+  // the SAME tick's drain consumes it into the pipeline: one pass,
+  // promotion → queue → ledger row, queue empty again.
+  engine.cards.onAskStart({ sourceKind: "question", sourceId: "que_1", sessionID: "s1", body: "Pick one?", ts: clock.ms });
+  clock.ms += 10 * 60_000 + 1;
+  await engine.cardTick();
+  assert.equal(ledgerRows.filter((x) => x.kind === "ask.question").length, 1);
+  assert.deepEqual((await stores.findings.load()).findings, []);
+  // The liveness pass ran too (an inbox card past its TTL auto-resolves on
+  // the same tick rather than lingering).
+  await stores.cards.save({
+    v: 1,
+    cards: [{ id: "gone", variant: "blocker", state: "open", sourceKind: "inbox", sourceId: "g", title: "t", body: "b", refs: [], pendingSince: clock.ms - INBOX_TTL_MS.blocker - 1, created: clock.ms, updatedAt: clock.ms }],
+  });
+  clock.ms += 1;
+  await engine.cardTick();
+  const left = (await stores.cards.load()).cards.filter((c) => c.state === "open");
+  assert.equal(left.length, 0);
+});
+
+test("BET-1516: start() prunes the orphaned concurrentEphemeral health card (marker-guarded)", async () => {
+  const stores = makeMemoryStores();
+  await stores.cards.save({
+    v: 1,
+    cards: [
+      { id: "orphan", variant: "blocker", state: "open", sourceKind: "health", sourceId: "rate_limit", body: "concurrentEphemeral", refs: [] },
+    ],
+  });
+  await stores.engineState.save({
+    v: 1,
+    pendingBlockers: [{ id: "b1", kind: "blocker", source: "rate_limit", reason: "concurrentEphemeral", ts: 1, resolved: false }],
+  });
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true }),
+    stores,
+    ledger: { append: async () => true },
+    now: () => 1_000_000,
+    publish: () => {},
+  });
+  await engine.start();
+  assert.equal((await stores.cards.load()).cards.length, 0);
+  assert.deepEqual((await stores.engineState.load()).pendingBlockers, []);
+  // Marker stamped — a rebuild is a no-op re-prune of a clean store.
+  assert.equal((await stores.engineState.load()).shedCardPrune?.pruned, true);
+  engine.dispose();
 });

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -1396,6 +1396,71 @@ test("drainFindings maps a promoted ask finding to an ask.<sourceKind> evidence 
   assert.deepEqual((await stores.inbox.load()).entries, []);
 });
 
+test("drainFindings maps a health escalation finding to a health.blocker evidence row (third producer, §9.1)", async () => {
+  const clock = { ms: 3_000_000 };
+  const ledgerRows = [];
+  const stores = makeMemoryStores();
+  await stores.findings.save({
+    v: 1,
+    findings: [
+      { source: "health", sourceKind: "health", sourceId: "watchdog", ts: clock.ms, message: "ambient spend 7 > 4x expected", title: "Health check", refs: [], pendingSince: clock.ms - 500, tag: "watchdog" },
+    ],
+  });
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true }),
+    stores,
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    cards: {},
+    facts: { getState: async () => ({ senderReliability: {} }) },
+    now: () => clock.ms,
+    publish: () => {},
+  });
+  const r = await engine.drainFindings();
+  assert.equal(r.drained, 1);
+  assert.deepEqual((await stores.findings.load()).findings, []);
+  const row = ledgerRows.find((x) => x.kind === "health.blocker");
+  assert.ok(row, "the health escalation folds as a health.* evidence row");
+  assert.equal(row.salience, "high");
+  assert.equal(row.message, "ambient spend 7 > 4x expected");
+  assert.equal(row.tag, "watchdog", "the trip source rides the tag");
+  assert.equal(row.sessionID, undefined, "health escalations have no sender session");
+  assert.deepEqual(row.refs, []);
+  // Keyless sender → neutral reliability, same as an unseen ask sender.
+  assert.ok(Math.abs(row.senderReliability - 1 / 2) < 1e-9);
+});
+
+test("cardTick enqueues the third blocker source (health escalation) and folds it into evidence on the same tick", async () => {
+  const clock = { ms: 1_000_000 };
+  const ledgerRows = [];
+  const stores = makeMemoryStores();
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true }),
+    stores,
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    facts: { getState: async () => ({ senderReliability: {} }) },
+    now: () => clock.ms,
+    publish: () => {},
+  });
+  // The watchdog wrote a pendingBlockers entry (the recordBlocker shape).
+  await stores.engineState.save({
+    v: 1,
+    pendingBlockers: [{ id: "b1", kind: "blocker", source: "rate_limit", reason: "sessionCreationsPerHour", ts: clock.ms, resolved: false }],
+  });
+  clock.ms += 1;
+  await engine.cardTick();
+  // The full third-source path in ONE tick: ingest → enqueue → drain →
+  // evidence, with the queue empty again and the health card open.
+  assert.equal(ledgerRows.filter((x) => x.kind === "health.blocker").length, 1);
+  assert.deepEqual((await stores.findings.load()).findings, []);
+  const open = (await stores.cards.load()).cards.filter((c) => c.state === "open");
+  assert.equal(open.length, 1);
+  assert.equal(open[0].sourceKind, "health");
+  // The consumed entry cannot re-enqueue on a later tick.
+  clock.ms += 1;
+  await engine.cardTick();
+  assert.equal(ledgerRows.filter((x) => x.kind === "health.blocker").length, 1);
+});
+
 test("cardTick drains the queue and runs the inbox-card liveness pass; a promoted ask enters the pipeline on the next tick", async () => {
   const clock = { ms: 1_000_000 };
   const ledgerRows = [];

--- a/src/server/ctoInbound.test.mjs
+++ b/src/server/ctoInbound.test.mjs
@@ -415,3 +415,30 @@ test("stableHash is a short stable hash", () => {
   assert.ok(stableHash("x").length >= 1);
   assert.notEqual(stableHash("x"), stableHash("y"));
 });
+
+test("BET-1516: the funnel persists a named condition onto the entry (predicate 2 input) and threads sender session to the card path", async () => {
+  const inbox = memInbox();
+  const blockers = [];
+  const inbound = createCtoInbound({
+    loadInbox: inbox.load,
+    saveInbox: inbox.save,
+    registerBlocker: async (e) => blockers.push(e),
+  });
+  await inbound.inbound({
+    surface: "session",
+    payload: {
+      kind: "blocker",
+      message: "deploy is blocked",
+      tag: "deploy",
+      sessionID: "ses-42",
+      condition: "CI on main is broken",
+    },
+  });
+  const entry = inbox.entries()[0];
+  assert.equal(entry.condition, "CI on main is broken");
+  assert.equal(blockers[0].sender.sessionID, "ses-42");
+  assert.equal(blockers[0].condition, "CI on main is broken");
+  // A non-string condition is dropped, not persisted as garbage.
+  await inbound.inbound({ surface: "session", payload: { kind: "blocker", message: "x", condition: 7 } });
+  assert.equal(inbox.entries()[1].condition, undefined);
+});

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -139,6 +139,13 @@ function createCtoJsonStore(name, path) {
 }
 
 export const inboxStore = createCtoJsonStore("inbox", ctoPath("inbox.json"));
+// BET-1516 (§9.1): the pending-findings queue — a blocker (an inbox blocker
+// note, or a worker ask promoted past the §10.3 threshold) waits here to
+// ENTER THE PIPELINE on the next engine tick, instead of riding evidence only
+// at a rollup-close breakpoint (the §9.2-v2 bypass). Payload shape:
+// `{ findings: [...] }`, drained to empty by the engine's card tick; the
+// retention rule below only bounds undrained residue.
+export const findingsStore = createCtoJsonStore("findings", ctoPath("findings.json"));
 export const cardsStore = createCtoJsonStore("cards", ctoPath("cards.json"));
 export const profileStore = createCtoJsonStore("profile", ctoPath("profile.json"));
 export const journalStore = createCtoJsonStore("journal", ctoPath("journal.json"));
@@ -501,6 +508,10 @@ export const probesStore = {
 export const RETENTION_MS = Object.freeze({
   ledger: 180 * DAY_MS,
   verdicts: 180 * DAY_MS,
+  // BET-1516: pending findings are drained by the engine's card tick within a
+  // minute; this is only the residue bound for an engine that stays down —
+  // pinned to the inbox blocker TTL (§4.4, the class it twins).
+  findings: 7 * DAY_MS,
   "rollups/hour": 14 * DAY_MS,
   "rollups/day": 120 * DAY_MS,
   "rollups/week": 2 * 365 * DAY_MS,
@@ -638,6 +649,19 @@ async function sweepVerdicts(nowMs) {
   });
 }
 
+// BET-1516: the pending-findings queue is normally emptied by the engine's
+// card tick within a minute of an enqueue; the sweep only bounds residue from
+// an engine that stayed down past the blocker TTL (§13.1). Exported for tests
+// (same pattern as sweepInbox).
+export async function sweepFindings(nowMs = Date.now()) {
+  await patchStore(findingsStore, (fresh) => {
+    const findings = Array.isArray(fresh?.findings) ? fresh.findings : [];
+    if (findings.length === 0) return {};
+    const { keep } = expireRows(findings, { nowMs, retentionMs: RETENTION_MS.findings });
+    return keep.length === findings.length ? {} : { findings: keep };
+  });
+}
+
 async function sweepDirByFileTime(dir, nowMs, retentionMs) {
   const files = await listJsonFiles(dir);
   for (const name of files) {
@@ -729,6 +753,7 @@ export async function sweepAllStores({ nowMs = Date.now() } = {}) {
     sweepDigests(),
     sweepArchiveCaps(),
     sweepInbox(nowMs),
+    sweepFindings(nowMs),
   ]);
 }
 

--- a/src/server/ctoStores.test.mjs
+++ b/src/server/ctoStores.test.mjs
@@ -24,6 +24,8 @@ import {
   capArchive,
   ctoPath,
   inboxStore,
+  findingsStore,
+  sweepFindings,
   verdictsStore,
   ledgerStore,
   factsArchiveStore,
@@ -713,4 +715,31 @@ test("startCtoStoreSweeper starts a poller that sweeps the stores on its interva
     sweeper.stop();
     await rm(ctoPath("ledger-1464-atomicity.jsonl"), { force: true });
   }
+});
+
+test("BET-1516: the findings store resolves under the sandbox and the retention sweep bounds undrained residue", async () => {
+  await findingsStore.save({
+    v: 1,
+    findings: [
+      { source: "inbox", ts: 1, noteId: "a", message: "ancient", sender: { sessionID: "s" } },
+      { source: "ask", ts: 2, sourceKind: "question", message: "fresh", sessionID: "s2" },
+    ],
+  });
+  await sweepFindings(RETENTION_MS.findings + 2);
+  const after = await findingsStore.load();
+  assert.deepEqual(after.findings.map((f) => f.message), ["fresh"]);
+  // Boundary-exact: an entry exactly at the cutoff survives.
+  await findingsStore.save({
+    v: 1,
+    findings: [{ source: "inbox", ts: 1, message: "edge", sender: null }],
+  });
+  await sweepFindings(RETENTION_MS.findings + 1);
+  assert.equal((await findingsStore.load()).findings.length, 1);
+  // SweepAllStores includes the findings queue (wiring canary).
+  await findingsStore.save({
+    v: 1,
+    findings: [{ source: "inbox", ts: 1, message: "ancient", sender: null }],
+  });
+  await sweepAllStores(Date.now() + RETENTION_MS.findings + 10);
+  assert.equal((await findingsStore.load()).findings.length, 0);
 });

--- a/src/server/ctoTestStores.mjs
+++ b/src/server/ctoTestStores.mjs
@@ -39,6 +39,8 @@ export function makeMemoryStores() {
     trust: jsonStore({}),
     cards: jsonStore({ v: 1, cards: [] }),
     inbox: jsonStore({ v: 1, entries: [] }),
+    // BET-1516 (§9.1): the pending-findings queue.
+    findings: jsonStore({ v: 1, findings: [] }),
     verdicts: jsonStore({ entries: [] }),
     budget: jsonStore({}),
     watchers: jsonStore({ watchers: [] }),

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1674,6 +1674,10 @@ function getCtoEngine() {
       listMessages: (sid, opts) => oc.listMessages(sid, opts),
       listModels: () => oc.listModels(),
       getSessionAgent: (sid) => oc.getSessionAgent(sid),
+      // BET-1516 (§10.3 predicate 1): the inbox-blocker cards' sender-session
+      // liveness check — the box's own sessionExists (definitive 404 → gone,
+      // transient → assume alive).
+      hasSession: (sid) => oc.sessionExists(sid),
       listSnapshots,
       listStopped,
       searchMessages,
@@ -5088,6 +5092,10 @@ const handleRequest = async (req, res) => {
             refs: body?.refs,
             tag: body?.tag,
             title: body?.title,
+            // BET-1516 (§10.3 predicate 2): the note may name a checkable
+            // condition ("CI on F broken") that the card liveness pass
+            // re-verifies via the §6.7 surface machinery.
+            condition: body?.condition,
             urgent: body?.urgent,
             sessionID: body?.sessionID,
             senderName: body?.senderName,


### PR DESCRIPTION
## BET-1516 — Blockers into the pipeline + inbox card liveness predicates

Implements spec §9.1 (blockers enter the pipeline on the next engine tick, ≤ 1 min — the §9.2-v2 bypass removed), §10.3 (inbox blocker cards gain the three liveness predicates), and §15-P4 item 1. Spec: docs/adaptive-cto-spec.md (merged via #1495).

### What changed

**1. Blockers enter the pipeline (§9.1) — `src/server/ctoStores.mjs`, `ctoCards.mjs`, `ctoEngine.mjs`**
- New pending-findings queue store (`findings.json`, payload `{ findings: [...] }`) in ctoStores.mjs + a retention sweep rule (blocker TTL bound, §13.1) for undrained residue.
- Two producers queue findings: `onInboxBlocker` at note arrival (source `inbox`), `promoteDue` at worker-ask promotion past the 10-min threshold (source `ask`) — the notification is untouched and stays the funnel's immediate path (separate timer).
- The engine's card tick (runs even while paused/disabled — ≤ 1 min guaranteed in every engine state) drains the queue into the A1 ledger: inbox findings become byte-shape-identical high-salience `inbox.blocker` rows (B1-weighted, same as drainInbox), ask findings become `ask.<sourceKind>` rows. The source inbox note is marked read AFTER the ledger patch commits so the breakpoint drain (drainInbox) never double-folds a blocker.
- The breakpoint drain remains the fallback path for anything that never queued (funnel crash).

**2. Inbox blocker card liveness (§10.3) — `ctoCards.mjs`**
- Inbox-sourced blocker cards now carry `noteId`, `noteExpires`, `noteSessionID`, `noteCondition` (threaded note → ask row → card; set only when present so legacy rebuilds converge byte-identically).
- `checkInboxLiveness()` runs on every card tick: (1) **sender session gone** — via the box's `oc.sessionExists` (definitive 404 → resolve; transient → keep); (2) **condition gone** — a note may name a checkable condition (`send_to_cto` gains an optional `condition` param; payload → entry → card), verified by the SAME §6.7 matcher + surface verify the facts engine uses; "no surface"/"unavailable" is a no-opinion, never a false resolution; (3) **inbox TTL** — the card never outlives the note that raised it (exact note-expiry stamp; pre-1516 cards bound by pendingSince + blocker retention window).
- A false predicate auto-retracts the card as `resolved` (CARD_RESOLVED ledger row) — never a verdict. POST /api/cto/verdict remains an independent third path.

**3. Orphaned `concurrentEphemeral` health card cleanup — `ctoCards.mjs`**
- BET-1513 made concurrency-limit trips shed (`pause:false`), so any open health card with sourceId `rate_limit` + body `concurrentEphemeral`/`concurrentDelegate` is residue: re-upserted by every tick, unresolvable by hand (closeOpenCard drops the whole rate_limit group). One-time marker-guarded prune (same contract as pruneLegacyOpenCards) drops the orphaned cards + the shed `pendingBlockers` entries, ledger-resolves each card, stamps the marker.

**Wiring fix riding along (predicate 1's prerequisite):** `onInboxBlocker` destructured a top-level `sessionID` that the funnel never sends (the sender session id lives in `sender.sessionID`) — the notification route + `noteSessionID` were always undefined on the live box. Now threaded from `sender` (top-level `sessionID` still accepted).

### Verification

- `npm run typecheck` — exit 0.
- `npm test` — 3916 pass / 0 fail (server suite 3368, +13 new BET-1516 tests: finding builders, queue→ledger drain, ask promotion into the pipeline, the three liveness predicates + no-opinion paths, legacy TTL bound, orphaned-shed prune idempotency, funnel condition passthrough, findings retention sweep).

Base: origin/main @ 82a1abe3
