### PR TITLE
BET-1521: §14-7 autonomy health rows + §9.5 calibration table + τ control

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -924,7 +924,10 @@ function BackfillCard({ state }: { state: CtoState | null }) {
 // ---------------------------------------------------------------------------
 // Settings & health (§10.5)
 // ---------------------------------------------------------------------------
-function SettingsView({
+// Exported for the Settings → CTO τ round-trip component test
+// (ctoSettingsTau.test.tsx, BET-1521) — the control drives a real mock
+// window.api through the shared test harness.
+export function SettingsView({
   paused,
   pausedAt,
   onBack,

--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -55,10 +55,12 @@ import {
   budgetTodayUsd,
   digestEvidenceAction,
   evidenceExpansion,
+  calibrationTableDisplay,
   type BlockerCard,
   type ConnectCardRow,
   type CtoState,
   type CtoHealthStat,
+  type CtoCalibrationTable,
   type DecisionCardRow,
   type SuggestionApi,
   type VetoCardRow,
@@ -129,6 +131,9 @@ type CtoSettingsConfig = {
   // both — the full render is gated on High + Overnight on (§10.5 card 3).
   ctoOvernight?: boolean;
   ctoNightCapUsd?: number;
+  // BET-1521 (§9.3/§9.4): the autonomy threshold τ (0..1, default 0.7) — the
+  // Settings τ control writes it; the gate + calibration read it.
+  ctoAutonomyThreshold?: number;
 };
 
 // §11.2 defaults — the same constants ctoBudget.mjs enforces server-side.
@@ -944,8 +949,12 @@ function SettingsView({
   const [config, setConfig] = useState<CtoSettingsConfig | null>(null);
   const [capText, setCapText] = useState("");
   const [nightCapText, setNightCapText] = useState("");
+  const [tauText, setTauText] = useState("");
   const [health, setHealth] = useState<CtoHealthStat[]>([]);
   const [busyPause, setBusyPause] = useState(false);
+  // BET-1521 (§9.5): the per-class calibration table (value + counts + current
+  // τ), read with the health stats on settings-open — one payload, no polling.
+  const [calibration, setCalibration] = useState<CtoCalibrationTable | null>(null);
   // BET-1405 (§10.5 card 3): budget payload (day buckets + quota cache) and
   // usage snapshots (provider window notes), read once on settings-open.
   const [budget, setBudget] = useState<{ days?: Record<string, { usd?: number } | undefined>; quota?: Record<string, { provider?: string; mode?: string | null; reserve?: number | null; mape14?: number | null } | undefined> } | null>(null);
@@ -982,12 +991,16 @@ function SettingsView({
         ctoDigestPush: !!c?.ctoDigestPush,
         ctoOvernight: !!c?.ctoOvernight,
         ctoNightCapUsd: c?.ctoNightCapUsd,
+        ctoAutonomyThreshold: c?.ctoAutonomyThreshold,
       });
       setCapText(String(c?.ctoAmbientCap ?? DEFAULT_AMBIENT_CAP_USD));
       setNightCapText(c?.ctoNightCapUsd != null ? String(c.ctoNightCapUsd) : "");
+      setTauText(c?.ctoAutonomyThreshold != null ? String(c.ctoAutonomyThreshold) : "");
     }).catch(reportSettingsLoadError("the CTO settings"));
     void window.api.ctoHealthGet().then((h) => {
-      if (aliveRef.current) setHealth(h.stats);
+      if (!aliveRef.current) return;
+      setHealth(h.stats);
+      setCalibration(h.calibration ?? null);
     }).catch(reportSettingsLoadError("the health stats"));
     // BET-1405 (§10.5 card 3): the persisted budget payload (day buckets +
     // quota cache) and the usage snapshots (provider window notes) — one read
@@ -1049,6 +1062,20 @@ function SettingsView({
     }
     void applyConfig({ ctoNightCapUsd: Math.round(n * 100) / 100 });
   }, [nightCapText, applyConfig, pushToast]);
+
+  // BET-1521 (§9.3/§9.4): the autonomy threshold τ — a proportion, 0..1.
+  // Two decimals is the meaningful precision (the gate compares against a
+  // calibration mean, not a micro-signal); values outside the range are a
+  // rejected write, not a silent clamp (a silently-clamped 5 would read as 1
+  // on reopen with no hint it was capped).
+  const saveTau = useCallback(() => {
+    const n = Number(tauText);
+    if (!Number.isFinite(n) || n < 0 || n > 1) {
+      pushToast({ id: `tau-${Date.now()}`, message: "Autonomy bar must be between 0 and 1." });
+      return;
+    }
+    void applyConfig({ ctoAutonomyThreshold: Math.round(n * 100) / 100 });
+  }, [tauText, applyConfig, pushToast]);
 
   const doPause = useCallback(async () => {
     setBusyPause(true);
@@ -1172,6 +1199,32 @@ function SettingsView({
                 </div>
               </div>
 
+              {/* Autonomy bar τ (BET-1521, §9.3/§9.4): the calibrated gate's
+                  threshold. Sits with the effort dial — both bound how much
+                  the CTO does on its own. */}
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm font-medium text-text">Autonomy bar (τ)</div>
+                  <div className="text-sm text-text-muted">
+                    The CTO acts on its own when its confidence clears this bar (0–1, default 0.7).
+                  </div>
+                </div>
+                <input
+                  type="number"
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  value={tauText}
+                  onChange={(e) => setTauText(e.target.value)}
+                  onBlur={saveTau}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") saveTau();
+                  }}
+                  className="w-20 rounded-md border border-border bg-bg px-2 py-1 text-sm text-text"
+                  aria-label="Autonomy threshold tau, between 0 and 1"
+                />
+              </div>
+
               {/* Ambient cap editor */}
               <div className="flex items-center justify-between gap-3">
                 <div>
@@ -1293,6 +1346,52 @@ function SettingsView({
           </section>
           )}
 
+          {/* ---------- Autonomy calibration table (§9.5, BET-1521) ---------- */}
+          {/* Read-only: where the CTO is holding itself back per class — the
+              Beta(1,1) mean over each class's last-30 outcomes, the raw counts
+              behind it, and the configured τ. Collects until the store holds
+              windows; a failed read renders the collecting line, never zeros. */}
+          <section className="rounded-lg border border-border-subtle p-4">
+            <h3 className="text-sm font-semibold text-text">Autonomy calibration</h3>
+            {(() => {
+              const cal = calibrationTableDisplay(calibration);
+              return cal.collecting ? (
+                <p className="mt-1 text-sm text-text-faint">
+                  Collecting — the per-class windows fill as the CTO resolves work.
+                </p>
+              ) : (
+                <div className="mt-3">
+                  <p className="text-sm text-text-muted">
+                    Beta mean over each class&rsquo;s last 30 outcomes
+                    {cal.tauText ? ` · current ${cal.tauText}` : ""}.
+                  </p>
+                  <div className="mt-2 overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="text-left text-xs text-text-faint">
+                          <th className="py-2 font-medium">Class</th>
+                          <th className="py-2 font-medium">Calibration</th>
+                          <th className="py-2 text-right font-medium">Outcomes</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-border-subtle">
+                        {cal.rows.map((row) => (
+                          <tr key={row.cls}>
+                            <td className="py-2 text-text-muted">{row.cls}</td>
+                            <td className="py-2 font-mono text-text">{row.value.toFixed(2)}</td>
+                            <td className="py-2 text-right font-mono text-text">
+                              {row.successes}/{row.outcomes}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              );
+            })()}
+          </section>
+
           {/* BET-1468 item 2: the config read landed but a secondary read
               failed — say so (the toast already fired) with a Retry, instead
               of leaving the health/budget sections silently empty. */}
@@ -1331,6 +1430,10 @@ function SettingsView({
                       ? "Cap-hits caused · 30d"
                       : id === "reserveFractile"
                       ? "Reserve fractile"
+                      : id === "autonomyResolvedUnaided"
+                      ? "Resolved unaided · 30d"
+                      : id === "autonomyBlockerToResolve"
+                      ? "Blocker → resolution · 30d"
                       : "ROI · self-report",
                   value: null,
                   n: 0,
@@ -1346,6 +1449,24 @@ function SettingsView({
                   </li>
                 );
               })}
+              {/* BET-1521 (§14-7): the per-class autonomy + calibration rows
+                  (`autonomyClass.<cls>` / `autonomyCalib.<cls>`) — the server
+                  emits them only for classes with signals in the 30d window,
+                  in a deterministic order, so they render only when the data
+                  exists and gate on their own min-sample size. */}
+              {health
+                .filter((s) => s.id.startsWith("autonomyClass.") || s.id.startsWith("autonomyCalib."))
+                .map((stat) => {
+                  const d = statDisplay(stat);
+                  return (
+                    <li key={stat.id} className="flex items-baseline justify-between gap-3 py-2">
+                      <span className="text-sm text-text-muted">{stat.label}</span>
+                      <span className={"text-right text-sm " + (d.ready ? "font-mono text-text" : "text-text-faint")}>
+                        {d.text}
+                      </span>
+                    </li>
+                  );
+                })}
             </ul>
           </section>
 
@@ -1427,8 +1548,10 @@ function SettingsView({
   );
 }
 
-// §10.5 card 2 render order. BET-1400's forecast/cap-hit/reserve rows and
-// BET-1405's ROI row (last — the self-report closes the list).
+// §10.5 card 2 render order. BET-1400's forecast/cap-hit/reserve rows,
+// BET-1405's ROI row, then BET-1521's box-wide §14-7 autonomy rows (the
+// per-class rows render dynamically after these — class ids are data-derived,
+// so they can't live in a const list).
 const HEALTH_ROW_ORDER = [
   "ambientSpendToday",
   "digestOpens",
@@ -1438,6 +1561,8 @@ const HEALTH_ROW_ORDER = [
   "capHitsCaused",
   "reserveFractile",
   "roi",
+  "autonomyResolvedUnaided",
+  "autonomyBlockerToResolve",
 ] as const;
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -38,6 +38,7 @@ import type {
   CtoTonightWindow,
   CtoDigest,
   CtoHealthStat,
+  CtoCalibrationTable,
   CtoLedgerRow,
   CtoLedgerPage,
   CtoProfileRender,
@@ -1571,22 +1572,26 @@ export const httpApi: Api = {
     return { ok: json.ok !== false, error: json.error };
   },
 
-  // GET /api/cto/health (A12, §10.5 card 2) — the P1 Health-card stats. Read
-  // on settings-open (no polling). A rejection degrades to empty stats so the
-  // card renders collecting rows rather than crashing.
-  ctoHealthGet: async (): Promise<{ stats: CtoHealthStat[] }> => {
+  // GET /api/cto/health (A12, §10.5 card 2) — the P1 Health-card stats +
+  // BET-1521's §9.5 calibration table. Read on settings-open (no polling). A
+  // rejection degrades to empty stats so the card renders collecting rows
+  // rather than crashing.
+  ctoHealthGet: async (): Promise<{ stats: CtoHealthStat[]; calibration?: CtoCalibrationTable | null }> => {
     const url = `${serverBase()}/api/cto/health`;
     let res: Response;
     try {
       res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
     } catch {
-      return { stats: [] };
+      return { stats: [], calibration: null };
     }
     if (res.status === 401) throw new AuthRequiredError();
-    if (!res.ok) return { stats: [] };
-    let json: { stats?: CtoHealthStat[] } = {};
+    if (!res.ok) return { stats: [], calibration: null };
+    let json: { stats?: CtoHealthStat[]; calibration?: CtoCalibrationTable | null } = {};
     try { json = await res.json() as typeof json; } catch { /* non-JSON */ }
-    return { stats: Array.isArray(json?.stats) ? json.stats : [] };
+    return {
+      stats: Array.isArray(json?.stats) ? json.stats : [],
+      calibration: json?.calibration ?? null,
+    };
   },
 
   // RPC `quota:read` (BET-1405) — the persisted budget payload (day buckets +

--- a/src/renderer/ctoSettingsTau.test.tsx
+++ b/src/renderer/ctoSettingsTau.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+//
+// Component tests for the Settings → CTO τ round-trip (BET-1521, §9.3/§9.4).
+// The issue's Tests deliverable: "τ load/save round-trips through
+// `configGet`/`configUpdate` (mock the api)". These mount the REAL
+// SettingsView through the shared test harness (mocked window.api + jsdom)
+// and drive the actual input — load renders the persisted value, Enter/blur
+// commits the edited value through configUpdate, and an out-of-range value is
+// rejected with a user-visible toast and NO write.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { act } from "react";
+import { mount, installMockApi, type Harness, type MockApi } from "./testHarness";
+import { SettingsView } from "./CtoPanel";
+import { useStore } from "./store";
+
+// Drive a controlled React input the way a user types: native value setter +
+// bubbling `input` event (React's onChange delegation).
+function typeInto(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  act(() => {
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+// Enter keydown — the τ editor commits on Enter (its other commit path is blur).
+function pressEnter(input: HTMLElement): void {
+  act(() => {
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+    );
+  });
+}
+
+async function mountSettings(
+  config: Record<string, unknown>,
+): Promise<{ h: Harness; api: MockApi }> {
+  const { api } = installMockApi({
+    configGet: () => Promise.resolve(config),
+    configUpdate: (patch: unknown) => Promise.resolve(patch),
+    ctoHealthGet: () => Promise.resolve({ stats: [], calibration: null }),
+  });
+  const h = mount(
+    <SettingsView
+      paused={false}
+      pausedAt={null}
+      onBack={() => {}}
+      onLedger={() => {}}
+      onProfile={() => {}}
+      onBlackboard={() => {}}
+      onTools={() => {}}
+      onResume={() => {}}
+    />,
+  );
+  await h.flush();
+  return { h, api };
+}
+
+const tauInput = (h: Harness) =>
+  h.container.querySelector<HTMLInputElement>(
+    'input[aria-label="Autonomy threshold tau, between 0 and 1"]',
+  );
+
+describe("SettingsView τ round-trip (BET-1521)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    act(() => useStore.setState({ appToasts: [] }));
+  });
+
+  it("load: renders the persisted ctoAutonomyThreshold from configGet", async () => {
+    const m = await mountSettings({
+      ctoEnabled: true,
+      ctoTier: "medium",
+      ctoAmbientCap: 2.5,
+      ctoAutonomyThreshold: 0.7,
+    });
+    h = m.h;
+    const input = tauInput(h);
+    expect(input).not.toBeNull();
+    expect(input!.value).toBe("0.7");
+  });
+
+  it("load: empty input when the box has no τ configured yet", async () => {
+    const m = await mountSettings({ ctoEnabled: true, ctoTier: "low", ctoAmbientCap: 2.5 });
+    h = m.h;
+    expect(tauInput(h)!.value).toBe("");
+  });
+
+  it("save: Enter commits the edited τ through configUpdate", async () => {
+    const m = await mountSettings({ ctoAutonomyThreshold: 0.7 });
+    h = m.h;
+    const input = tauInput(h)!;
+    typeInto(input, "0.85");
+    pressEnter(input);
+    await h.flush();
+    expect(m.api.calls.configUpdate).toContainEqual([{ ctoAutonomyThreshold: 0.85 }]);
+  });
+
+  it("save: two-decimal rounding — 0.856 writes 0.86", async () => {
+    const m = await mountSettings({ ctoAutonomyThreshold: 0.7 });
+    h = m.h;
+    const input = tauInput(h)!;
+    typeInto(input, "0.856");
+    pressEnter(input);
+    await h.flush();
+    expect(m.api.calls.configUpdate).toContainEqual([{ ctoAutonomyThreshold: 0.86 }]);
+  });
+
+  it("save: out-of-range τ is rejected — user-visible toast, no configUpdate write", async () => {
+    const m = await mountSettings({ ctoAutonomyThreshold: 0.7 });
+    h = m.h;
+    const toastsBefore = useStore.getState().appToasts.length;
+    const input = tauInput(h)!;
+    typeInto(input, "5");
+    pressEnter(input);
+    await h.flush();
+    expect(m.api.calls.configUpdate).toBeUndefined();
+    const toasts = useStore.getState().appToasts;
+    expect(toasts.length).toBeGreaterThan(toastsBefore);
+    expect(toasts[toasts.length - 1]?.message).toContain("between 0 and 1");
+  });
+});

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -22,6 +22,7 @@ import {
   digestEvidenceAction,
   refChipAction,
   evidenceExpansion,
+  calibrationTableDisplay,
   type CtoState,
   type CtoHealthStat,
 } from "./ctoView";
@@ -113,6 +114,61 @@ describe("statDisplay (§10.5 stat min-sample collecting)", () => {
     const out = statDisplay(undefined as unknown as CtoHealthStat);
     expect(out.ready).toBe(false);
     expect(out.text).toBe("collecting (0 / 0)");
+  });
+
+  // BET-1521 (§14-7): the per-class autonomy rows ride the same stat shape —
+  // their ids are data-derived (`autonomyClass.<cls>` / `autonomyCalib.<cls>`)
+  // and must flow through the display selector unchanged.
+  it("BET-1521: per-class autonomy rows gate on their own min-sample size", () => {
+    const decisions = statDisplay(
+      stat({
+        id: "autonomyClass.record-decision",
+        label: "Autonomy · record-decision",
+        value: "plans 5 · act 3 · ask 2 · none 1 · esc 1 · retries 0",
+        n: 8,
+        min: 5,
+      }),
+    );
+    expect(decisions.ready).toBe(true);
+    expect(decisions.text).toContain("act 3");
+    const calib = statDisplay(
+      stat({ id: "autonomyCalib.record-decision", label: "Calibration · record-decision", n: 2, min: 5 }),
+    );
+    expect(calib.ready).toBe(false);
+    expect(calib.text).toBe("collecting (2 / 5)");
+  });
+});
+
+describe("calibrationTableDisplay (§9.5 Settings → CTO table, BET-1521)", () => {
+  it("renders the collecting line for a null / empty payload — never fabricated zeros", () => {
+    expect(calibrationTableDisplay(null).collecting).toBe(true);
+    expect(calibrationTableDisplay({ tau: 0.7, classes: [] }).collecting).toBe(true);
+    expect(calibrationTableDisplay({ tau: 0.7, classes: [{ cls: "a", value: NaN, successes: 1, outcomes: 2 }] }).collecting).toBe(true);
+  });
+
+  it("passes the server's deterministic row order through + annotates the configured τ", () => {
+    const out = calibrationTableDisplay({
+      tau: 0.7,
+      classes: [
+        { cls: "record-decision", value: 0.375, successes: 11, outcomes: 30 },
+        { cls: "queue-tonight", value: 0.5, successes: 3, outcomes: 8 },
+      ],
+    });
+    expect(out.collecting).toBe(false);
+    expect(out.tauText).toBe("τ 0.70");
+    expect(out.rows.map((r) => r.cls)).toEqual(["record-decision", "queue-tonight"]);
+    expect(out.rows[0]).toEqual({ cls: "record-decision", value: 0.375, successes: 11, outcomes: 30 });
+  });
+
+  it("drops malformed rows instead of rendering NaN cells", () => {
+    const out = calibrationTableDisplay({
+      tau: 0.7,
+      classes: [
+        { cls: "good", value: 0.6, successes: 3, outcomes: 6 },
+        { cls: "bad", value: NaN, successes: 1, outcomes: 1 },
+      ],
+    });
+    expect(out.rows.map((r) => r.cls)).toEqual(["good"]);
   });
 });
 

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -48,6 +48,9 @@ export const idleBackfill: BackfillState = {
 // sample size before the value may be trusted. While `n < min` the renderer
 // shows `collecting (n/k)` and never the number — a stat never displays noise
 // as signal.
+// BET-1521 (§14-7): `autonomyResolvedUnaided` / `autonomyBlockerToResolve` are
+// the box-wide autonomy rows; `autonomyClass.<cls>` / `autonomyCalib.<cls>`
+// are emitted per triage class found in the 30d window (deterministic order).
 export type CtoHealthStat = {
   id:
     | "ambientSpendToday"
@@ -59,7 +62,11 @@ export type CtoHealthStat = {
     | "capHitsCaused"
     | "reserveFractile"
     // BET-1405 (§12.4): the monthly ROI self-report roll.
-    | "roi";
+    | "roi"
+    | "autonomyResolvedUnaided"
+    | "autonomyBlockerToResolve"
+    | `autonomyClass.${string}`
+    | `autonomyCalib.${string}`;
   label: string;
   value: string | null;
   n: number;
@@ -69,6 +76,44 @@ export type CtoHealthStat = {
   // supplies it verbatim; otherwise the generic `collecting (n / min)` renders.
   collectingText?: string;
 };
+
+// BET-1521 (§9.5): one read-only row of the per-class calibration table
+// (Settings → CTO) — the Beta(1,1) posterior mean over the class's last-30
+// outcome window plus the raw counts it was computed from.
+export type CtoCalibrationRow = {
+  cls: string;
+  value: number;
+  successes: number;
+  outcomes: number;
+};
+
+// The §9.5 calibration table payload (rides GET /api/cto/health). `tau` is
+// the configured autonomy threshold the table annotates.
+export type CtoCalibrationTable = {
+  tau: number;
+  classes: CtoCalibrationRow[];
+};
+
+// Pure selector for the §9.5 calibration table (Settings → CTO): what to
+// render for the given payload. `null`/empty payload → the collecting line
+// (never fabricated zeros); a payload → its rows in the server's
+// deterministic order + the τ annotation for the subline.
+export function calibrationTableDisplay(
+  table: CtoCalibrationTable | null | undefined,
+): { rows: CtoCalibrationRow[]; tauText: string | null; collecting: boolean } {
+  const rows = Array.isArray(table?.classes)
+    ? table.classes.filter((r) => r && typeof r.cls === "string" && Number.isFinite(Number(r.value)))
+    : [];
+  if (rows.length === 0) {
+    return { rows: [], tauText: null, collecting: true };
+  }
+  const tau = Number(table?.tau);
+  return {
+    rows,
+    tauText: Number.isFinite(tau) ? `τ ${tau.toFixed(2)}` : null,
+    collecting: false,
+  };
+}
 
 // Pure stat-display selector (§10.5): when a stat has not reached its minimum
 // sample size, render `collecting (n / min)` — or the stat's own

--- a/src/server/ctoHealth.mjs
+++ b/src/server/ctoHealth.mjs
@@ -8,7 +8,7 @@
 // that produce their data (rule 4 in the decomposition) — they are NOT
 // rendered here.
 
-import { effectsForVerdict } from "./ctoVerdicts.mjs";
+import { effectsForVerdict, betaMean } from "./ctoVerdicts.mjs";
 import { todaySpend, roiMonthKey } from "./ctoBudget.mjs";
 
 const DAY_MS = 86_400_000;
@@ -29,6 +29,15 @@ export const HEALTH_STAT_MIN = Object.freeze({
   reserveFractile: 1,
   roi: 1,
   probeHealth: 1,
+  // BET-1521 (§14-7): the autonomy rows over the 30d window. A per-class
+  // decision row means something at ≥5 signals (executions + silent-logs +
+  // dismissed asks); the calibration row needs ≥5 stated-confidence entries
+  // before an average reads as signal; the box-wide unaided-rate wants ≥5
+  // executions; and the blocker→resolution mean is noise under 3 findings.
+  autonomyDecisions: 5,
+  autonomyCalibration: 5,
+  autonomyResolvedUnaided: 5,
+  autonomyBlockerToResolve: 3,
 });
 
 // EN month labels for ROI row copy — deterministic (server locale must not
@@ -91,9 +100,26 @@ export async function computeHealthStats({
   // BET-1396 (§7.5/§10.5): async () => { tools, probes, healthy, authFailed,
   // lastRunAt } — the probe runner's snapshot over consented tools.
   probesRead = async () => null,
+  // BET-1521 (§14-7): async () => entries[] — the §9.4 cto.resolve ledger
+  // (one entry per plan execution: { ts, planId, class, findingId,
+  // confidence, effective, tau, trigger: act|accepted, outcome:
+  // resolved|escalated, attempts, ... }). Executed plans only.
+  resolveRead = async () => [],
+  // BET-1521 (§9.5): async () => { classes: { <cls>: { successes, outcomes } } }
+  // — the calibration store's per-class last-30 outcome windows.
+  calibrationRead = async () => null,
+  // BET-1521 (§9.3/§9.4): the configured autonomy threshold τ (0..1, default
+  // 0.7) — annotated on the per-class rows + the calibration table payload.
+  ctoAutonomyThreshold = 0.7,
 } = {}) {
   const t = now();
   const stats = [];
+  // BET-1521: the configured autonomy bar, clamped to [0, 1] — an out-of-range
+  // config value (hand-edited config, buggy writer) must never surface as a
+  // nonsense τ on the health rows or the calibration table.
+  const threshold = Number.isFinite(Number(ctoAutonomyThreshold))
+    ? Math.min(1, Math.max(0, Number(ctoAutonomyThreshold)))
+    : 0.7;
 
   // 1. Ambient spend today / cap.
   let budget = null;
@@ -329,5 +355,201 @@ export async function computeHealthStats({
     ...(probeCount > 0 && !probeRan ? { collectingText: "configured — waiting for first run" } : {}),
   });
 
-  return { stats, generatedAt: t };
+  // 10. Autonomy rows (BET-1521, §14-7) — ledger-derived over the 30d window.
+  //     Per class: plans generated, act / ask / none counts, stated vs realized
+  //     confidence (the calibration curve), escalations, retries used, τ at
+  //     decision time. Box-wide: resolved-unaided rate, mean time from blocker
+  //     to resolution. Sources: the §9.4 cto.resolve ledger (executions), the
+  //     `suggest.silent` activity-ledger rows (gate→none decisions) and
+  //     suggestion-dismiss verdicts (asks the user ended without an execution).
+  //     Every read failure degrades to an empty source — rows collect, the
+  //     health read never throws.
+  const resolveCutoff = t - 30 * DAY_MS;
+  let resolveEntries = [];
+  try {
+    resolveEntries = (await resolveRead()) ?? [];
+  } catch {
+    resolveEntries = [];
+  }
+  const resolves = (Array.isArray(resolveEntries) ? resolveEntries : []).filter(
+    (e) => e && typeof e === "object" && typeof e.ts === "number" && e.ts >= resolveCutoff,
+  );
+
+  // Gate→none decisions: below-p_ask silent-logs (each row carries the
+  // finding's class). Read from the same A1 ledger the earlier rows consume.
+  const silentRows = rows.filter(
+    (r) => r?.kind === "suggest.silent" && typeof r?.ts === "number" && r.ts >= resolveCutoff,
+  );
+  // Asks ended without an execution: dismiss verdicts on suggestion subjects
+  // (§9.5 — a rejection). Accepts do not appear here: an accepted ask became
+  // a cto.resolve entry with trigger "accepted".
+  const askDismissedRows = verdicts.filter(
+    (v) =>
+      v?.verdict === "dismiss" &&
+      v?.subject?.type === "suggestion" &&
+      typeof v.subject?.class === "string" &&
+      typeof v?.ts === "number" &&
+      v.ts >= verdictCutoff,
+  );
+
+  const classOf = (c) => (typeof c === "string" && c.length > 0 ? c : null);
+  const perClass = new Map(); // cls -> { entries, silent, askDismissed }
+  const groupFor = (cls) => {
+    let g = perClass.get(cls);
+    if (!g) {
+      g = { entries: [], silent: 0, askDismissed: 0 };
+      perClass.set(cls, g);
+    }
+    return g;
+  };
+  for (const e of resolves) {
+    const cls = classOf(e.class);
+    if (cls) groupFor(cls).entries.push(e);
+  }
+  for (const r of silentRows) {
+    const cls = classOf(r.class);
+    if (cls) groupFor(cls).silent += 1;
+  }
+  for (const v of askDismissedRows) {
+    const cls = classOf(v.subject.class);
+    if (cls) groupFor(cls).askDismissed += 1;
+  }
+
+  // Box-wide: resolved-unaided rate — the share of executions that ended
+  // resolved WITHOUT asking (trigger "act"). Denominator is all executions
+  // (every resolve entry is a resolution attempt, aided or not).
+  const unaided = resolves.filter((e) => e.trigger === "act" && e.outcome === "resolved").length;
+  stats.push({
+    id: "autonomyResolvedUnaided",
+    label: "Resolved unaided · 30d",
+    min: HEALTH_STAT_MIN.autonomyResolvedUnaided,
+    n: resolves.length,
+    value:
+      resolves.length >= HEALTH_STAT_MIN.autonomyResolvedUnaided
+        ? `${Math.round((unaided / resolves.length) * 100)}% unaided (${unaided}/${resolves.length})`
+        : null,
+  });
+
+  // Box-wide: mean time from blocker to resolution. Per finding: the lag
+  // between its FIRST ledgered execution and the execution that resolved it
+  // (escalations + later accepted asks fold in). The §9.4 ledger stamps the
+  // execution time, not the blocker's first-reported time — when BET-1519's
+  // entries carry an explicit first-seen ts, the wiring here upgrades to it.
+  const firstSeen = new Map(); // findingId -> earliest ts
+  for (const e of [...resolves].sort((a, b) => a.ts - b.ts)) {
+    const fid = typeof e.findingId === "string" && e.findingId ? e.findingId : null;
+    if (fid && !firstSeen.has(fid)) firstSeen.set(fid, e.ts);
+  }
+  const resolveLags = [];
+  for (const e of resolves) {
+    if (e.outcome !== "resolved") continue;
+    const fid = typeof e.findingId === "string" && e.findingId ? e.findingId : null;
+    const start = fid ? firstSeen.get(fid) : undefined;
+    if (typeof start === "number" && e.ts - start > 0) resolveLags.push(e.ts - start);
+  }
+  const meanLag = resolveLags.length
+    ? resolveLags.reduce((a, b) => a + b, 0) / resolveLags.length
+    : null;
+  const formatLag = (ms) =>
+    ms >= 3_600_000 ? `${(ms / 3_600_000).toFixed(1)} h` : `${Math.max(1, Math.round(ms / 60_000))} min`;
+  stats.push({
+    id: "autonomyBlockerToResolve",
+    label: "Blocker → resolution · 30d",
+    min: HEALTH_STAT_MIN.autonomyBlockerToResolve,
+    n: resolveLags.length,
+    value:
+      resolveLags.length >= HEALTH_STAT_MIN.autonomyBlockerToResolve && meanLag != null
+        ? `mean ${formatLag(meanLag)}`
+        : null,
+  });
+
+  // Per-class rows, deterministically ordered: class name, then decisions row
+  // before its calibration row. `plans` = distinct executed planIds (the
+  // resolve ledger holds executions; generated-but-never-executed plans
+  // surface as none / dismissed-ask signals instead). `ask` = accepted asks
+  // plus asks dismissed without an execution. Retries = spent extra turns
+  // (attempts − 1, floored at 0).
+  const classNames = [...perClass.keys()].sort((a, b) => a.localeCompare(b));
+  for (const cls of classNames) {
+    const g = perClass.get(cls);
+    const entries = g.entries;
+    const acts = entries.filter((e) => e.trigger === "act").length;
+    const asks = entries.filter((e) => e.trigger === "accepted").length + g.askDismissed;
+    const escs = entries.filter((e) => e.outcome === "escalated").length;
+    const retries = entries.reduce((sum, e) => sum + Math.max(0, (Number(e.attempts) || 1) - 1), 0);
+    const planIds = new Set(entries.map((e) => (typeof e.planId === "string" ? e.planId : "")).filter(Boolean));
+    const signals = entries.length + g.silent + g.askDismissed;
+    stats.push({
+      id: `autonomyClass.${cls}`,
+      label: `Autonomy · ${cls}`,
+      min: HEALTH_STAT_MIN.autonomyDecisions,
+      n: signals,
+      value:
+        signals >= HEALTH_STAT_MIN.autonomyDecisions
+          ? `plans ${planIds.size} · act ${acts} · ask ${asks} · none ${g.silent} · esc ${escs} · retries ${retries}`
+          : null,
+    });
+  }
+
+  // Per-class calibration curve (§14-7): stated vs realized confidence. Stated
+  // = the mean confidence the gate recorded on the entries; realized = the
+  // share that actually resolved. τ at decision time = the most recent
+  // entry's recorded τ, falling back to the configured bar when the entries
+  // predate τ stamping.
+  for (const cls of classNames) {
+    const g = perClass.get(cls);
+    const withConf = g.entries.filter((e) => typeof e.confidence === "number" && Number.isFinite(e.confidence));
+    if (withConf.length === 0) continue;
+    const stated = withConf.reduce((a, e) => a + e.confidence, 0) / withConf.length;
+    const realized = g.entries.length
+      ? g.entries.filter((e) => e.outcome === "resolved").length / g.entries.length
+      : 0;
+    const lastEntry = [...g.entries].sort((a, b) => a.ts - b.ts).at(-1);
+    const tauAtDecision = typeof lastEntry?.tau === "number" && Number.isFinite(lastEntry.tau)
+      ? lastEntry.tau
+      : threshold;
+    stats.push({
+      id: `autonomyCalib.${cls}`,
+      label: `Calibration · ${cls}`,
+      min: HEALTH_STAT_MIN.autonomyCalibration,
+      n: withConf.length,
+      value:
+        withConf.length >= HEALTH_STAT_MIN.autonomyCalibration
+          ? `stated ${stated.toFixed(2)} · realized ${realized.toFixed(2)} · τ ${tauAtDecision.toFixed(2)}`
+          : null,
+    });
+  }
+
+  // 11. Calibration table payload (BET-1521, §9.5) — returned alongside the
+  //     stats for the Settings → CTO read-only table: per class the Beta(1,1)
+  //     posterior mean over its last-30 outcome window (via the shared
+  //     estimator in ctoVerdicts.mjs), the raw counts it was computed from,
+  //     and the configured τ. null when the store is absent or the read
+  //     fails — the table then renders its collecting line, never zeros.
+  let calibration = null;
+  try {
+    const cal = await calibrationRead();
+    const windows = cal && typeof cal === "object" ? (cal.classes && typeof cal.classes === "object" ? cal.classes : null) : null;
+    if (windows) {
+      calibration = {
+        tau: threshold,
+        classes: Object.entries(windows)
+          .filter(([, w]) => w && typeof w === "object" && Number.isFinite(Number(w.outcomes)))
+          .map(([cls, w]) => {
+            const successes = Math.max(0, Math.min(Number(w.outcomes), Number(w.successes) || 0));
+            return {
+              cls,
+              value: betaMean(successes + 1, Number(w.outcomes) - successes + 1),
+              successes,
+              outcomes: Number(w.outcomes),
+            };
+          })
+          .sort((a, b) => a.cls.localeCompare(b.cls)),
+      };
+    }
+  } catch {
+    calibration = null;
+  }
+
+  return { stats, calibration, generatedAt: t };
 }

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -338,3 +338,195 @@ test("ROI row: roiRead failure degrades to collecting, never throws", async () =
   assert.equal(r.value, null);
   assert.equal(r.collectingText, "collecting");
 });
+
+// --- BET-1521: §14-7 autonomy rows + §9.5 calibration table ----------------
+
+// A §9.4 cto.resolve entry — one row per plan execution.
+function resolveEntry(over = {}) {
+  return {
+    ts: NOW - 1 * DAY,
+    planId: "plan-1",
+    class: "record-decision",
+    findingId: "f-1",
+    confidence: 0.8,
+    effective: 0.75,
+    tau: 0.7,
+    trigger: "act",
+    outcome: "resolved",
+    attempts: 1,
+    ...over,
+  };
+}
+
+test("autonomy rows: no ledger → both box-wide rows collecting (0/min)", async () => {
+  const { stats } = await computeHealthStats({ now: () => NOW });
+  for (const id of ["autonomyResolvedUnaided", "autonomyBlockerToResolve"]) {
+    const s = stats.find((x) => x.id === id);
+    assert.equal(s.value, null);
+    assert.equal(s.n, 0);
+    assert.equal(s.min, HEALTH_STAT_MIN[id]);
+  }
+});
+
+test("resolved unaided: share of executions that resolved without asking", async () => {
+  const entries = [
+    resolveEntry(), // act + resolved → unaided
+    resolveEntry({ findingId: "f-2", trigger: "accepted" }), // aided
+    resolveEntry({ findingId: "f-3", outcome: "escalated" }), // act but escalated
+    resolveEntry({ findingId: "f-4" }),
+    resolveEntry({ findingId: "f-5" }),
+  ];
+  const { stats } = await computeHealthStats({ now: () => NOW, resolveRead: async () => entries });
+  const s = stats.find((x) => x.id === "autonomyResolvedUnaided");
+  assert.equal(s.n, 5);
+  assert.equal(s.value, "60% unaided (3/5)"); // 3 act-resolved of 5 executions
+});
+
+test("resolved unaided: entries older than 30d are excluded", async () => {
+  const entries = [
+    resolveEntry({ ts: NOW - 40 * DAY }),
+    ...Array.from({ length: 5 }, (_, i) => resolveEntry({ findingId: `f-${i}` })),
+  ];
+  const { stats } = await computeHealthStats({ now: () => NOW, resolveRead: async () => entries });
+  const s = stats.find((x) => x.id === "autonomyResolvedUnaided");
+  assert.equal(s.n, 5);
+});
+
+test("blocker → resolution: mean lag from first ledgered execution to the resolving one", async () => {
+  const entries = [
+    // finding A: first seen 90 min before resolution (lag 90 min)
+    resolveEntry({ findingId: "f-a", ts: NOW - 3 * 3_600_000 }),
+    resolveEntry({ findingId: "f-a", ts: NOW - 1.5 * 3_600_000 }),
+    // finding B: first seen 30 min before resolution (lag 30 min)
+    resolveEntry({ findingId: "f-b", trigger: "accepted", ts: NOW - 2 * 3_600_000 }),
+    resolveEntry({ findingId: "f-b", trigger: "accepted", ts: NOW - 1.5 * 3_600_000 }),
+    // finding C: first seen 60 min before resolution (lag 60 min)
+    resolveEntry({ findingId: "f-c", ts: NOW - 2 * 3_600_000 }),
+    resolveEntry({ findingId: "f-c", ts: NOW - 3_600_000 }),
+  ];
+  const { stats } = await computeHealthStats({ now: () => NOW, resolveRead: async () => entries });
+  const s = stats.find((x) => x.id === "autonomyBlockerToResolve");
+  assert.equal(s.n, 3); // three findings resolved
+  assert.equal(s.value, "mean 1.0 h"); // (90 + 30 + 60) / 3 = 60 min
+});
+
+test("blocker → resolution: only findings with a positive resolution lag count", async () => {
+  const entries = [
+    resolveEntry({ findingId: "f-a" }), // resolved, single entry → lag 0 → excluded
+    resolveEntry({ findingId: "f-b", outcome: "escalated", ts: NOW - 3_600_000 }), // never resolved
+    resolveEntry({ findingId: "f-c", ts: NOW - 3 * 3_600_000 }), // first seen
+    resolveEntry({ findingId: "f-c", ts: NOW - 3_600_000 }), // resolved, lag 2 h
+  ];
+  const { stats } = await computeHealthStats({ now: () => NOW, resolveRead: async () => entries });
+  const s = stats.find((x) => x.id === "autonomyBlockerToResolve");
+  assert.equal(s.n, 1); // only f-c has a positive lag
+});
+
+test("per-class decisions row: counts act/ask/none/escalations/retries over the window", async () => {
+  const entries = [
+    resolveEntry({ planId: "p-1" }), // act
+    resolveEntry({ planId: "p-2", findingId: "f-2" }), // act
+    resolveEntry({ planId: "p-3", findingId: "f-3", trigger: "accepted" }), // accepted ask
+    resolveEntry({ planId: "p-4", findingId: "f-4", outcome: "escalated", attempts: 2 }), // retry used
+    resolveEntry({ planId: "p-5", findingId: "f-5", trigger: "accepted", attempts: 3 }), // 2 retries
+  ];
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    resolveRead: async () => entries,
+    ledgerRead: async () => [
+      { kind: "suggest.silent", ts: NOW - DAY, class: "record-decision" },
+      { kind: "suggest.silent", ts: NOW - DAY, class: "other-class" },
+    ],
+    verdictsRead: async () => [
+      { ts: NOW - DAY, verdict: "dismiss", subject: { type: "suggestion", id: "s-1", class: "record-decision" } },
+      { ts: NOW - DAY, verdict: "dismiss", subject: { type: "suggestion", id: "s-2", class: "record-decision" } },
+      // a fact rejection is NOT a dismissed ask
+      { ts: NOW - DAY, verdict: "dismiss", subject: { type: "fact", id: "x", class: "record-decision" } },
+    ],
+  });
+  const s = stats.find((x) => x.id === "autonomyClass.record-decision");
+  assert.equal(s.n, 8); // 5 entries + 1 silent + 2 dismissed asks
+  assert.equal(s.min, HEALTH_STAT_MIN.autonomyDecisions);
+  assert.equal(s.value, "plans 5 · act 3 · ask 4 · none 1 · esc 1 · retries 3");
+});
+
+test("per-class rows: absent class id or missing class stays out of per-class rows but counts box-wide", async () => {
+  const entries = [
+    ...Array.from({ length: 5 }, (_, i) => resolveEntry({ findingId: `f-${i}` })), // class set
+    resolveEntry({ findingId: "f-9", class: undefined }), // no class
+  ];
+  const { stats } = await computeHealthStats({ now: () => NOW, resolveRead: async () => entries });
+  assert.equal(stats.find((x) => x.id === "autonomyClass.record-decision").n, 5);
+  assert.equal(stats.find((x) => x.id === "autonomyResolvedUnaided").n, 6); // box-wide sees all
+  assert.ok(!stats.some((x) => x.id === "autonomyClass.undefined"));
+});
+
+test("per-class calibration row: stated mean vs realized share, τ from the last entry", async () => {
+  const entries = Array.from({ length: 4 }, (_, i) => resolveEntry({ findingId: `f-${i}`, confidence: 0.9 - i * 0.1 }));
+  entries.push(resolveEntry({ findingId: "f-9", confidence: 0.5, outcome: "escalated", tau: 0.65 }));
+  const { stats } = await computeHealthStats({ now: () => NOW, resolveRead: async () => entries });
+  const s = stats.find((x) => x.id === "autonomyCalib.record-decision");
+  assert.equal(s.n, 5);
+  // stated: (0.9+0.8+0.7+0.6+0.5)/5 = 0.70; realized: 4 resolved / 5 = 0.80
+  assert.equal(s.value, "stated 0.70 · realized 0.80 · τ 0.65");
+});
+
+test("per-class calibration row: τ falls back to the configured bar when entries lack it", async () => {
+  const entries = Array.from({ length: 5 }, (_, i) => resolveEntry({ findingId: `f-${i}`, tau: undefined }));
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    ctoAutonomyThreshold: 0.55,
+    resolveRead: async () => entries,
+  });
+  const s = stats.find((x) => x.id === "autonomyCalib.record-decision");
+  assert.match(s.value, /τ 0\.55$/);
+});
+
+test("autonomy rows: resolveRead failure degrades to collecting, never throws", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    resolveRead: async () => {
+      throw new Error("store down");
+    },
+  });
+  for (const s of stats.filter((x) => x.id.startsWith("autonomy"))) {
+    assert.equal(s.value, null);
+  }
+});
+
+test("calibration table: Beta(1,1) posterior mean over the raw counts + τ annotation", async () => {
+  const { calibration } = await computeHealthStats({
+    now: () => NOW,
+    calibrationRead: async () => ({ classes: { "record-decision": { successes: 11, outcomes: 30 } } }),
+  });
+  assert.equal(calibration.tau, 0.7); // default τ
+  assert.deepEqual(calibration.classes, [
+    { cls: "record-decision", value: 0.375, successes: 11, outcomes: 30 }, // (11+1)/(30+2)
+  ]);
+});
+
+test("calibration table: configured τ is clamped into [0, 1]", async () => {
+  const { calibration } = await computeHealthStats({
+    now: () => NOW,
+    ctoAutonomyThreshold: 5,
+    calibrationRead: async () => ({ classes: { a: { successes: 1, outcomes: 2 } } }),
+  });
+  assert.equal(calibration.tau, 1);
+});
+
+test("calibration table: absent store, bare default payload or failed read → null, never fabricated rows", async () => {
+  const absent = await computeHealthStats({ now: () => NOW });
+  assert.equal(absent.calibration, null);
+  const bare = await computeHealthStats({
+    now: () => NOW,
+    calibrationRead: async () => ({ v: 1 }), // the store's default payload
+  });
+  assert.equal(bare.calibration, null);
+  const failed = await computeHealthStats({
+    now: () => NOW,
+    calibrationRead: async () => {
+      throw new Error("store down");
+    },
+  });
+  assert.equal(failed.calibration, null);
+});

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -157,6 +157,18 @@ export const engineStateStore = createCtoJsonStore("engine-state", ctoPath("engi
 // so it moved to a dedicated file no other writer touches. ctoTrust.mjs
 // migrates a legacy `es.trust` payload on first load.
 export const trustStore = createCtoJsonStore("trust", ctoPath("trust.json"));
+// BET-1521: the §9.4 cto.resolve ledger — one entry per plan execution
+// ({ planId, class, findingId, confidence, calibration, effective, tau,
+// trigger: act|accepted, outcome: resolved|escalated, attempts, cost, undo,
+// refs }). Payload `{ entries: [...] }`, verdicts-mirrored; owned by the
+// executor (BET-1519) and read by the §14-7 health rows. Readers tolerate the
+// bare `{ v: 1 }` default payload (entries ?? []).
+export const resolveStore = createCtoJsonStore("resolve", ctoPath("resolve.json"));
+// BET-1521: the §9.5 calibration store — per-class last-30 outcome windows
+// (`{ classes: { <cls>: { successes, outcomes } } }`), Beta(1,1) prior.
+// Owned by the gate/calibration engine (BET-1518); read by the §10.5
+// calibration table. Readers tolerate the bare `{ v: 1 }` default.
+export const calibrationStore = createCtoJsonStore("calibration", ctoPath("calibration.json"));
 
 // ---------------------------------------------------------------------------
 // BET-1425 engine-state write hygiene, generalized in BET-1464 (defect 3) —

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -146,7 +146,7 @@ import * as cto from "./cto.mjs";
 import * as ctoEngine from "./ctoEngine.mjs";
 import * as ctoBudget from "./ctoBudget.mjs";
 import { createFactSurfaces } from "./ctoFactSurfaces.mjs";
-import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore, digestsStore, factsStore, startCtoStoreSweeper, CTO_STORE_SWEEP_INTERVAL_MS } from "./ctoStores.mjs";
+import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore, digestsStore, factsStore, resolveStore, calibrationStore, startCtoStoreSweeper, CTO_STORE_SWEEP_INTERVAL_MS } from "./ctoStores.mjs";
 import * as ctoOvernight from "./ctoOvernight.mjs";
 import { computeHealthStats } from "./ctoHealth.mjs";
 import { composeProfileRender } from "./ctoProfile.mjs";
@@ -4482,13 +4482,18 @@ const handleRequest = async (req, res) => {
   // GET /api/cto/health — the §10.5 Health-card P1 stats, composed by the
   // engine from the ledger + budget + segment stores. Read on settings-open,
   // never polled. Each stat carries `n` samples seen and `min` minimum — the
-  // renderer shows `collecting (n/k)` below `min`, never the number.
+  // renderer shows `collecting (n/k)` below `min`, never the number. The
+  // payload also carries the §9.5 calibration table (BET-1521) for the
+  // Settings → CTO read-only table.
   if (path === "/api/cto/health") {
     try {
       if (req.method === "GET") {
         const cfg = await local.configGet();
         const result = await computeHealthStats({
           ctoAmbientCap: typeof cfg?.ctoAmbientCap === "number" ? cfg.ctoAmbientCap : 2.5,
+          ctoAutonomyThreshold: typeof cfg?.ctoAutonomyThreshold === "number" ? cfg.ctoAutonomyThreshold : 0.7,
+          resolveRead: async () => (await resolveStore.load())?.entries ?? [],
+          calibrationRead: async () => await calibrationStore.load(),
       ledgerRead: () => ledgerStore.read(),
       budgetRead: () => budgetStore.load(),
       listSegments: async () => {

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -98,6 +98,12 @@ const DEFAULT_CONFIG = {
   // Adaptive CTO (BET-1386): push the pre-generated digest to the phone (§5.5
   // notify). Off by default.
   ctoDigestPush: false,
+  // Adaptive CTO (BET-1521, §9.3/§9.4): the autonomy threshold τ — the gate
+  // acts on its own when a candidate's confidence clears this bar; per-class
+  // calibration (§9.5) modulates the effective bar around it. 0.7 = the spec
+  // default. The Settings τ control writes it; the Health card shows the τ in
+  // effect at decision time.
+  ctoAutonomyThreshold: 0.7,
 };
 
 let _config = null;

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -379,6 +379,9 @@ export type CtoDigest = {
 // far, `min` the minimum sample size before the value may be trusted. While
 // `n < min` the renderer shows `collecting (n/min)` — or the row's own
 // `collectingText` when the server supplies one — and never the number.
+// BET-1521 (§14-7): `autonomyResolvedUnaided` / `autonomyBlockerToResolve` are
+// the box-wide autonomy rows; `autonomyClass.<cls>` / `autonomyCalib.<cls>`
+// are emitted per triage class found in the 30d window (deterministic order).
 export type CtoHealthStat = {
   id:
     | "ambientSpendToday"
@@ -388,12 +391,35 @@ export type CtoHealthStat = {
     | "forecastAccuracy"
     | "capHitsCaused"
     | "reserveFractile"
-    | "roi";
+    | "roi"
+    | "autonomyResolvedUnaided"
+    | "autonomyBlockerToResolve"
+    | `autonomyClass.${string}`
+    | `autonomyCalib.${string}`;
   label: string;
   value: string | null;
   n: number;
   min: number;
   collectingText?: string;
+};
+
+// BET-1521 (§9.5): one row of the read-only per-class calibration table
+// (Settings → CTO). `value` is the Beta(1,1) posterior mean over the class's
+// last-30 outcome window; `successes`/`outcomes` are the raw counts it was
+// computed from (the table shows both — a mean alone hides the sample size).
+export type CtoCalibrationRow = {
+  cls: string;
+  value: number;
+  successes: number;
+  outcomes: number;
+};
+
+// The §9.5 calibration table payload, returned alongside the §10.5 health
+// stats by GET /api/cto/health. `tau` is the configured autonomy threshold
+// the table annotates (the same value the Settings τ control writes).
+export type CtoCalibrationTable = {
+  tau: number;
+  classes: CtoCalibrationRow[];
 };
 
 // A raw Activity-ledger row (A12 drill-down). Append-only; reverse-chron view.
@@ -1340,7 +1366,9 @@ export interface Api {
    ctoDigestNow(): Promise<{ ok: boolean; error?: string }>;
   // GET /api/cto/health — the §10.5 Health-card P1 stats (composed by the
   // engine from the ledger + budget + segment stores). Read on settings-open.
-  ctoHealthGet(): Promise<{ stats: CtoHealthStat[] }>;
+  // BET-1521: `calibration` carries the §9.5 per-class table payload for the
+  // Settings → CTO read-only table (null when the store is absent or fails).
+  ctoHealthGet(): Promise<{ stats: CtoHealthStat[]; calibration?: CtoCalibrationTable | null }>;
   // RPC `quota:read` — the persisted budget payload (day buckets + §11.3
   // per-provider quota cache). Read-only; feeds the Tonight's-budget card
   // (§10.5 card 3, BET-1405).

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -319,6 +319,10 @@ export type AppConfig = {
   // budget module's DEFAULT_NIGHT_CAP_USD); once tonight's estimated
   // overnight spend reaches it, no further overnight jobs are selected.
   ctoNightCapUsd?: number;
+  // Adaptive CTO (BET-1521, §9.3/§9.4): the autonomy threshold τ (0..1,
+  // default 0.7) — act on its own when the candidate's confidence clears this
+  // bar. The Settings τ control writes it; the gate + calibration read it.
+  ctoAutonomyThreshold?: number;
   // ----- Manta Optimizer (BET-1342 / Phase 2) -----
   // Master switch for the optimizer. DEFAULT FALSE. Opt-in: with it OFF the
   // optimizer changes nothing. It does NOT gate Automatic Manta Routing —

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,61 +2,61 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-22T17:17:23.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-22T16:04:35.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,61 +2,61 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T17:17:23.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T16:04:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-09-01T19:29:35.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## BET-1521 — P4.6: autonomy health rows + calibration table + τ control

Implements §14-7 (autonomy metrics), §9.5 (calibration renders in Settings → CTO) and §10.5 (Health card rows) from the spec merged in #1495.

**Base:** `origin/main @ 82a1abe3`

### Server

- `src/server/ctoHealth.mjs` — `computeHealthStats` now emits the §14-7 rows as `CtoHealthStat[]` (same shape `statDisplay` consumes, min-sample gated with `collecting (n/k)`):
  - **Per class** (`autonomyClass.<cls>` / `autonomyCalib.<cls>`, emitted only for classes with signals in the 30d window, deterministic order): plans, act/ask/none counts, escalations, retries, stated-vs-realized confidence, τ at decision time.
  - **Box-wide** (`autonomyResolvedUnaided`, `autonomyBlockerToResolve`): resolved-unaided rate; mean blocker→resolution lag.
  - New injected deps: `resolveRead` (§9.4 `cto.resolve` ledger), `calibrationRead` (§9.5 store), `ctoAutonomyThreshold` (τ, clamped to [0,1], default 0.7). All reads fail-soft to empty.
  - Sources for gate decisions: `cto.resolve` entries (executions: act = trigger `act`, ask = trigger `accepted`), `suggest.silent` ledger rows (gate→none), and suggestion-dismiss verdicts (asks ended without execution). Calibration payload = Beta(1,1) mean via the existing `betaMean` estimator in `ctoVerdicts.mjs` (no duplicated formula).
- `src/server/ctoStores.mjs` — `resolveStore` (`cto/resolve.json`, `{entries:[]}`) + `calibrationStore` (`cto/calibration.json`, `{classes:{}}`), verdicts-mirrored; readers tolerate the bare `{v:1}` default payload. **BET-1518/1519 will own the writers** — until they land the stores stay empty and every new row degrades to collecting by design.
- `src/server/index.mjs` — the health route wires the two readers + τ from config; the payload now carries `calibration`.
- `src/server/local.mjs` + `src/shared/types.ts` — `ctoAutonomyThreshold: 0.7` default (the key name the decomposition pinned; BET-1518 will bind its gate to it).

### Renderer

- `CtoPanel.tsx` — τ control in the Behavior card (numeric, step 0.05, 0..1 validated, two-decimal precision, instant-apply like the caps); read-only per-class calibration table (Class | Calibration | Outcomes + τ subline, collecting line when empty); box-wide autonomy rows joined `HEALTH_ROW_ORDER`; per-class rows render through the same `statDisplay` markup — no new card variants.
- `ctoView.ts` — widened the `CtoHealthStat` id union with the autonomy ids; `calibrationTableDisplay` selector (+ `CtoCalibrationTable` types); `httpApi.ts` passes the `calibration` payload through `ctoHealthGet`.

### Follow-ups

- Filed: **BET-1523** — when BET-1519's `cto.resolve` entries carry an explicit first-seen ts, upgrade the `plans` count and the blocker→resolution lag derivation (both currently derive from the ledger's execution timestamps; the first-execution→resolved lag is the closest ledger-derivable reading of "blocker to resolution").

### Verification

| Suite | PR branch (`multica/BET-1521-autonomy-health-ui` @ `53292160`) | Base (`main` @ `82a1abe3`) |
|---|---|---|
| typecheck | exit 0, no errors | exit 0, no errors |
| test | 3918 vitest pass / 0 fail (18 new: 13 server + 5 τ round-trip) · 3912 node:test pass / 0 fail | 3899 vitest+node pass / 0 fail |

**Conclusion:** 0 pre-existing failures, 0 new failures; this PR adds 13 tests (11 server + 2 new renderer describes). Logs: `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.



### Review cycle 1 — Block resolution

**Block (fix-here):** the issue's Tests deliverable "τ load/save round-trips through `configGet`/`configUpdate` (mock the api)" was absent. **Choice made: the component-test route** (the issue's own wording), not the pure-selector extraction — `src/renderer/ctoSettingsTau.test.tsx` mounts the real `SettingsView` through the shared test harness (`testHarness.tsx`, mocked `window.api` + jsdom, `CardMount.test.tsx` precedent) and drives the real input: load renders the persisted `ctoAutonomyThreshold` (or empty when unset), Enter commits through `configUpdate` (incl. two-decimal rounding), and an out-of-range value is rejected with a user-visible toast and no write. `SettingsView` is exported for the test; `saveTau`/`applyConfig` untouched.
