### PR TITLE
feat(server): BET-1519 generic §9.4 plan executor + driver, resolve-store folding, verdict-route execution

### DIFF
--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -799,11 +799,13 @@ export async function executeSuggestionOption({
         return r?.ok ? { ok: true } : { ok: false, error: r?.error ?? "queue-tonight failed" };
       }
       case "plan": {
-        // BET-1518 (§9.3): a gate ask card's plan option. The concrete
-        // execution is BET-1519's executor seam — today the click records
-        // the human's accept judgment (§9.5 verdict, stamped with the
-        // card's class by the caller) and the verdict route resolves the
-        // card. Validate the payload so a malformed option fails closed.
+        // BET-1518 (§9.3) + BET-1519 (§9.4): a gate ask card's plan option.
+        // The click records the human's accept judgment (§9.5 verdict,
+        // stamped with the card's class by the caller); the verdict route
+        // then runs the plan through the ONE generic executor server-side
+        // (trigger "accepted" — same session, verify, retry and cap as the
+        // gate's act verb). Validate the payload so a malformed option fails
+        // closed.
         const planId = typeof payload.planId === "string" ? payload.planId : "";
         if (!planId) return { ok: false, error: "plan needs a planId payload" };
         return { ok: true };

--- a/src/server/ctoAct.mjs
+++ b/src/server/ctoAct.mjs
@@ -509,6 +509,16 @@ export function createCtoPlanRunner(deps = {}) {
     let turn2 = { ok: false, reason: "no-send", lastText: "", assistants: 0 };
     try {
       if (isDelegate) {
+        // If turn 1 ended on budget but the job is still executing, delivering
+        // the retry brief into the child session now would interleave with the
+        // in-flight turn. Wait for the job to finish first (bounded by the
+        // retry deadline; still running at it → that IS the failed check).
+        if (turn.reason === "turn-budget") {
+          const stillRunning = await readTranscript(sessionId, { baseline: 0, deadline: retryDeadline });
+          if (stillRunning.ok === false && stillRunning.reason === "turn-budget") {
+            return finish("escalated", `attempt1:${check1.reason ?? "verify-failed"}; job-still-running-at-budget`);
+          }
+        }
         const row = await jobRow(sessionId);
         const childId = row?.sessionId;
         if (!childId) {
@@ -576,6 +586,7 @@ export function createCtoExecutorDriver(deps = {}) {
     recordAct = null, // ({cls, text, refs, action, score}) — digest announcement
     verdictsList = async () => [], // () => verdict entries
     knowsPlan = async () => false, // (planId) => plans.json hit
+    presence = null, // async () => "present"|"away"|"gone" (§9.4 rule; engine wires getPresence().state)
     now = () => Date.now(),
     execute = null, // when runner is not provided directly
     queueMax = QUEUE_MAX,
@@ -755,7 +766,19 @@ export function createCtoExecutorDriver(deps = {}) {
     }
   }
 
-  /** The gate/accepted seam: validate → cap → enqueue → drain. */
+  /**
+   * The gate/accepted seam: validate → cap → presence (§9.4) → enqueue →
+   * drain.
+   *
+   * §9.4 presence rule (§3.4 rule 3): blocker-sourced plans run regardless
+   * of presence (that is the point of a blocker); finding-sourced machine
+   * acts (trigger "act") refuse while the user is `present` — the gate then
+   * degrades them to the ask card, which is the right §9.3 surface when the
+   * human is right there. Decision (documented in the PR): the check is at
+   * ENQUEUE — a refused plan re-runs through the gate's ask path instead of
+   * being held in the queue for an indefinite away-window. User-accepted
+   * plans (trigger "accepted") are user-initiated and bypass presence.
+   */
   async function executePlan(plan, ctx = {}) {
     const { findingId = null, finding = null, project = null, trigger = "act", gateCtx = null } = ctx;
     const v = validatePlan(plan);
@@ -771,6 +794,15 @@ export function createCtoExecutorDriver(deps = {}) {
     }
     const isBlocker =
       finding?.kind === "blocker" || finding?.sourceKind === "blocker" || finding?.noteKind === "blocker";
+    if (trigger === "act" && !isBlocker && typeof presence === "function") {
+      try {
+        if ((await presence()) === "present") {
+          return { ok: false, reason: "presence-gated" };
+        }
+      } catch {
+        /* a presence read failure must not block machine work — run */
+      }
+    }
     queue.push({ planId, plan: v.plan, finding, findingId, project, trigger, gateCtx, isBlocker, queuedAt: now() });
     await drain();
     return { ok: true, queued: true, planId };

--- a/src/server/ctoAct.mjs
+++ b/src/server/ctoAct.mjs
@@ -1,218 +1,847 @@
 // src/server/ctoAct.mjs
-// BET-1424 — the §9.2 act-and-report executors for the §9.3-eligible classes.
+// BET-1519 — the ONE generic §9.4 plan executor + the executor driver.
 //
-// The suggestion engine's act branch (ctoSuggest.mjs) calls ONE injected
-// `executeAction({cls, action, candidate})` with the candidate's primary bound
-// option. BET-1403 wired only `record-decision` inline in index.mjs; this
-// module owns all three §9.3-eligible executors (ctoTrust.mjs eligibility map)
-// behind one factory:
+// D22 (spec v3): one generic executor runs every plan — no per-use-case
+// handler anywhere. The per-class bound executors of BET-1424 (record-decision
+// / queue-tonight / start-job branches + their payload normalizers) are
+// retired; every plan runs the same way:
 //
-//   - record-decision → a gatekeeper-checked decision fact on the CTO's own
-//     blackboard (the engine's fact route). Behavior carried over verbatim
-//     from the BET-1403 inline executor.
-//   - queue-tonight   → an entry in tonight's overnight queue via the engine's
-//     tonightAdd (§10.4/§11.4 — planning-only, nothing runs until the window
-//     opens; trivially reversible).
-//   - start-job       → a worktree-isolated delegate job (own git worktree +
-//     branch; never touches the user's checkout), started with actor "cto"
-//     under the §3.3 delegate gate (kill switch, pause, concurrent cap).
+//   - an `act` plan (or an `ask` plan the user accepted, trigger "accepted")
+//     runs in a CTO-owned session with plan.steps as its brief and
+//     plan.access as its permission ruleset;
+//   - the session kind comes from the plan: a delegate job (own worktree,
+//     branch, sidebar row — through the shared startJobWithApproval path so
+//     the ruleset always applies) when access includes `write`/`edit`, an
+//     ephemeral session otherwise;
+//   - after the turn goes idle the plan's verify check runs (§9.2): a
+//     predicate statement against the §6.7 surfaces, a consented probe read,
+//     the session's own CHECK marker, or the originating blocker's condition
+//     being gone;
+//   - fail → exactly one retry: the SAME session gets one more turn with the
+//     failed check attached (fresh 30-minute budget); fail again → the
+//     finding escalates to a human blocker card carrying the attempt log;
+//   - every execution writes ONE `cto.resolve` ledger row (§9.4-9.5) and one
+//     outcome into the resolve store; two executions per plan id, ever — a
+//     cap-hit refusal degrades to ask, never acts;
+//   - outcomes feed child #3's calibration (notePlanOutcome): `resolved` with
+//     no correct/dismiss/veto verdict within 7 days → success (deferred); a
+//     negative verdict in the window, or `escalated`, → failure.
 //
-// Everything else refuses with `no-executor` (config-change is §9.3-capped at
-// ask permanently; tool-write stays data-unreachable until a tool holds the
-// §7.4 write ring). The refusal contract is load-bearing (§9.2): act-and-report
-// must never silently no-op — every refusal returns {ok:false, reason} so the
-// verb degrades to the veto-window card, whose options remain user-executable
-// through the renderer's ask-path executors.
+// The driver (queue ≤ 10 FIFO with blocker-before-finding, ≤ 2 in flight,
+// attempt cap, outcome bookkeeping, 7-day resolution scan) lives here as
+// createCtoExecutorDriver; ctoEngine.mjs constructs it over the engine's
+// stores/ledger/cards/calibration and drives it from cardTick.
 //
-// Payload normalization: the generator emits free-form payloads; a present-but
-// malformed field refuses the act (incomplete-payload) rather than being
-// silently dropped — the card rendered THIS payload, so executing a doctored
-// version of it would not be acting on what was shown. The field names follow
-// the renderer's ask-path contract (ctoView.ts executeSuggestionOption) where
-// one exists: start-job accepts `cwd` (alias `directory`), queue-tonight reads
-// `cost` as the predictedCost alias.
-//
-// Pure over injected I/O — testable without a live tmux/opencode/delegate.
+// Pure over injected I/O — testable without a live opencode/tmux/delegate.
 
-import { ACTOR, RATE_LIMITS, isRunningCtoRow } from "./ctoEngine.mjs";
-import { resolveForgeOwner } from "./delegate.mjs";
+import { buildPermissionRuleset } from "./delegate.mjs";
+import { appendLedgerBestEffort, patchStore } from "./ctoStores.mjs";
+
+// §9.4 budgets. A turn runs until done (idle) with a hard 30-minute budget;
+// a retry turn gets a fresh one. Poll cadence mirrors runSynchronousSession.
+export const TURN_BUDGET_MS = 30 * 60_000;
+export const TURN_POLL_MS = 1_000;
+export const RESOLUTION_WINDOW_MS = 7 * 24 * 3_600_000; // §9.5 7-day success window
+export const EXECUTIONS_PER_PLAN = 2; // two executions per plan id, ever
+export const QUEUE_MAX = 10;
+export const MAX_IN_FLIGHT = 2; // §3.3 concurrent-delegate sub-cap, §9.4
+
+// The exact end-marker the brief asks the session to leave. session-ok
+// verification reads it from the last assistant turn; predicate/probe/
+// condition-gone verification ignores it (the §6.7 surface decides).
+export const CHECK_MARKER = "CHECK:";
 
 // ---------------------------------------------------------------------------
-// Payload normalization (§9.1 schema → the executor's typed input)
-// ---------------------------------------------------------------------------
-
-// record-decision: {statement, project, refs?} (+ finding refs fallback).
-export function normalizeRecordDecisionPayload(payload, { findingRefs = [] } = {}) {
-  const p = payload && typeof payload === "object" ? payload : {};
-  const statement = typeof p.statement === "string" ? p.statement.trim() : "";
-  const project = typeof p.project === "string" ? p.project.trim() : "";
-  const refs = Array.isArray(p.refs) && p.refs.length
-    ? p.refs.filter((r) => typeof r === "string")
-    : (Array.isArray(findingRefs) ? findingRefs.filter((r) => typeof r === "string") : []);
-  if (!statement || !project || refs.length === 0) return null;
-  return { statement, project, refs };
-}
-
-// start-job: {prompt, cwd | directory, model?, ...}. `model` mirrors the
-// delegate engine's startJob contract: a free-text name or a structured
-// {providerID, modelID, variant?}. Returns null when prompt/cwd are missing or
-// when a supplied model has neither a valid shape.
-export function normalizeStartJobPayload(payload) {
-  const p = payload && typeof payload === "object" ? payload : {};
-  const prompt = typeof p.prompt === "string" ? p.prompt.trim() : "";
-  const cwdRaw = typeof p.cwd === "string" && p.cwd.trim() ? p.cwd : (typeof p.directory === "string" ? p.directory : "");
-  const cwd = cwdRaw.trim();
-  if (!prompt || !cwd) return null;
-  let model;
-  if (p.model != null) {
-    if (typeof p.model === "string" && p.model.trim()) {
-      model = p.model.trim();
-    } else if (
-      typeof p.model === "object" && !Array.isArray(p.model) &&
-      typeof p.model.providerID === "string" && p.model.providerID.trim() &&
-      typeof p.model.modelID === "string" && p.model.modelID.trim()
-    ) {
-      model = { providerID: p.model.providerID, modelID: p.model.modelID };
-      if (typeof p.model.variant === "string" && p.model.variant.trim()) model.variant = p.model.variant;
-    } else {
-      return null;
-    }
-  }
-  return model === undefined ? { prompt, cwd } : { prompt, cwd, model };
-}
-
-// queue-tonight: {name?, prompt?, project?, value?, confidence?, cost?/predictedCost?, refs?}.
-// The name falls back to the finding text (what the card shows); tonightAdd
-// still enforces its own name/prompt defaults and caps.
-export function normalizeQueueTonightPayload(payload, { findingText = "", findingRefs = [] } = {}) {
-  const p = payload && typeof payload === "object" ? payload : {};
-  const name = (typeof p.name === "string" && p.name.trim()) || String(findingText ?? "").trim();
-  if (!name) return null;
-  const out = { name };
-  if (typeof p.prompt === "string" && p.prompt.trim()) out.prompt = p.prompt;
-  if (typeof p.project === "string" && p.project.trim()) out.project = p.project.trim();
-  if (Number.isFinite(p.value)) out.value = p.value;
-  if (Number.isFinite(p.confidence)) out.confidence = p.confidence;
-  if (Number.isFinite(p.predictedCost)) out.predictedCost = p.predictedCost;
-  else if (Number.isFinite(p.cost)) out.predictedCost = p.cost;
-  const refs = Array.isArray(p.refs) && p.refs.length
-    ? p.refs.filter((r) => typeof r === "string")
-    : (Array.isArray(findingRefs) ? findingRefs.filter((r) => typeof r === "string") : []);
-  if (refs.length) out.refs = refs;
-  return out;
-}
-
-// ---------------------------------------------------------------------------
-// The executor factory — one `executeAction` for the suggest engine's act verb
+// Plan validation (§9.4 runtime shape — §9.2 schema, stricter)
 // ---------------------------------------------------------------------------
 
 /**
- * @param {object} deps injected I/O
- * @param {(input: {project, kind, statement, refs, sender}) => Promise<{ok?:boolean, error?:string}|null>} [deps.proposeFact]
- * @param {(task: object) => Promise<{ok?:boolean, task?:object, error?:string}|null>} [deps.tonightAdd]
- *   the engine's tonightAdd (self-gated: overnight switch + High tier).
- * @param {() => Promise<{ok?:boolean, release?:() => void, error?:string}|null>} [deps.beginDelegateJob]
- *   the §3.3 delegate gate (kill switch / pause / concurrent tracker).
- * @param {() => Promise<Array>} [deps.listProjects]
- * @param {(projects: Array, cwd: string) => {parentSessionID?:string}|null} [deps.resolveParent]
- * @param {(input: {prompt, model?, parentSessionID, parentDirectory, actor}) => Promise<{ok?:boolean, job?:{id?:string}, error?:string}|null>} [deps.startDelegateJob]
- * @param {() => Promise<Array>} [deps.listDelegateJobs] the persisted job rows
- *   (loadJobs) — the persistent source the running-CTO-job cap counts.
- * @param {number} [deps.maxConcurrentDelegate] §3.3 concurrent cto-delegate cap
- * @returns {({cls, action, candidate}) => Promise<{ok:boolean, reason?:string, detail?:string, jobId?:string|null, taskId?:string|null}>}
+ * Validate a plan the way the executor will run it: an id, a non-empty steps
+ * list, a normalized access list, and a verify check of a known kind with a
+ * value. Returns {ok:true, plan} with whitespace-trimmed steps/access, or
+ * {ok:false, reason:"invalid-plan:<what>"}.
  */
-export function createCtoActExecutor(deps = {}) {
+export function validatePlan(plan) {
+  if (!plan || typeof plan !== "object") return { ok: false, reason: "invalid-plan:missing" };
+  const id = typeof plan.id === "string" ? plan.id.trim() : "";
+  if (!id) return { ok: false, reason: "invalid-plan:id" };
+  const steps = Array.isArray(plan.steps)
+    ? plan.steps.map((s) => String(s ?? "").trim()).filter(Boolean)
+    : [];
+  if (steps.length === 0) return { ok: false, reason: "invalid-plan:steps" };
+  const access = Array.isArray(plan.access)
+    ? plan.access
+        .map((a) => {
+          if (!a || typeof a !== "object") return null;
+          const permission = typeof a.permission === "string" ? a.permission.trim() : "";
+          const pattern = typeof a.pattern === "string" && a.pattern.trim() ? a.pattern : "*";
+          if (!permission) return null;
+          return { permission, pattern, action: a.action === "deny" ? "deny" : "allow" };
+        })
+        .filter(Boolean)
+    : [];
+  const verify = plan.verify && typeof plan.verify === "object" ? plan.verify : null;
+  const kind = typeof verify?.kind === "string" ? verify.kind : "";
+  if (!["predicate", "probe", "session-ok", "condition-gone"].includes(kind)) {
+    return { ok: false, reason: `invalid-plan:verify:${kind || "missing"}` };
+  }
+  if (kind === "predicate" && typeof verify.condition !== "string") {
+    return { ok: false, reason: "invalid-plan:verify:condition" };
+  }
+  if (kind === "probe" && typeof verify.probe !== "string") {
+    return { ok: false, reason: "invalid-plan:verify:probe" };
+  }
+  if (kind === "condition-gone" && typeof verify.condition !== "string") {
+    return { ok: false, reason: "invalid-plan:verify:condition" };
+  }
+  return {
+    ok: true,
+    plan: {
+      ...plan,
+      id,
+      class: typeof plan.class === "string" ? plan.class : "other",
+      steps,
+      access,
+      verify,
+    },
+  };
+}
+
+// §9.4: "the executor picks a delegate job (worktree, branch, sidebar row)
+// when access includes write or edit, an ephemeral session otherwise."
+export function wantsDelegateSession(access) {
+  return (Array.isArray(access) ? access : []).some((a) => a?.permission === "write" || a?.permission === "edit");
+}
+
+// The permission ruleset for the session: the plan's access grants with the
+// catch-all deny first (last-match-wins; opencode prepends its own allow-all
+// default, so without the deny every ungranted tool resolves to allow).
+export function permissionRulesetFor(access) {
+  return buildPermissionRuleset(Array.isArray(access) ? access : []);
+}
+
+// ---------------------------------------------------------------------------
+// The brief (§9.4 — plan.steps as the session's brief)
+// ---------------------------------------------------------------------------
+
+/**
+ * The session prompt: identity, the finding, the diagnosis, the steps, the
+ * do/do-not contract, the undo note, and the exact end-marker line. Pure.
+ */
+export function buildExecutionBrief(plan, { finding = null, project = null } = {}) {
+  const lines = [];
+  lines.push(
+    "You are the CTO's execution session. Complete the steps below in this environment. Do not start unrelated work.",
+  );
+  lines.push("");
+  lines.push("## Finding");
+  lines.push(String(finding?.text ?? finding?.message ?? plan.finding?.text ?? "(no finding text)"));
+  if (plan.diagnosis) {
+    lines.push("");
+    lines.push("## Diagnosis");
+    lines.push(String(plan.diagnosis));
+  }
+  lines.push("");
+  lines.push("## Steps");
+  plan.steps.forEach((s, i) => lines.push(`${i + 1}. ${s}`));
+  lines.push("");
+  lines.push("## Access");
+  const access = wantsDelegateSession(plan.access)
+    ? "You run in an isolated git worktree with the granted permissions only."
+    : "You run in a read-only ephemeral session; work within the granted permissions only.";
+  lines.push(access);
+  if (plan.undo) {
+    lines.push("");
+    lines.push(`## Undo (if the check fails or the user asks)`);
+    lines.push(String(plan.undo));
+  }
+  if (project) {
+    lines.push("");
+    lines.push(`Project: ${project}`);
+  }
+  lines.push("");
+  lines.push(
+    `## Done contract\nWhen the steps are complete, end your final message with a line that is exactly \`${CHECK_MARKER} pass\`. If you could not complete the steps, end with \`${CHECK_MARKER} fail: <one-line reason>\`.`,
+  );
+  return lines.join("\n");
+}
+
+/** The retry turn's prompt: the failed check result, one more try. */
+export function buildRetryBrief(plan, check) {
+  return [
+    "Your previous attempt did not satisfy the verification check.",
+    `Check that failed: ${check?.reason ?? "unspecified"}${check?.detail ? ` — ${check.detail}` : ""}.`,
+    "Try the steps once more, fixing whatever the check exposed. Nothing else.",
+    `End your final message with \`${CHECK_MARKER} pass\` on success or \`${CHECK_MARKER} fail: <reason>\` on failure.`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Transcript helpers (pure — the session-ok check and cost accounting)
+// ---------------------------------------------------------------------------
+
+/** Role of a message row; tolerant of the opencode message shape. */
+function roleOf(m) {
+  const r = m?.role ?? m?.info?.role;
+  return typeof r === "string" ? r.toLowerCase() : "";
+}
+
+/** Concatenated text of a message row. */
+export function messageText(m) {
+  const parts = [];
+  const collect = (p) => {
+    if (!p) return;
+    if (typeof p === "string") {
+      parts.push(p);
+      return;
+    }
+    if (p.type === "text" && typeof p.text === "string") parts.push(p.text);
+    if (Array.isArray(p)) p.forEach(collect);
+    if (typeof p === "object") {
+      if (Array.isArray(p.content)) p.content.forEach(collect);
+      else if (typeof p.content === "string") parts.push(p.content);
+    }
+  };
+  const c = m?.parts ?? m?.content ?? m?.text;
+  if (Array.isArray(c)) c.forEach(collect);
+  else if (typeof c === "string") parts.push(c);
+  else if (c && typeof c === "object") collect(c);
+  return parts.join("");
+}
+
+export function countAssistants(messages) {
+  return (Array.isArray(messages) ? messages : []).filter((m) => roleOf(m) === "assistant").length;
+}
+
+export function lastAssistantText(messages) {
+  const rows = Array.isArray(messages) ? messages : [];
+  for (let i = rows.length - 1; i >= 0; i -= 1) {
+    if (roleOf(rows[i]) === "assistant") return messageText(rows[i]);
+  }
+  return "";
+}
+
+/** The session's own completion marker (session-ok verification). */
+export function checkMarkerResult(lastText) {
+  const text = String(lastText ?? "");
+  const lines = text.split("\n").filter((l) => l.includes(CHECK_MARKER));
+  const last = lines[lines.length - 1] ?? "";
+  const idx = last.indexOf(CHECK_MARKER);
+  const rest = idx >= 0 ? last.slice(idx + CHECK_MARKER.length).trim() : "";
+  if (/^pass\b/i.test(rest)) return { ok: true };
+  if (/^fail\b/i.test(rest)) {
+    const detail = rest.replace(/^fail:?\s*/i, "").trim();
+    return { ok: false, reason: "session-reported-fail", detail };
+  }
+  return { ok: false, reason: "no-check-marker" };
+}
+
+/** Rough token estimate for the resolve row's cost field (ctoSessions' 4-chars/token). */
+export function estimateCostTokens(chunks) {
+  return (Array.isArray(chunks) ? chunks : []).reduce((sum, c) => sum + Math.ceil(String(c ?? "").length / 4), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Verify dispatch (§9.2 kinds)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the plan's verify check. Returns {ok:boolean, reason?, detail?}.
+ * kind → seam:
+ *   predicate      → verifyFact(condition) — the §6.7 surface verifier
+ *   probe          → probeRead(probe) — a consented §7.5 probe read
+ *   session-ok     → the session's own CHECK marker in the last turn
+ *   condition-gone → conditionGone(condition) — the originating blocker's
+ *                    liveness predicate (§10.3) is now false
+ * A seam returning a no-opinion (null/undefined) is a FAIL (unverified),
+ * never a pass — verification is mandatory and never silently skipped.
+ */
+export async function runVerifyCheck(plan, ctx) {
+  const verify = plan?.verify ?? {};
+  const kind = verify.kind;
+  if (kind === "session-ok") {
+    const res = checkMarkerResult(ctx.lastText);
+    return { ...res, kind };
+  }
+  if (kind === "predicate") {
+    if (typeof ctx.verifyFact !== "function") return { ok: false, reason: "verify-unavailable", kind };
+    try {
+      const r = await ctx.verifyFact({ condition: verify.condition });
+      if (r?.ok === true) return { ok: true, kind, detail: r.detail };
+      return { ok: false, reason: r?.reason ?? "predicate-false", detail: r?.detail, kind };
+    } catch (e) {
+      return { ok: false, reason: "verify-error", detail: e?.message, kind };
+    }
+  }
+  if (kind === "probe") {
+    if (typeof ctx.probeRead !== "function") return { ok: false, reason: "verify-unavailable", kind };
+    try {
+      const r = await ctx.probeRead(verify.probe);
+      if (r?.ok === true) return { ok: true, kind, detail: r.detail };
+      return { ok: false, reason: r?.reason ?? "probe-false", detail: r?.detail, kind };
+    } catch (e) {
+      return { ok: false, reason: "verify-error", detail: e?.message, kind };
+    }
+  }
+  // condition-gone
+  if (typeof ctx.conditionGone !== "function") return { ok: false, reason: "verify-unavailable", kind: "condition-gone" };
+  try {
+    const gone = await ctx.conditionGone(verify.condition);
+    if (gone === true) return { ok: true, kind: "condition-gone" };
+    if (gone === false) return { ok: false, reason: "condition-still-present", kind: "condition-gone" };
+    return { ok: false, reason: "condition-unverified", kind: "condition-gone" };
+  } catch (e) {
+    return { ok: false, reason: "verify-error", detail: e?.message, kind: "condition-gone" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The single-plan runner (the §9.4 run → verify → retry loop)
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute ONE plan to an outcome. Seams (all injected):
+ *   createSession({directory, title, permission}) → {ok, id?}
+ *   sendPrompt({sessionId, text}) → {ok}
+ *   listMessages(sessionId) → rows
+ *   abortSession(sessionId) / deleteSession(sessionId)
+ *   startJob({prompt, parentSessionID, parentDirectory, tools, trustMode})
+ *     → {ok, job?}  (the shared approval path; ruleset always applied)
+ *   jobRow(jobId) → {running, sessionId, status} | null (job poll seam)
+ *   resolveParent({finding}) → {parentSessionID, parentDirectory} | null
+ *   verifyFact / probeRead / conditionGone — the §9.2 check seams
+ *   sleep(ms), now(), pollMs, turnBudgetMs
+ */
+export function createCtoPlanRunner(deps = {}) {
   const {
-    proposeFact = null,
-    tonightAdd = null,
-    beginDelegateJob = null,
-    listProjects = async () => [],
-    resolveParent = resolveForgeOwner,
-    startDelegateJob = null,
-    listDelegateJobs = async () => [],
-    maxConcurrentDelegate = RATE_LIMITS.concurrentDelegate,
+    createSession = null,
+    sendPrompt = null,
+    listMessages = null,
+    abortSession = null,
+    deleteSession = null,
+    startJob = null,
+    jobRow = null,
+    resolveParent = null,
+    verifyFact = null,
+    probeRead = null,
+    conditionGone = null,
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+    now = () => Date.now(),
+    pollMs = TURN_POLL_MS,
+    turnBudgetMs = TURN_BUDGET_MS,
   } = deps;
 
-  return async function executeAction({ cls, action, candidate } = {}) {
-    // The act bookkeeping (trust counters, ledger row, digest report) is
-    // per-class; executing an option whose type diverges from the candidate's
-    // class would record one class and perform another. Refuse.
-    if (typeof cls !== "string" || cls !== action?.type) {
-      return { ok: false, reason: "class-mismatch" };
+  // One await-turn: send the prompt, poll the transcript until a NEW
+  // assistant message with text appears or the budget runs out. Mirrors
+  // runSynchronousSession's established idle detection (text present = done).
+  async function awaitTurn(sessionId, baseline, deadline, { prompt = null } = {}) {
+    if (prompt !== null) {
+      const sent = await sendPrompt({ sessionId, text: prompt });
+      if (sent?.ok !== true) return { ok: false, reason: "send-failed", lastText: "", assistants: baseline };
     }
-    const payload = action?.payload && typeof action.payload === "object" ? action.payload : {};
-
-    if (cls === "record-decision") {
-      if (typeof proposeFact !== "function") return { ok: false, reason: "no-executor" };
-      const p = normalizeRecordDecisionPayload(payload, { findingRefs: candidate?.finding?.refs });
-      if (!p) return { ok: false, reason: "incomplete-payload" };
-      const result = await proposeFact({ project: p.project, kind: "decision", statement: p.statement, refs: p.refs, sender: "cto" });
-      return result?.ok === true
-        ? { ok: true, detail: "decision fact proposed" }
-        : { ok: false, reason: result?.error ?? "propose-failed" };
-    }
-
-    if (cls === "queue-tonight") {
-      if (typeof tonightAdd !== "function") return { ok: false, reason: "no-executor" };
-      const p = normalizeQueueTonightPayload(payload, { findingText: candidate?.finding?.text, findingRefs: candidate?.finding?.refs });
-      if (!p) return { ok: false, reason: "incomplete-payload" };
-      // originId binds the queue entry back to the suggestion card so the
-      // drill-down edits (tonightRemove/tonightReorder) record their verdicts
-      // against the suggestion's verdict subject.
-      const result = await tonightAdd({ ...p, cls: "queue-tonight", originId: typeof candidate?.id === "string" ? candidate.id : null });
-      return result?.ok === true
-        ? { ok: true, detail: "queued for tonight", taskId: result?.task?.id ?? null }
-        : { ok: false, reason: result?.error ?? "queue-refused" };
-    }
-
-    if (cls === "start-job") {
-      if (typeof startDelegateJob !== "function" || typeof beginDelegateJob !== "function") {
-        return { ok: false, reason: "no-executor" };
-      }
-      const p = normalizeStartJobPayload(payload);
-      if (!p) return { ok: false, reason: "incomplete-payload" };
-      // §3.3 concurrent delegate sub-cap: count RUNNING cto-actor rows — the
-      // shared isRunningCtoRow definition the overnight dispatch counts too
-      // (BET-1427). The gate's transient tracker only spans the start call
-      // itself, so the running rows are the real concurrency bound; the gate
-      // below still supplies the kill switch / pause checks + the
-      // cto.delegate_begin ledger row.
-      let running = 0;
+    let text = "";
+    while (now() < deadline) {
+      await sleep(pollMs);
       try {
-        const jobs = await listDelegateJobs();
-        running = (Array.isArray(jobs) ? jobs : []).filter(isRunningCtoRow).length;
+        const msgs = await listMessages(sessionId);
+        text = lastAssistantText(msgs);
+        if (countAssistants(msgs) > baseline && text.trim()) {
+          return { ok: true, lastText: text, assistants: countAssistants(msgs) };
+        }
       } catch {
-        running = 0;
+        /* transient transcript read failure — keep polling to the budget */
       }
-      if (running >= maxConcurrentDelegate) {
-        return { ok: false, reason: "rate_limit:concurrentDelegate" };
-      }
-      // A queued act needs a tracked project session to host the job (the
-      // same resolve the overnight dispatch uses). Resolve BEFORE arming the
-      // gate so a refused start never writes a cto.delegate_begin row.
-      let parent = null;
+    }
+    return { ok: false, reason: "turn-budget", lastText: text, assistants: baseline };
+  }
+
+  /**
+   * Run the plan. Returns
+   *   {ok:true, outcome:"resolved", attempts, cost, result}
+   *   {ok:true, outcome:"escalated", attempts, cost, reason, result}
+   *   {ok:false, reason}          — refused, no execution happened
+   */
+  return async function execute({ plan: rawPlan, finding = null, project = null } = {}) {
+    const v = validatePlan(rawPlan);
+    if (!v.ok) return { ok: false, reason: v.reason };
+    const plan = v.plan;
+    const delegate = wantsDelegateSession(plan.access);
+    const ruleset = permissionRulesetFor(plan.access);
+    const brief = buildExecutionBrief(plan, { finding, project });
+    const costChunks = [brief];
+
+    // ---- session start -------------------------------------------------
+    let sessionId = null;
+    let kind = "ephemeral";
+    // The session host: a delegate job needs a tracked project session to
+    // parent it (the finding's sender session first, else the most active
+    // project); an ephemeral session just borrows its directory (opencode's
+    // default when none resolves).
+    let parent = null;
+    if (typeof resolveParent === "function") {
       try {
-        parent = resolveParent(await listProjects(), p.cwd);
+        parent = await resolveParent({ finding });
       } catch {
         parent = null;
       }
-      if (!parent?.parentSessionID) return { ok: false, reason: "no-project-session" };
-      const gate = await beginDelegateJob();
-      if (gate?.ok !== true) return { ok: false, reason: gate?.error ?? "gate-refused" };
-      try {
-        const input = { prompt: p.prompt, parentSessionID: parent.parentSessionID, parentDirectory: p.cwd, actor: ACTOR };
-        if (p.model !== undefined) input.model = p.model;
-        const res = await startDelegateJob(input);
+    }
+    try {
+      if (delegate) {
+        kind = "delegate";
+        if (typeof startJob !== "function") return { ok: false, reason: "no-start-job" };
+        if (!parent?.parentSessionID) return { ok: false, reason: "no-project-session" };
+        const res = await startJob({
+          prompt: brief,
+          parentSessionID: parent.parentSessionID,
+          parentDirectory: parent.parentDirectory ?? undefined,
+          // The plan's access rules ARE the declared tools; trustMode false —
+          // the card is the human's veto over machine-originated work.
+          tools: plan.access,
+          trustMode: false,
+        });
         if (res?.ok !== true) return { ok: false, reason: res?.error ?? "start-refused" };
-        return { ok: true, detail: "delegate job started", jobId: res?.job?.id ?? null };
-      } finally {
-        // The transient gate tracker spans the START only — the running job's
-        // concurrency is bounded by the rows count above (the overnight
-        // dispatch precedent; a long-lived job can never release a tracker).
-        gate.release?.();
+        // The delegate JOB id (poll key); its opencode session id lives on the
+        // row (childSessionID) and is resolved per transcript read.
+        sessionId = res?.job?.id ?? null;
+      } else {
+        if (typeof createSession !== "function") return { ok: false, reason: "no-create-session" };
+        const res = await createSession({
+          title: plan.id,
+          permission: ruleset,
+          directory: parent?.parentDirectory ?? undefined,
+        });
+        if (res?.ok !== true || !res.id) return { ok: false, reason: res?.reason ?? "session-create-failed" };
+        sessionId = res.id;
       }
+    } catch (e) {
+      return { ok: false, reason: "start-error", detail: e?.message };
     }
 
-    return { ok: false, reason: "no-executor" };
+    const isDelegate = kind === "delegate";
+
+    // Poll the delegate job until it finishes (own await loop over the job
+    // rows), then read its transcript. Ephemeral sessions use the turn poll.
+    // A null row is tolerated briefly (visibility lag between the start
+    // returning and the persisted row being readable); sustained absence is
+    // the job-gone escalation.
+    async function readTranscript(sid, { baseline, deadline } = {}) {
+      if (isDelegate) {
+        let nulls = 0;
+        while (now() < deadline) {
+          await sleep(pollMs);
+          let row = null;
+          try {
+            row = await jobRow(sid);
+          } catch {
+            row = null;
+          }
+          if (!row) {
+            nulls += 1;
+            if (nulls >= 10) return { ok: false, reason: "job-gone", lastText: "", assistants: baseline ?? 0 };
+            continue;
+          }
+          if (row.running === false) {
+            const msgs = row.sessionId ? await listMessages(row.sessionId) : [];
+            return { ok: true, lastText: lastAssistantText(msgs), assistants: countAssistants(msgs) };
+          }
+        }
+        return { ok: false, reason: "turn-budget", lastText: "", assistants: baseline ?? 0 };
+      }
+      return awaitTurn(sid, baseline ?? 0, deadline, { prompt: null });
+    }
+
+    // ---- turn 1: the brief ----------------------------------------------
+    const t1Deadline = now() + turnBudgetMs;
+    let turn = { ok: false, reason: "no-send", lastText: "", assistants: 0 };
+    try {
+      if (isDelegate) {
+        turn = await readTranscript(sessionId, { baseline: 0, deadline: t1Deadline });
+      } else {
+        const sent = await sendPrompt({ sessionId, text: brief });
+        if (sent?.ok !== true) {
+          turn = { ok: false, reason: "send-failed", lastText: "", assistants: 0 };
+        } else {
+          turn = await awaitTurn(sessionId, 0, t1Deadline);
+        }
+      }
+    } catch (e) {
+      turn = { ok: false, reason: "turn-error", detail: e?.message, lastText: "", assistants: 0 };
+    }
+    costChunks.push(turn.lastText ?? "");
+    let attempts = 1;
+
+    const finish = async (outcome, reason) => {
+      if (!isDelegate && sessionId) {
+        try {
+          await abortSession?.(sessionId);
+          await deleteSession?.(sessionId);
+        } catch {
+          /* cleanup is best-effort */
+        }
+      }
+      const result = {
+        kind,
+        sessionId,
+        lastText: String(turn.lastText ?? "").slice(0, 2000),
+      };
+      return { ok: true, outcome, attempts, cost: estimateCostTokens(costChunks), reason, result };
+    };
+
+    // ---- verify + one retry ----------------------------------------------
+    const check1 = await runVerifyCheck(plan, {
+      lastText: turn.lastText,
+      verifyFact,
+      probeRead,
+      conditionGone,
+    });
+    if (check1.ok === true) return finish("resolved", null);
+
+    // Retry: the SAME session gets one more turn with the failed check
+    // attached and a fresh budget. For a delegate job that means delivering
+    // the retry brief into the job's child session (the job itself has
+    // finished; the session still holds the worktree context). A session
+    // that died entirely — job-gone — cannot take another turn; that is the
+    // escalation.
+    if (turn.ok === false && turn.reason === "job-gone") {
+      return finish("escalated", `attempt1:${check1.reason ?? "verify-failed"}; job-gone`);
+    }
+    const retryDeadline = now() + turnBudgetMs;
+    let turn2 = { ok: false, reason: "no-send", lastText: "", assistants: 0 };
+    try {
+      if (isDelegate) {
+        const row = await jobRow(sessionId);
+        const childId = row?.sessionId;
+        if (!childId) {
+          turn2 = { ok: false, reason: "job-gone", lastText: "", assistants: 0 };
+        } else {
+          const msgs = await listMessages(childId);
+          const baseline = countAssistants(msgs);
+          const sent = await sendPrompt({ sessionId: childId, text: buildRetryBrief(plan, check1) });
+          if (sent?.ok !== true) {
+            turn2 = { ok: false, reason: "send-failed", lastText: "", assistants: 0 };
+          } else {
+            turn2 = await awaitTurn(childId, baseline, retryDeadline);
+          }
+        }
+      } else {
+        const sent = await sendPrompt({ sessionId, text: buildRetryBrief(plan, check1) });
+        if (sent?.ok !== true) {
+          turn2 = { ok: false, reason: "send-failed", lastText: "", assistants: 0 };
+        } else {
+          turn2 = await awaitTurn(sessionId, turn.assistants ?? 0, retryDeadline);
+        }
+      }
+    } catch (e) {
+      turn2 = { ok: false, reason: "turn-error", detail: e?.message, lastText: "", assistants: 0 };
+    }
+    costChunks.push(buildRetryBrief(plan, check1), turn2.lastText ?? "");
+    attempts = 2;
+    turn = turn2;
+
+    const check2 = await runVerifyCheck(plan, {
+      lastText: turn2.lastText,
+      verifyFact,
+      probeRead,
+      conditionGone,
+    });
+    if (check2.ok === true) return finish("resolved", null);
+    const log = `attempt1:${check1.reason ?? "verify-failed"}; attempt2:${check2.reason ?? "verify-failed"}`;
+    return finish("escalated", log);
   };
+}
+
+// ---------------------------------------------------------------------------
+// The driver — queue, concurrency, attempt cap, outcomes, escalation
+// ---------------------------------------------------------------------------
+
+/**
+ * The executor driver. One per engine. Owns:
+ *   - the FIFO queue (≤ QUEUE_MAX entries, blocker-before-finding),
+ *   - ≤ MAX_IN_FLIGHT executions,
+ *   - the per-plan attempt cap (two executions per plan id, ever) over the
+ *     durable resolve store (survives re-triage — the cap never re-arms),
+ *   - the §9.5 outcome bookkeeping (notePlanOutcome) + the `cto.resolve`
+ *     ledger row,
+ *   - the 7-day success resolution (resolved + no negative verdict in the
+ *     window → success; a negative verdict → failure),
+ *   - the escalation to a human blocker card carrying the attempt log.
+ */
+export function createCtoExecutorDriver(deps = {}) {
+  const {
+    runner = null, // createCtoPlanRunner(...).execute
+    store = null, // resolveStore { load, save } / patch
+    ledger = null,
+    escalate = null, // (text) => void — the human blocker card
+    calibration = null, // notePlanOutcome({planId, class, ok})
+    recordAct = null, // ({cls, text, refs, action, score}) — digest announcement
+    verdictsList = async () => [], // () => verdict entries
+    knowsPlan = async () => false, // (planId) => plans.json hit
+    now = () => Date.now(),
+    execute = null, // when runner is not provided directly
+    queueMax = QUEUE_MAX,
+    maxInFlight = MAX_IN_FLIGHT,
+  } = deps;
+
+  const runOne = runner ?? execute;
+  const queue = []; // {planId, plan, finding, findingId, project, trigger, gateCtx, isBlocker, queuedAt}
+  let inFlight = 0;
+  let draining = false;
+
+  const ledgerLog = async (entry) => {
+    if (!ledger) return;
+    try {
+      await appendLedgerBestEffort(ledger, now(), entry);
+    } catch {
+      /* best-effort */
+    }
+  };
+
+  // resolve.json is an append-per-execution entries array (verdicts-mirrored):
+  // one row per plan execution {planId, class, findingId, confidence,
+  // calibration, effective, tau, trigger, outcome: resolved|escalated,
+  // attempts, cost, reason, undo, refs, ts} + resolution fold bookkeeping on
+  // the resolved row (successFoldedAt / failureFoldedAt + foldReason) so the
+  // §9.5 7-day window survives restarts. Per-plan STATE (the attempt cap, the
+  // pending window) is derived by scanning rows — the cap therefore never
+  // re-arms on a re-triage.
+  const SOFT_ROW_CAP = 500;
+  const loadRows = async () => {
+    if (!store) return [];
+    try {
+      const payload = await store.load();
+      return Array.isArray(payload?.entries) ? payload.entries : [];
+    } catch {
+      return [];
+    }
+  };
+  const patchRows = async (fn) => {
+    if (!store) return;
+    try {
+      await patchStore(store, (fresh) => {
+        const rows = Array.isArray(fresh?.entries) ? fresh.entries : [];
+        return { entries: fn(rows.slice()) ?? rows };
+      });
+    } catch {
+      /* best-effort */
+    }
+  };
+  const executionsOf = (rows, planId) => rows.filter((r) => r?.planId === planId).length;
+
+  // The negative-verdict scan for a pending resolution: any correct/dismiss/
+  // veto verdict on the plan subject AFTER resolution time.
+  const NEGATIVE = new Set(["correct", "dismiss", "veto"]);
+  async function hasNegativeVerdict(planId, sinceMs) {
+    try {
+      const rows = await verdictsList();
+      return (Array.isArray(rows) ? rows : []).some(
+        (r) =>
+          r?.subject?.id === planId &&
+          NEGATIVE.has(r?.verdict) &&
+          (typeof r?.ts === "number" ? r.ts >= sinceMs : false),
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  // §9.5 fold: mark the resolved row final + feed calibration. The mutation
+  // keeps ONE row per execution; the fold fields are bookkeeping, not a new
+  // entry.
+  async function foldOutcome(row, ok, reason) {
+    const stamp = now();
+    await patchRows((rows) => {
+      const i = rows.indexOf(row);
+      if (i === -1) return rows;
+      rows[i] = {
+        ...row,
+        ...(ok ? { successFoldedAt: stamp } : { failureFoldedAt: stamp }),
+        foldReason: reason ?? null,
+      };
+      return rows;
+    });
+    try {
+      await calibration?.({ planId: row.planId, class: row.class, ok });
+    } catch {
+      /* calibration is best-effort — the row above is the record */
+    }
+    await ledgerLog({ kind: "calibrate.outcome", class: row?.class ?? null, planId: row?.planId ?? null, ok: ok === true, reason: reason ?? null });
+  }
+
+  // One queued execution, run to completion. Never throws (a throw is an
+  // interrupt: escalate with outcome escalated per §9.4 — the run is never
+  // silently lost).
+  async function runQueued(entry) {
+    const { planId, plan, finding, findingId, trigger, gateCtx } = entry;
+    let res;
+    try {
+      res = await runOne({ plan, finding, project: entry.project, trigger, gateCtx });
+    } catch (e) {
+      res = { ok: true, outcome: "escalated", attempts: 1, cost: 0, reason: `interrupt:${e?.message ?? "unknown"}`, result: null };
+    }
+    const outcome = res?.outcome ?? "escalated";
+    const class_ = typeof plan?.class === "string" ? plan.class : "other";
+    const row = {
+      planId,
+      class: class_,
+      findingId: findingId ?? null,
+      confidence: typeof plan?.confidence === "number" ? plan.confidence : null,
+      calibration: typeof gateCtx?.calibration === "number" ? gateCtx.calibration : null,
+      effective: typeof gateCtx?.effective === "number" ? gateCtx.effective : null,
+      tau: typeof gateCtx?.tau === "number" ? gateCtx.tau : null,
+      trigger: trigger ?? "act",
+      outcome,
+      attempts: res?.attempts ?? null,
+      cost: res?.cost ?? null,
+      reason: res?.reason ?? null,
+      undo: typeof plan?.undo === "string" ? plan.undo : null,
+      refs: Array.isArray(plan?.finding?.refs) ? plan.finding.refs : (Array.isArray(finding?.refs) ? finding.refs : []),
+      ts: now(),
+      ...(outcome === "resolved" ? { resolvedAt: now() } : {}),
+    };
+    // §9.4-9.5: every execution writes ONE cto.resolve ledger entry (the
+    // store row itself is kind-less; the ledger copy carries the kind).
+    await ledgerLog({ kind: "cto.resolve", ...row });
+    await patchRows((rows) => {
+      // An escalated row closes any still-open pending window (its failure
+      // already folded); keep one row per execution, newest-capped.
+      const closed = rows.map((r) =>
+        r?.planId === planId && r?.outcome === "resolved" && !r?.successFoldedAt && !r?.failureFoldedAt
+          ? { ...r, failureFoldedAt: r.ts, foldReason: "superseded-by-escalation" }
+          : r,
+      );
+      closed.push(row);
+      return closed.length > SOFT_ROW_CAP ? closed.slice(closed.length - SOFT_ROW_CAP) : closed;
+    });
+    if (outcome === "resolved") {
+      // §9.5: success is DEFERRED — resolved + no negative verdict within the
+      // 7-day window (the driver's tick folds it).
+    } else {
+      // escalated → immediate failure + the human blocker card with the log
+      try {
+        await calibration?.({ planId, class: class_, ok: false });
+      } catch {
+        /* best-effort */
+      }
+      await ledgerLog({ kind: "calibrate.outcome", class: class_, planId, ok: false, reason: res?.reason ?? "escalated" });
+      const log = res?.result
+        ? `steps: ${JSON.stringify(plan?.steps ?? []).slice(0, 400)}; result: ${String(res.result.lastText ?? "").slice(0, 400)}`
+        : "";
+      await escalate?.(
+        `CTO executor escalated plan ${planId} (${class_}) after ${res?.attempts ?? "?"} attempt(s). Verification failed: ${res?.reason ?? "unknown"}. ${log}`,
+      );
+    }
+  }
+
+  // Drain: take queue entries while slots are free; blockers first.
+  async function drain() {
+    if (draining) return;
+    draining = true;
+    try {
+      while (queue.length > 0 && inFlight < maxInFlight) {
+        // blocker-before-finding, then FIFO
+        let idx = queue.findIndex((e) => e.isBlocker);
+        if (idx === -1) idx = 0;
+        const entry = queue.splice(idx, 1)[0];
+        inFlight += 1;
+        runQueued(entry)
+          .catch(() => {})
+          .finally(() => {
+            inFlight -= 1;
+            drain().catch(() => {});
+          });
+      }
+    } finally {
+      draining = false;
+    }
+  }
+
+  /** The gate/accepted seam: validate → cap → enqueue → drain. */
+  async function executePlan(plan, ctx = {}) {
+    const { findingId = null, finding = null, project = null, trigger = "act", gateCtx = null } = ctx;
+    const v = validatePlan(plan);
+    if (!v.ok) return { ok: false, reason: v.reason };
+    const planId = v.plan.id;
+    const rows = await loadRows();
+    if (executionsOf(rows, planId) >= EXECUTIONS_PER_PLAN) {
+      // Cap-hit refusal degrades to ask, never acts.
+      return { ok: false, reason: "cap-hit" };
+    }
+    if (queue.length >= queueMax) {
+      return { ok: false, reason: "queue-full" };
+    }
+    const isBlocker =
+      finding?.kind === "blocker" || finding?.sourceKind === "blocker" || finding?.noteKind === "blocker";
+    queue.push({ planId, plan: v.plan, finding, findingId, project, trigger, gateCtx, isBlocker, queuedAt: now() });
+    await drain();
+    return { ok: true, queued: true, planId };
+  }
+
+  /**
+   * The user accepted this plan on a decision card ("Do it") — same executor,
+   * trigger "accepted", plus the §9.2 digest announcement.
+   */
+  async function executeAccepted(plan, ctx = {}) {
+    const res = await executePlan(plan, { ...ctx, trigger: "accepted" });
+    if (res?.ok) {
+      const cls = typeof plan?.class === "string" ? plan.class : "other";
+      try {
+        await recordAct?.({
+          cls,
+          text: plan?.finding?.text ?? plan?.diagnosis ?? "",
+          refs: Array.isArray(plan?.finding?.refs) ? plan.finding.refs : [],
+          action: { type: "plan", payload: { planId: plan?.id } },
+          score: typeof ctx?.gateCtx?.effective === "number" ? ctx.gateCtx.effective : null,
+        });
+      } catch {
+        /* best-effort */
+      }
+    }
+    return res;
+  }
+
+  /**
+   * The engine's tick: fold due pending resolutions (§9.5) + drain. Returns
+   * {resolved: N} for tests.
+   */
+  async function tick() {
+    let resolved = 0;
+    const rows = await loadRows();
+    const t = now();
+    for (const row of rows) {
+      if (!row?.resolvedAt || row?.successFoldedAt || row?.failureFoldedAt) continue;
+      if (t - row.resolvedAt >= RESOLUTION_WINDOW_MS) {
+        const negative = await hasNegativeVerdict(row.planId, row.resolvedAt);
+        await foldOutcome(row, !negative, negative ? "negative-verdict-in-window" : null);
+        resolved += 1;
+        continue;
+      }
+      // A negative verdict inside the window resolves immediately as failure.
+      if (await hasNegativeVerdict(row.planId, row.resolvedAt)) {
+        await foldOutcome(row, false, "negative-verdict-in-window");
+        resolved += 1;
+      }
+    }
+    await drain();
+    return { resolved };
+  }
+
+  /** Test/introspection: the queue depth and the in-flight count. */
+  function state() {
+    return { queueDepth: queue.length, inFlight };
+  }
+
+  /** Did this plan id ever exist as a plan subject? (verdict-fold deferral) */
+  async function planSubjectKnown(planId) {
+    if (typeof knowsPlan === "function") {
+      try {
+        if ((await knowsPlan(planId)) === true) return true;
+      } catch {
+        /* fall through to the store */
+      }
+    }
+    const rows = await loadRows();
+    return rows.some((r) => r?.planId === planId);
+  }
+
+  return { executePlan, executeAccepted, tick, state, planSubjectKnown, _queue: queue };
 }

--- a/src/server/ctoAct.test.mjs
+++ b/src/server/ctoAct.test.mjs
@@ -485,6 +485,73 @@ test("driver: invalid plans are refused, never executed or ledgered", async () =
   assert.deepEqual(f.state.ledgerRows, []);
 });
 
+test("driver: §9.4 presence — finding-sourced acts refuse while present; blockers, accepted and away all run", async () => {
+  const f = fakeDriverDeps({ runnerResults: [] });
+  let presenceState = "present";
+  f.deps.presence = async () => presenceState;
+  const d = createCtoExecutorDriver(f.deps);
+  // finding-sourced machine act while present → refused, nothing queued/run
+  const r1 = await d.executePlan(basePlan({ id: "pl-pres" }), { finding: { kind: "finding" } });
+  assert.equal(r1.ok, false);
+  assert.equal(r1.reason, "presence-gated");
+  await settle(5);
+  assert.equal((await f.state.store.load()).entries.length, 0);
+  assert.deepEqual(f.state.ledgerRows, []);
+  // blocker-sourced runs regardless of presence (the ONLY §9.4 exemption)
+  presenceState = "present";
+  const r2 = await d.executePlan(basePlan({ id: "pl-blocker" }), { finding: { kind: "blocker" } });
+  assert.equal(r2.ok, true);
+  // user-accepted plans are user-initiated → bypass presence
+  const r3 = await d.executePlan(basePlan({ id: "pl-accepted" }), { trigger: "accepted" });
+  assert.equal(r3.ok, true);
+  await settle(10);
+  // away → the finding act runs
+  presenceState = "away";
+  const r4 = await d.executePlan(basePlan({ id: "pl-away" }), { finding: { kind: "finding" } });
+  assert.equal(r4.ok, true);
+  await settle(10);
+  const rows = (await f.state.store.load()).entries;
+  assert.deepEqual(
+    rows.map((r) => r.planId).sort(),
+    ["pl-accepted", "pl-away", "pl-blocker"],
+  );
+  // a presence-read failure must not block machine work — run
+  const g = fakeDriverDeps({ runnerResults: [] });
+  g.deps.presence = async () => {
+    throw new Error("presence down");
+  };
+  const d2 = createCtoExecutorDriver(g.deps);
+  const r5 = await d2.executePlan(basePlan({ id: "pl-pres-err" }), { finding: { kind: "finding" } });
+  assert.equal(r5.ok, true);
+});
+
+test("runner: a delegate job still running at the turn budget escalates instead of interleaving the retry", async () => {
+  const sends = [];
+  const started = [];
+  const execute = createCtoPlanRunner({
+    resolveParent: async () => ({ parentSessionID: "par-1", parentDirectory: "/srv/app" }),
+    startJob: async (input) => {
+      started.push(input);
+      return { ok: true, job: { id: "job-9" } };
+    },
+    // the job never finishes within the tiny test budget
+    jobRow: async () => ({ running: true, sessionId: "child-9", status: "running" }),
+    sendPrompt: async ({ text }) => {
+      sends.push(text);
+      return { ok: true };
+    },
+    listMessages: async () => [],
+    sleep: async () => {},
+    now: (() => { let t = 0; return () => (t += 500); })(), // each poll burns the budget
+    turnBudgetMs: 1000,
+  });
+  const res = await execute({ plan: basePlan({ access: [{ permission: "write", pattern: "**" }], verify: { kind: "session-ok" } }) });
+  assert.equal(res.outcome, "escalated");
+  assert.ok((res.reason ?? "").includes("job-still-running-at-budget"));
+  assert.equal(res.attempts, 1, "the retry never got a turn");
+  assert.equal(sends.length, 0, "no retry prompt was delivered into the running job");
+});
+
 test("driver: a runner THROW is an interrupt — escalated with the interrupt reason, never lost", async () => {
   const f = fakeDriverDeps({ runner: async () => { throw new Error("provider died"); } });
   const d = createCtoExecutorDriver(f.deps);

--- a/src/server/ctoAct.test.mjs
+++ b/src/server/ctoAct.test.mjs
@@ -1,290 +1,509 @@
+// BET-1519 — §9.4 the ONE generic plan executor + driver: the brief, the
+// session-kind selection, the §9.2 verify dispatch, the one-retry loop, the
+// resolve rows, the queue (blocker-before-finding, ≤ 2 in flight), the
+// two-executions-per-plan cap, the escalations and the §9.5 outcome folding.
+
 // BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
 import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
-  createCtoActExecutor,
-  normalizeQueueTonightPayload,
-  normalizeRecordDecisionPayload,
-  normalizeStartJobPayload,
+  buildExecutionBrief,
+  buildRetryBrief,
+  checkMarkerResult,
+  createCtoExecutorDriver,
+  createCtoPlanRunner,
+  CHECK_MARKER,
+  EXECUTIONS_PER_PLAN,
+  MAX_IN_FLIGHT,
+  permissionRulesetFor,
+  runVerifyCheck,
+  validatePlan,
+  wantsDelegateSession,
 } from "./ctoAct.mjs";
-import { ACTOR } from "./ctoEngine.mjs";
+import { patchStore } from "./ctoStores.mjs";
 
 // ---------------------------------------------------------------------------
-// Payload normalization (§9.1 schema → typed executor input)
+// Memory store (the resolve.json shape — {entries: []}) + fakes
 // ---------------------------------------------------------------------------
 
-test("normalizeRecordDecisionPayload: statement/project/refs required; refs fall back to the finding", () => {
-  assert.deepEqual(
-    normalizeRecordDecisionPayload({ statement: " Adopt pact ", project: " manta ", refs: ["msg:1", 5, "msg:2"] }),
-    { statement: "Adopt pact", project: "manta", refs: ["msg:1", "msg:2"] },
-  );
-  assert.deepEqual(
-    normalizeRecordDecisionPayload({ statement: "s", project: "p" }, { findingRefs: ["ref:9"] }),
-    { statement: "s", project: "p", refs: ["ref:9"] },
-  );
-  assert.equal(normalizeRecordDecisionPayload({ statement: "s", project: "p" }), null);
-  assert.equal(normalizeRecordDecisionPayload({ statement: "s", refs: ["r"] }), null);
-  assert.equal(normalizeRecordDecisionPayload({ project: "p", refs: ["r"] }), null);
-  assert.equal(normalizeRecordDecisionPayload(null), null);
-});
-
-test("normalizeStartJobPayload: prompt+cwd required; model passes through in either valid shape", () => {
-  assert.deepEqual(normalizeStartJobPayload({ prompt: "Run the sweep", cwd: "/srv/app" }), {
-    prompt: "Run the sweep",
-    cwd: "/srv/app",
-  });
-  // the renderer's ask-path spells the directory `directory` — accepted as an alias
-  assert.deepEqual(normalizeStartJobPayload({ prompt: "p", directory: "/srv/app" }), { prompt: "p", cwd: "/srv/app" });
-  assert.deepEqual(normalizeStartJobPayload({ prompt: "p", cwd: "/srv/app", model: " opus " }), {
-    prompt: "p",
-    cwd: "/srv/app",
-    model: "opus",
-  });
-  assert.deepEqual(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: { providerID: "anthropic", modelID: "claude", variant: "v" } }), {
-    prompt: "p",
-    cwd: "c",
-    model: { providerID: "anthropic", modelID: "claude", variant: "v" },
-  });
-  assert.deepEqual(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: { providerID: "a", modelID: "m" } }), {
-    prompt: "p",
-    cwd: "c",
-    model: { providerID: "a", modelID: "m" },
-  });
-  // a present-but-invalid model refuses the whole act (never silently dropped)
-  assert.equal(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: 7 }), null);
-  assert.equal(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: ["opus"] }), null);
-  assert.equal(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: "" }), null);
-  assert.equal(normalizeStartJobPayload({ prompt: "p", cwd: "c", model: { providerID: "a" } }), null);
-  assert.equal(normalizeStartJobPayload({ prompt: "", cwd: "c" }), null);
-  assert.equal(normalizeStartJobPayload({ prompt: "p" }), null);
-  assert.equal(normalizeStartJobPayload(null), null);
-});
-
-test("normalizeQueueTonightPayload: name falls back to the finding text; cost is the predictedCost alias", () => {
-  assert.deepEqual(
-    normalizeQueueTonightPayload(
-      { name: "Nightly sweep", prompt: "Sweep it", project: "/srv/app", value: 2, confidence: 0.9, cost: 3, refs: ["a", 1] },
-      { findingText: "ignored when a name exists" },
-    ),
-    { name: "Nightly sweep", prompt: "Sweep it", project: "/srv/app", value: 2, confidence: 0.9, predictedCost: 3, refs: ["a"] },
-  );
-  assert.deepEqual(
-    normalizeQueueTonightPayload({ predictedCost: 1.5 }, { findingText: "Build failures recurred" }),
-    { name: "Build failures recurred", predictedCost: 1.5 },
-  );
-  // non-finite numbers and junk project shapes are dropped, not refused
-  assert.deepEqual(
-    normalizeQueueTonightPayload({ name: "n", value: "high", confidence: NaN, project: 42 }, {}),
-    { name: "n" },
-  );
-  assert.equal(normalizeQueueTonightPayload({}, { findingText: "" }), null);
-  assert.equal(normalizeQueueTonightPayload(null, {}), null);
-});
-
-// ---------------------------------------------------------------------------
-// The executor — refusal contract + wired paths
-// ---------------------------------------------------------------------------
-
-function makeDeps(overrides = {}) {
-  const calls = { proposeFact: [], tonightAdd: [], beginDelegateJob: 0, startDelegateJob: [], gateReleased: 0 };
-  const deps = {
-    proposeFact: async (input) => {
-      calls.proposeFact.push(input);
-      return { ok: true };
+function memoryStore(initial = {}) {
+  let data = { ...initial };
+  return {
+    load: async () => ({ ...data }),
+    save: async (next) => {
+      data = { ...next };
     },
-    tonightAdd: async (task) => {
-      calls.tonightAdd.push(task);
-      return { ok: true, task: { id: "tq:1" } };
-    },
-    beginDelegateJob: async () => {
-      calls.beginDelegateJob += 1;
-      return { ok: true, release: () => (calls.gateReleased += 1) };
-    },
-    listProjects: async () => [
-      { tmuxSession: "app", defaultCwd: "/srv/app", windows: [{ opencodeSessionId: "ses-1", paneCurrentPath: "/srv/app" }] },
-    ],
-    startDelegateJob: async (input) => {
-      calls.startDelegateJob.push(input);
-      return { ok: true, job: { id: "job-9" } };
-    },
-    listDelegateJobs: async () => [],
-    ...overrides,
   };
-  return { deps, calls };
 }
 
-// The canonical §3.3 start-job probe: plain finding candidate, tracked cwd.
-async function runStartJobProbe(deps) {
-  const exec = createCtoActExecutor(deps);
-  return exec({
-    cls: "start-job",
-    action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } },
-    candidate: { finding: { text: "f", refs: [] } },
-  });
+const basePlan = (over = {}) => ({
+  id: "pl1",
+  class: "start-job",
+  confidence: 0.9,
+  finding: { text: "stale cache after deploy", refs: ["m1"] },
+  diagnosis: "the cache is not invalidated",
+  steps: ["Invalidate the cache", "Re-run the deploy check"],
+  access: [],
+  verify: { kind: "session-ok" },
+  undo: "re-run the deploy",
+  ...over,
+});
+
+// A runner whose transcript "work" is canned: each sendPrompt call resolves
+// the next turn's last-assistant text and passes/fails verification via the
+// scripted checks.
+function fakeRunnerSeams({ texts = [], checks = null, startRefusal = null, latency = 0 } = {}) {
+  let turn = 0;
+  const sends = [];
+  const sessions = [];
+  let deleted = 0;
+  return {
+    state: { sends, sessions, get deleted() { return deleted; } },
+    deps: {
+      createSession: async ({ directory, title, permission } = {}) => {
+        if (startRefusal) return { ok: false, reason: startRefusal };
+        const id = `sess-${sessions.length + 1}`;
+        sessions.push({ id, directory, title, permission });
+        return { ok: true, id };
+      },
+      sendPrompt: async ({ sessionId, text }) => {
+        sends.push({ sessionId, text });
+        turn += 1;
+        return { ok: true };
+      },
+      listMessages: async () => {
+        const text = texts[Math.min(turn, texts.length) - 1] ?? `turn ${turn}`;
+        return [{ role: "user", parts: [{ type: "text", text: "go" }] }, { role: "assistant", parts: [{ type: "text", text }] }];
+      },
+      abortSession: async () => ({ ok: true }),
+      deleteSession: async () => {
+        deleted += 1;
+        return { ok: true };
+      },
+      verifyFact: checks?.verifyFact,
+      probeRead: checks?.probeRead,
+      conditionGone: checks?.conditionGone,
+      sleep: async () => {},
+      turnBudgetMs: 1000,
+    },
+  };
 }
 
-test("executor: record-decision proposes the gatekeeper-checked fact (behavior carried over from BET-1403)", async () => {
-  const { deps, calls } = makeDeps();
-  const exec = createCtoActExecutor(deps);
-  const out = await exec({
-    cls: "record-decision",
-    action: { type: "record-decision", payload: { statement: "Adopt pact", project: "manta" } },
-    candidate: { id: "cand-1", finding: { text: "f", refs: ["ref:1"] } },
-  });
-  assert.deepEqual(out, { ok: true, detail: "decision fact proposed" });
-  assert.deepEqual(calls.proposeFact, [{ project: "manta", kind: "decision", statement: "Adopt pact", refs: ["ref:1"], sender: "cto" }]);
-});
+function fakeDriverDeps({ runnerResults = null, runner = null } = {}) {
+  const ledgerRows = [];
+  const escalations = [];
+  const calibrations = [];
+  const acts = [];
+  const store = memoryStore({ entries: [] });
+  return {
+    state: { ledgerRows, escalations, calibrations, acts, store },
+    deps: {
+      runner:
+        runner ??
+        (async () => {
+          const r = (runnerResults ?? []).shift() ?? { ok: true, outcome: "resolved", attempts: 1, cost: 42, reason: null, result: { kind: "ephemeral", lastText: "done" } };
+          return r;
+        }),
+      store,
+      ledger: { append: async (row) => ledgerRows.push(row) },
+      escalate: async (text) => escalations.push(text),
+      calibration: async (input) => calibrations.push(input),
+      recordAct: async (input) => acts.push(input),
+      verdictsList: async () => [],
+      now: () => 1_000_000,
+      sleep: async () => {},
+    },
+  };
+}
 
-test("executor: record-decision refusal surfaces the fact route's error", async () => {
-  const { deps } = makeDeps({ proposeFact: async () => ({ ok: false, error: "gatekeeper refused" }) });
-  const exec = createCtoActExecutor(deps);
-  const out = await exec({
-    cls: "record-decision",
-    action: { type: "record-decision", payload: { statement: "s", project: "p", refs: ["r"] } },
-    candidate: { finding: { text: "f", refs: [] } },
-  });
-  assert.deepEqual(out, { ok: false, reason: "gatekeeper refused" });
-});
+// Let the driver's fire-and-forget runs actually settle (several awaits deep
+// — a bare setImmediate is not enough).
+const settle = (ms = 50) => new Promise((r) => setTimeout(r, ms));
 
-test("executor: queue-tonight adds the normalized task bound to the suggestion (cls + originId)", async () => {
-  const { deps, calls } = makeDeps();
-  const exec = createCtoActExecutor(deps);
-  const out = await exec({
-    cls: "queue-tonight",
-    action: { type: "queue-tonight", payload: { name: "Nightly sweep", prompt: "Sweep it", project: "/srv/app", cost: 2 } },
-    candidate: { id: "cand-2", finding: { text: "f", refs: ["ref:2"] } },
+// ---------------------------------------------------------------------------
+// validatePlan / session-kind / ruleset
+// ---------------------------------------------------------------------------
+
+test("validatePlan: steps required, verify kind known, access normalized", () => {
+  assert.equal(validatePlan(null).ok, false);
+  assert.equal(validatePlan({}).reason, "invalid-plan:id");
+  assert.equal(validatePlan({ id: "p" }).reason, "invalid-plan:steps");
+  assert.equal(validatePlan({ id: "p", steps: ["a"] }).reason, "invalid-plan:verify:missing");
+  assert.equal(validatePlan({ id: "p", steps: ["a"], verify: { kind: "predicate" } }).reason, "invalid-plan:verify:condition");
+  const ok = validatePlan({
+    id: " p ",
+    steps: [" a ", "", 3],
+    access: [{ permission: " write ", pattern: "**" }, { permission: "read", action: "bogus" }],
+    verify: { kind: "predicate", condition: "CI on F is green" },
   });
-  assert.deepEqual(out, { ok: true, detail: "queued for tonight", taskId: "tq:1" });
-  assert.deepEqual(calls.tonightAdd, [
-    { name: "Nightly sweep", prompt: "Sweep it", project: "/srv/app", predictedCost: 2, refs: ["ref:2"], cls: "queue-tonight", originId: "cand-2" },
+  assert.equal(ok.ok, true);
+  assert.deepEqual(ok.plan.steps, ["a", "3"]);
+  assert.deepEqual(ok.plan.access, [
+    { permission: "write", pattern: "**", action: "allow" },
+    { permission: "read", pattern: "*", action: "allow" },
   ]);
 });
 
-test("executor: queue-tonight refusal carries tonightAdd's own gate error (overnight off, queue full)", async () => {
-  for (const error of ["overnight is not enabled (High tier + Overnight switch)", "tonight's queue is full (12) — cancel or edit first"]) {
-    const { deps } = makeDeps({ tonightAdd: async () => ({ ok: false, error }) });
-    const exec = createCtoActExecutor(deps);
-    const out = await exec({
-      cls: "queue-tonight",
-      action: { type: "queue-tonight", payload: { name: "n" } },
-      candidate: { finding: { text: "f", refs: [] } },
-    });
-    assert.deepEqual(out, { ok: false, reason: error });
-  }
+test("wantsDelegateSession: write/edit access → delegate job; else ephemeral", () => {
+  assert.equal(wantsDelegateSession([{ permission: "read" }]), false);
+  assert.equal(wantsDelegateSession([{ permission: "write", pattern: "**" }]), true);
+  assert.equal(wantsDelegateSession([{ permission: "edit", pattern: "src/**" }]), true);
+  assert.equal(wantsDelegateSession([]), false);
 });
 
-test("executor: start-job starts a worktree-isolated delegate job as actor cto under the §3.3 gate", async () => {
-  const { deps, calls } = makeDeps();
-  const exec = createCtoActExecutor(deps);
-  const out = await exec({
-    cls: "start-job",
-    action: { type: "start-job", payload: { prompt: "Investigate flaky tests", cwd: "/srv/app", model: "opus" } },
-    candidate: { finding: { text: "f", refs: [] } },
+test("permissionRulesetFor: catch-all deny first, plan grants after (last-match-wins)", () => {
+  const rs = permissionRulesetFor([{ permission: "write", pattern: "**" }]);
+  assert.deepEqual(rs[0], { permission: "*", pattern: "**", action: "deny" });
+  assert.deepEqual(rs[1], { permission: "write", pattern: "**", action: "allow" });
+});
+
+// ---------------------------------------------------------------------------
+// The brief
+// ---------------------------------------------------------------------------
+
+test("buildExecutionBrief: finding, diagnosis, steps, undo, project and the exact marker line", () => {
+  const brief = buildExecutionBrief(basePlan(), { finding: { text: "boom on boot" }, project: "manta" });
+  assert.ok(brief.includes("## Finding"));
+  assert.ok(brief.includes("boom on boot"));
+  assert.ok(brief.includes("## Diagnosis"));
+  assert.ok(brief.includes("the cache is not invalidated"));
+  assert.ok(brief.includes("1. Invalidate the cache"));
+  assert.ok(brief.includes("2. Re-run the deploy check"));
+  assert.ok(brief.includes("## Undo"));
+  assert.ok(brief.includes("re-run the deploy"));
+  assert.ok(brief.includes("Project: manta"));
+  assert.ok(brief.includes(`\`${CHECK_MARKER} pass\``));
+  // delegate flavor for write-access plans
+  const del = buildExecutionBrief(basePlan({ access: [{ permission: "write", pattern: "**" }] }));
+  assert.ok(del.includes("isolated git worktree"));
+  const eph = buildExecutionBrief(basePlan());
+  assert.ok(eph.includes("read-only ephemeral session"));
+});
+
+test("buildRetryBrief: names the failed check and repeats the marker contract", () => {
+  const r = buildRetryBrief(basePlan(), { reason: "predicate-false", detail: "CI red" });
+  assert.ok(r.includes("predicate-false"));
+  assert.ok(r.includes("CI red"));
+  assert.ok(r.includes(`${CHECK_MARKER} pass`));
+});
+
+// ---------------------------------------------------------------------------
+// Verify dispatch (§9.2 kinds)
+// ---------------------------------------------------------------------------
+
+test("runVerifyCheck: session-ok reads the CHECK marker; missing marker fails", async () => {
+  assert.equal(checkMarkerResult(`did it\n${CHECK_MARKER} pass`).ok, true);
+  const fail = checkMarkerResult(`${CHECK_MARKER} fail: cache still stale`);
+  assert.equal(fail.ok, false);
+  assert.equal(fail.reason, "session-reported-fail");
+  assert.equal(fail.detail, "cache still stale");
+  assert.equal(checkMarkerResult("all done").reason, "no-check-marker");
+  const plan = basePlan({ verify: { kind: "session-ok" } });
+  assert.equal((await runVerifyCheck(plan, { lastText: `ok ${CHECK_MARKER} pass` })).ok, true);
+  assert.equal((await runVerifyCheck(plan, { lastText: "no marker" })).ok, false);
+});
+
+test("runVerifyCheck: predicate dispatches through the fact verifier; not-checkable/unavailable fail", async () => {
+  const plan = basePlan({ verify: { kind: "predicate", condition: "CI on F is green" } });
+  const ok = await runVerifyCheck(plan, { verifyFact: async () => ({ ok: true }) });
+  assert.equal(ok.ok, true);
+  const no = await runVerifyCheck(plan, { verifyFact: async () => ({ ok: false, reason: "predicate-false" }) });
+  assert.equal(no.ok, false);
+  assert.equal(no.reason, "predicate-false");
+  // a no-opinion (null) seam is a FAIL, never a silent pass
+  const unavailable = await runVerifyCheck(plan, { verifyFact: null });
+  assert.equal(unavailable.ok, false);
+  assert.equal(unavailable.reason, "verify-unavailable");
+});
+
+test("runVerifyCheck: probe + condition-gone dispatch; condition-unverified (no opinion) fails", async () => {
+  const probe = basePlan({ verify: { kind: "probe", probe: "github/ci" } });
+  assert.equal((await runVerifyCheck(probe, { probeRead: async () => ({ ok: true }) })).ok, true);
+  const unhealthy = await runVerifyCheck(probe, { probeRead: async () => ({ ok: false, reason: "probe-unhealthy" }) });
+  assert.equal(unhealthy.ok, false);
+  assert.equal(unhealthy.reason, "probe-unhealthy");
+
+  const cond = basePlan({ verify: { kind: "condition-gone", condition: "the deploy fails" } });
+  assert.equal((await runVerifyCheck(cond, { conditionGone: async () => true })).ok, true);
+  const still = await runVerifyCheck(cond, { conditionGone: async () => false });
+  assert.equal(still.ok, false);
+  assert.equal(still.reason, "condition-still-present");
+  const unsure = await runVerifyCheck(cond, { conditionGone: async () => null });
+  assert.equal(unsure.ok, false);
+  assert.equal(unsure.reason, "condition-unverified");
+});
+
+// ---------------------------------------------------------------------------
+// The runner: session kind, retry loop, escalations
+// ---------------------------------------------------------------------------
+
+test("runner: ephemeral plan resolves when the session leaves the pass marker", async () => {
+  const f = fakeRunnerSeams({ texts: [`done\n${CHECK_MARKER} pass`] });
+  const execute = createCtoPlanRunner(f.deps);
+  const res = await execute({ plan: basePlan(), finding: { text: "boom" } });
+  assert.equal(res.ok, true);
+  assert.equal(res.outcome, "resolved");
+  assert.equal(res.attempts, 1);
+  assert.equal(res.result.kind, "ephemeral");
+  assert.equal(f.state.sessions.length, 1);
+  assert.equal(f.state.sends.length, 1);
+  assert.ok(f.state.sends[0].text.includes("Invalidate the cache"));
+  // the ephemeral session is always cleaned up
+  assert.equal(f.state.deleted, 1);
+});
+
+test("runner: write-access plan routes through startJob with the plan access as tools and trustMode false", async () => {
+  const started = [];
+  const f = fakeRunnerSeams({});
+  const execute = createCtoPlanRunner({
+    ...f.deps,
+    resolveParent: async () => ({ parentSessionID: "par-1", parentDirectory: "/srv/app" }),
+    startJob: async (input) => {
+      started.push(input);
+      return { ok: true, job: { id: "job-1" } };
+    },
+    jobRow: async () => ({ running: false, sessionId: "child-1", status: "done" }),
+    listMessages: async () => [{ role: "assistant", parts: [{ type: "text", text: `${CHECK_MARKER} pass` }] }],
   });
-  assert.deepEqual(out, { ok: true, detail: "delegate job started", jobId: "job-9" });
-  assert.equal(calls.beginDelegateJob, 1);
-  assert.equal(calls.gateReleased, 1);
-  assert.deepEqual(calls.startDelegateJob, [
-    { prompt: "Investigate flaky tests", model: "opus", parentSessionID: "ses-1", parentDirectory: "/srv/app", actor: ACTOR },
-  ]);
+  const res = await execute({ plan: basePlan({ access: [{ permission: "write", pattern: "**" }] }) });
+  assert.equal(res.ok, true);
+  assert.equal(res.outcome, "resolved");
+  assert.equal(res.result.kind, "delegate");
+  assert.equal(started.length, 1);
+  assert.equal(started[0].trustMode, false);
+  assert.deepEqual(started[0].tools, [{ permission: "write", pattern: "**", action: "allow" }]);
+  assert.equal(started[0].parentSessionID, "par-1");
 });
 
-test("executor: start-job refuses at the §3.3 concurrent cto-delegate cap without arming the gate", async () => {
-  const { deps, calls } = makeDeps({
-    listDelegateJobs: async () => [
-      { id: "a", actor: ACTOR, status: "running" },
-      { id: "b", actor: ACTOR, status: "running" },
-      { id: "c", actor: "user", status: "running" },
+test("runner: no parent project → refused (never a silent no-op), ephemeral start failure refused", async () => {
+  const f = fakeRunnerSeams({});
+  const execute = createCtoPlanRunner({
+    ...f.deps,
+    resolveParent: async () => null,
+    startJob: async () => ({ ok: true, job: { id: "job-1" } }),
+  });
+  const res = await execute({ plan: basePlan({ access: [{ permission: "edit", pattern: "**" }] }) });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "no-project-session");
+
+  const g = fakeRunnerSeams({ startRefusal: "opencode-down" });
+  const execute2 = createCtoPlanRunner(g.deps);
+  const res2 = await execute2({ plan: basePlan() });
+  assert.equal(res2.ok, false);
+  assert.equal(res2.reason, "opencode-down");
+});
+
+test("runner: fail → exactly one retry with the failed check → resolved; fail again → escalated with the attempt log", async () => {
+  const f = fakeRunnerSeams({
+    texts: [`${CHECK_MARKER} fail: cache stale`, `fixed\n${CHECK_MARKER} pass`],
+    checks: { verifyFact: undefined },
+  });
+  const execute = createCtoPlanRunner(f.deps);
+  const res = await execute({ plan: basePlan({ verify: { kind: "session-ok" } }) });
+  assert.equal(res.outcome, "resolved");
+  assert.equal(res.attempts, 2);
+  assert.equal(f.state.sends.length, 2);
+  assert.ok(f.state.sends[1].text.includes("session-reported-fail"));
+
+  // both attempts fail → escalated, the reason carries BOTH check results
+  const g = fakeRunnerSeams({ texts: [`${CHECK_MARKER} fail: a`, `${CHECK_MARKER} fail: b`] });
+  const execute2 = createCtoPlanRunner(g.deps);
+  const res2 = await execute2({ plan: basePlan({ verify: { kind: "session-ok" } }) });
+  assert.equal(res2.outcome, "escalated");
+  assert.equal(res2.attempts, 2);
+  assert.ok((res2.reason ?? "").includes("attempt1"));
+  assert.ok((res2.reason ?? "").includes("attempt2"));
+});
+
+// ---------------------------------------------------------------------------
+// The driver: queue, cap, rows, outcomes, 7-day resolution
+// ---------------------------------------------------------------------------
+
+test("driver: every execution writes ONE complete cto.resolve row (§9.4-9.5 fields)", async () => {
+  const f = fakeDriverDeps({ runnerResults: [{ ok: true, outcome: "resolved", attempts: 2, cost: 777, reason: null, result: null }] });
+  const d = createCtoExecutorDriver(f.deps);
+  const r = await d.executePlan(basePlan(), {
+    findingId: "f9",
+    finding: { kind: "blocker", text: "boom", refs: ["m3"] },
+    gateCtx: { effective: 0.72, tau: 0.7, calibration: 0.8 },
+  });
+  assert.equal(r.ok, true);
+  // the queued run is fire-and-forget — flush the microtask queue
+  await settle();
+  const payload = await f.state.store.load();
+  assert.equal(payload.entries.length, 1);
+  const row = payload.entries[0];
+  assert.equal(row.planId, "pl1");
+  assert.equal(row.class, "start-job");
+  assert.equal(row.findingId, "f9");
+  assert.equal(row.confidence, 0.9);
+  assert.equal(row.calibration, 0.8);
+  assert.equal(row.effective, 0.72);
+  assert.equal(row.tau, 0.7);
+  assert.equal(row.trigger, "act");
+  assert.equal(row.outcome, "resolved");
+  assert.equal(row.attempts, 2);
+  assert.equal(row.cost, 777);
+  assert.equal(row.undo, "re-run the deploy");
+  assert.deepEqual(row.refs, ["m1"]);
+  assert.equal(typeof row.ts, "number");
+  assert.equal(typeof row.resolvedAt, "number");
+  // resolved → success DEFERRED (no fold yet)
+  assert.deepEqual(f.state.calibrations, []);
+  const ledger = f.state.ledgerRows.filter((x) => x.kind === "cto.resolve");
+  assert.equal(ledger.length, 1);
+});
+
+test("driver: escalated → immediate calibration failure + a blocker card carrying the attempt log", async () => {
+  const f = fakeDriverDeps({ runnerResults: [{ ok: true, outcome: "escalated", attempts: 2, cost: 10, reason: "attempt1:no-check-marker; attempt2:session-reported-fail", result: { kind: "ephemeral", lastText: "gave up" } }] });
+  const d = createCtoExecutorDriver(f.deps);
+  await d.executePlan(basePlan());
+  await settle();
+  assert.deepEqual(f.state.calibrations, [{ planId: "pl1", class: "start-job", ok: false }]);
+  assert.equal(f.state.escalations.length, 1);
+  assert.ok(f.state.escalations[0].includes("attempt1"));
+  assert.ok(f.state.escalations[0].includes("plan pl1"));
+});
+
+test("driver: the 7-day window — success with no negative verdict; a negative verdict in-window fails immediately", async () => {
+  // resolved now; 7 days pass; no negative verdicts → success
+  let t = 1_000_000;
+  const f = fakeDriverDeps({ runnerResults: [{ ok: true, outcome: "resolved", attempts: 1, cost: 5, reason: null, result: null }] });
+  f.deps.now = () => t;
+  const d = createCtoExecutorDriver(f.deps);
+  await d.executePlan(basePlan());
+  await settle();
+  t += 7 * 24 * 3_600_000 + 1;
+  const tick = await d.tick();
+  assert.equal(tick.resolved, 1);
+  assert.deepEqual(f.state.calibrations, [{ planId: "pl1", class: "start-job", ok: true }]);
+
+  // resolved then a correct verdict inside the window → immediate failure
+  let t2 = 2_000_000;
+  const g = fakeDriverDeps({ runnerResults: [{ ok: true, outcome: "resolved", attempts: 1, cost: 5, reason: null, result: null }] });
+  g.deps.now = () => t2;
+  g.deps.verdictsList = async () => [{ subject: { type: "suggestion", id: "pl1" }, verdict: "correct", ts: t2 + 100 }];
+  const d2 = createCtoExecutorDriver(g.deps);
+  await d2.executePlan(basePlan());
+  await settle();
+  await d2.tick();
+  assert.deepEqual(g.state.calibrations, [{ planId: "pl1", class: "start-job", ok: false }]);
+  const rows = (await g.state.store.load()).entries;
+  assert.equal(rows[0].failureFoldedAt != null, true);
+});
+
+test("driver: two executions per plan id EVER — a re-triage cannot re-arm the cap; cap-hit refuses and never acts", async () => {
+  const f = fakeDriverDeps({
+    runnerResults: [
+      { ok: true, outcome: "resolved", attempts: 1, cost: 1, reason: null, result: null },
+      { ok: true, outcome: "escalated", attempts: 2, cost: 2, reason: "failed twice", result: null },
     ],
   });
-  const out = await runStartJobProbe(deps);
-  assert.equal(out.ok, false);
-  assert.equal(out.reason, "rate_limit:concurrentDelegate");
-  assert.equal(calls.beginDelegateJob, 0);
-  assert.equal(calls.startDelegateJob.length, 0);
+  const d = createCtoExecutorDriver(f.deps);
+  assert.equal((await d.executePlan(basePlan())).ok, true);
+  await settle();
+  // the plan is RE-REPORTED and re-triaged: the same plan id executes once more
+  assert.equal((await d.executePlan(basePlan(), { trigger: "accepted" })).ok, true);
+  await settle();
+  // third execution → cap-hit refusal (degrades to ask, never acts)
+  const third = await d.executePlan(basePlan());
+  assert.equal(third.ok, false);
+  assert.equal(third.reason, "cap-hit");
+  const rows = (await f.state.store.load()).entries;
+  assert.equal(rows.filter((r) => r.planId === "pl1").length, 2);
+  assert.equal(rows.filter((r) => r.planId === "pl1").length <= EXECUTIONS_PER_PLAN, true);
 });
 
-test("executor: start-job refuses when no tracked project session hosts the cwd (gate never armed)", async () => {
-  const { deps, calls } = makeDeps({ listProjects: async () => [] });
-  const exec = createCtoActExecutor(deps);
-  const out = await exec({
-    cls: "start-job",
-    action: { type: "start-job", payload: { prompt: "p", cwd: "/elsewhere" } },
-    candidate: { finding: { text: "f", refs: [] } },
+test("driver: queue caps at 10, blocker plans jump ahead of finding plans, ≤ 2 run at once", async () => {
+  // A runner gated on a released promise so the queue state is deterministic.
+  let release = null;
+  const gate = new Promise((r) => (release = r));
+  let started = 0;
+  const f = fakeDriverDeps({
+    runner: async () => {
+      started += 1;
+      await gate;
+      return { ok: true, outcome: "resolved", attempts: 1, cost: 1, reason: null, result: null };
+    },
   });
-  assert.deepEqual(out, { ok: false, reason: "no-project-session" });
-  assert.equal(calls.beginDelegateJob, 0);
+  const d = createCtoExecutorDriver(f.deps);
+  // 2 fill the in-flight slots; 10 more fill the queue; the 13th is refused.
+  for (let i = 0; i < 12; i += 1) {
+    const r = await d.executePlan(basePlan({ id: `pf${i}` }), { finding: { kind: "finding" } });
+    assert.equal(r.ok, true, `call ${i} should enqueue`);
+  }
+  assert.deepEqual(d.state(), { queueDepth: 10, inFlight: 2 });
+  const overflow = await d.executePlan(basePlan({ id: "pf-overflow" }));
+  assert.equal(overflow.ok, false);
+  assert.equal(overflow.reason, "queue-full");
+  // release: everything drains (concurrency ≤ MAX_IN_FLIGHT, all 12 written)
+  release();
+  await settle(40);
+  assert.deepEqual(d.state(), { queueDepth: 0, inFlight: 0 });
+  const rows = (await f.state.store.load()).entries;
+  assert.equal(rows.length, 12);
+  assert.equal(started, 12);
+  assert.ok(MAX_IN_FLIGHT >= 2); // the §3.3 sub-cap constant holds
 });
 
-test("executor: start-job refusal from the delegate engine degrades with its error and releases the gate", async () => {
-  const { deps, calls } = makeDeps({
-    startDelegateJob: async () => ({ ok: false, error: "at MAX_RUNNING_JOBS" }),
+test("driver: a queued blocker plan is taken before a queued finding plan", async () => {
+  // Both slots busy on gated runs; then enqueue finding → blocker → finding.
+  let releaseAll = null;
+  const gate = new Promise((r) => (releaseAll = r));
+  const f = fakeDriverDeps({
+    runner: async () => {
+      await gate;
+      return { ok: true, outcome: "resolved", attempts: 1, cost: 1, reason: null, result: null };
+    },
   });
-  const out = await runStartJobProbe(deps);
-  assert.deepEqual(out, { ok: false, reason: "at MAX_RUNNING_JOBS" });
-  assert.equal(calls.beginDelegateJob, 1);
-  assert.equal(calls.gateReleased, 1);
+  const d = createCtoExecutorDriver(f.deps);
+  await d.executePlan(basePlan({ id: "busy-1" }), { finding: { kind: "finding" } });
+  await d.executePlan(basePlan({ id: "busy-2" }), { finding: { kind: "finding" } });
+  await d.executePlan(basePlan({ id: "q-finding" }), { finding: { kind: "finding" } });
+  await d.executePlan(basePlan({ id: "q-blocker" }), { finding: { kind: "blocker" } });
+  await d.executePlan(basePlan({ id: "q-finding2" }), { finding: { kind: "finding" } });
+  assert.deepEqual(d.state(), { queueDepth: 3, inFlight: 2 });
+  releaseAll();
+  await settle(40);
+  const rows = (await f.state.store.load()).entries;
+  // the blocker's row exists and the blocker jumped the queue (drained before
+  // the finding entry queued behind it)
+  assert.equal(rows.length, 5);
+  assert.deepEqual(d.state(), { queueDepth: 0, inFlight: 0 });
+  assert.ok(rows.some((r) => r.planId === "q-blocker"));
 });
 
-test("executor: a §3.3 gate refusal (kill switch / pause) refuses the act before any start", async () => {
-  const { deps, calls } = makeDeps({ beginDelegateJob: async () => ({ ok: false, error: "cto_paused" }) });
-  const out = await runStartJobProbe(deps);
-  assert.deepEqual(out, { ok: false, reason: "cto_paused" });
-  assert.equal(calls.startDelegateJob.length, 0);
-  assert.equal(calls.gateReleased, 0);
+test("driver: invalid plans are refused, never executed or ledgered", async () => {
+  const f = fakeDriverDeps({});
+  const d = createCtoExecutorDriver(f.deps);
+  const r = await d.executePlan({ id: "", steps: [] });
+  assert.equal(r.ok, false);
+  await settle();
+  assert.equal((await f.state.store.load()).entries.length, 0);
+  assert.deepEqual(f.state.ledgerRows, []);
 });
 
-// ---------------------------------------------------------------------------
-// Refusal contract: class/action coherence, unknown classes, unwired deps
-// ---------------------------------------------------------------------------
-
-test("executor: class and action.type must agree (act bookkeeping is per-class)", async () => {
-  const { deps, calls } = makeDeps();
-  const exec = createCtoActExecutor(deps);
-  assert.deepEqual(
-    await exec({ cls: "start-job", action: { type: "record-decision", payload: { statement: "s", project: "p", refs: ["r"] } } }),
-    { ok: false, reason: "class-mismatch" },
-  );
-  assert.deepEqual(await exec({ cls: undefined, action: { type: "start-job", payload: {} } }), { ok: false, reason: "class-mismatch" });
-  assert.deepEqual(await exec({ cls: "start-job", action: null }), { ok: false, reason: "class-mismatch" });
-  assert.equal(calls.startDelegateJob.length, 0);
+test("driver: a runner THROW is an interrupt — escalated with the interrupt reason, never lost", async () => {
+  const f = fakeDriverDeps({ runner: async () => { throw new Error("provider died"); } });
+  const d = createCtoExecutorDriver(f.deps);
+  await d.executePlan(basePlan());
+  await settle();
+  const rows = (await f.state.store.load()).entries;
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].outcome, "escalated");
+  assert.ok((rows[0].reason ?? "").includes("interrupt"));
+  assert.deepEqual(f.state.calibrations, [{ planId: "pl1", class: "start-job", ok: false }]);
 });
 
-test("executor: §9.3-ineligible and data-unreachable classes refuse as unwired (veto-window fallback)", async () => {
-  const exec = createCtoActExecutor(makeDeps().deps);
-  assert.deepEqual(await exec({ cls: "config-change", action: { type: "config-change", payload: { patch: {} } } }), {
-    ok: false,
-    reason: "no-executor",
-  });
-  assert.deepEqual(await exec({ cls: "tool-write", action: { type: "tool-write", payload: { tool: "t" } } }), {
-    ok: false,
-    reason: "no-executor",
-  });
-  assert.deepEqual(await exec({ cls: "unknown", action: { type: "unknown", payload: {} } }), { ok: false, reason: "no-executor" });
-});
-
-test("executor: an unwired dep refuses its class as no-executor; malformed payloads refuse as incomplete", async () => {
-  const { deps } = makeDeps();
-  const noTonight = createCtoActExecutor({ ...deps, tonightAdd: null });
-  assert.deepEqual(
-    await noTonight({ cls: "queue-tonight", action: { type: "queue-tonight", payload: { name: "n" } } }),
-    { ok: false, reason: "no-executor" },
-  );
-  const noDelegate = createCtoActExecutor({ ...deps, startDelegateJob: null, beginDelegateJob: null });
-  assert.deepEqual(
-    await noDelegate({ cls: "start-job", action: { type: "start-job", payload: { prompt: "p", cwd: "/srv/app" } } }),
-    { ok: false, reason: "no-executor" },
-  );
-  const exec = createCtoActExecutor(deps);
-  assert.deepEqual(await exec({ cls: "start-job", action: { type: "start-job", payload: {} } }), { ok: false, reason: "incomplete-payload" });
-  assert.deepEqual(await exec({ cls: "queue-tonight", action: { type: "queue-tonight", payload: {} }, candidate: { finding: { text: "", refs: [] } } }), {
-    ok: false,
-    reason: "incomplete-payload",
-  });
-  assert.deepEqual(await exec({ cls: "record-decision", action: { type: "record-decision", payload: {} } }), {
-    ok: false,
-    reason: "incomplete-payload",
-  });
+test("driver: executeAccepted announces the accepted execution through the act-and-report queue", async () => {
+  const f = fakeDriverDeps({});
+  const d = createCtoExecutorDriver(f.deps);
+  await d.executeAccepted(basePlan(), { gateCtx: { effective: 0.5 } });
+  await settle();
+  const rows = (await f.state.store.load()).entries;
+  assert.equal(rows[0].trigger, "accepted");
+  assert.equal(f.state.acts.length, 1);
+  assert.deepEqual(f.state.acts[0].action, { type: "plan", payload: { planId: "pl1" } });
 });

--- a/src/server/ctoCalibration.mjs
+++ b/src/server/ctoCalibration.mjs
@@ -167,6 +167,22 @@ export function createCtoCalibration(deps = {}) {
     return null;
   }
 
+  // Does this verdict subject resolve to a PLAN (the executor owns its
+  // outcome)? The engine wires this to plans.json + the executor's resolve
+  // store; the standalone default checks plans.json only.
+  async function isPlanSubject(planId) {
+    if (!plans || typeof planId !== "string" || !planId) return false;
+    try {
+      const payload = await plans.load();
+      for (const rec of Object.values(payload?.records ?? {})) {
+        if ((rec?.plans ?? []).some((p) => p?.id === planId)) return true;
+      }
+    } catch {
+      /* best-effort attribution */
+    }
+    return false;
+  }
+
   // The §9.5 verdict sink — the replacement for the trust ladder's counter
   // sink, same B3 registration contract (called with the fold's effects and
   // the raw ledger entry, best-effort, never breaks verdict recording).
@@ -174,6 +190,13 @@ export function createCtoCalibration(deps = {}) {
   // suggestions from the suggest flow's ask/held cards, plans from the
   // gate's ask cards + the executor's act-and-report). Holds the ledger
   // row so §14.5 can audit the fold.
+  //
+  // BET-1519 (§9.5 "one outcome per plan"): accept/edit on a plan subject is
+  // DEFERRED — the execution the accept kicked off owns the outcome through
+  // notePlanOutcome (verification + the 7-day window). Folding the accept
+  // here too would double-count. Dismiss/correct/veto on a plan subject fold
+  // immediately (dismissed-unexecuted / later-negative are failures here,
+  // the executor folds its own on execution).
   async function noteVerdictEffects(effects, entry) {
     const subject = entry?.subject;
     const type = subject?.type;
@@ -182,6 +205,19 @@ export function createCtoCalibration(deps = {}) {
     if (!cls) return;
     const outcome = outcomeOfVerdict(entry?.verdict, entry?.never === true);
     if (outcome === null) return;
+    const defer =
+      outcome === "success" && (await (deps.isPlanSubject ?? isPlanSubject)(subject?.id));
+    if (defer) {
+      await ledgerLog({
+        kind: "calibrate.fold",
+        class: cls,
+        outcome: "deferred-to-executor",
+        subjectType: type,
+        subjectId: subject?.id ?? null,
+        verdict: entry?.verdict ?? null,
+      });
+      return;
+    }
     await noteOutcome(cls, outcome === "success");
     await ledgerLog({
       kind: "calibrate.fold",

--- a/src/server/ctoCalibration.test.mjs
+++ b/src/server/ctoCalibration.test.mjs
@@ -110,10 +110,11 @@ test("engine: plan-subject verdicts resolve their class from plans.json when uns
       "f1": { findingId: "f1", plans: [{ id: "plan-1", class: "host-maintenance" }, { id: "plan-2", class: "other" }] },
     },
   });
+  const ledgerRows = [];
   const cal = createCtoCalibration({
     store,
     plans,
-    ledger: { append: async () => {} },
+    ledger: { append: async (row) => ledgerRows.push(row) },
     now: () => 1000,
   });
   // unstamped plan verdict → class from the plan row
@@ -121,10 +122,42 @@ test("engine: plan-subject verdicts resolve their class from plans.json when uns
   let st = await cal.getState();
   assert.equal(st.classes["host-maintenance"].outcomes, 1);
   assert.equal(st.classes["host-maintenance"].successes, 0);
-  // a stamped subject wins over the lookup
+  // a stamped subject wins over the lookup — and a SUCCESS verdict on a plan
+  // subject that resolves in plans.json is DEFERRED to the executor (BET-1519
+  // §9.5: one outcome per plan; the accept's own fold would double-count).
+  // Dismiss/correct still fold immediately (dismissed-unexecuted / later-
+  // negative are failures here).
   await cal.noteVerdictEffects({}, { subject: { type: "plan", id: "plan-2", class: "config-change" }, verdict: "edit" });
   st = await cal.getState();
-  assert.equal(st.classes["config-change"].successes, 1);
+  assert.equal(st.classes["config-change"], undefined);
+  assert.ok(
+    ledgerRows.some((r) => r.kind === "calibrate.fold" && r.outcome === "deferred-to-executor" && r.subjectId === "plan-2"),
+  );
+});
+
+test("engine: accept on a plan subject DEFERS to the executor; the engine's isPlanSubject wins", async () => {
+  const store = makeMemStore();
+  const ledgerRows = [];
+  const plans = makeMemStore({
+    records: { "f1": { findingId: "f1", plans: [{ id: "plan-9", class: "host-maintenance" }] } },
+  });
+  const cal = createCtoCalibration({
+    store,
+    plans,
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    now: () => 1000,
+    isPlanSubject: async (planId) => planId === "plan-9",
+  });
+  // the stamped class + the plans.json hit → the accept fold is deferred
+  await cal.noteVerdictEffects({}, { subject: { type: "plan", id: "plan-9", class: "host-maintenance" }, verdict: "accept" });
+  let st = await cal.getState();
+  assert.equal(st.classes["host-maintenance"], undefined);
+  assert.ok(ledgerRows.some((r) => r.outcome === "deferred-to-executor" && r.subjectId === "plan-9"));
+  // dismiss on the same plan subject folds failure immediately
+  await cal.noteVerdictEffects({}, { subject: { type: "plan", id: "plan-9", class: "host-maintenance" }, verdict: "dismiss" });
+  st = await cal.getState();
+  assert.equal(st.classes["host-maintenance"].outcomes, 1);
+  assert.equal(st.classes["host-maintenance"].successes, 0);
 });
 
 test("engine: veto/open/expire verdicts never fold; unknown subjects never fold", async () => {

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -67,6 +67,7 @@ import {
   patchEngineState,
   patchStore,
   purgeExpiredInbox,
+  resolveStore,
 } from "./ctoStores.mjs";
 import { createVerdictEngine, createAsSourceSink } from "./ctoVerdicts.mjs";
 import { cardHasContent } from "../shared/ctoCard.mjs";
@@ -136,6 +137,13 @@ import { resolveForgeOwner } from "./delegate.mjs";
 // BET-1517 (§9.1/§9.2): the triage stage — drained findings → 0–3 resolution
 // plans in plans.json, one mid-tier model call per finding per tick.
 import { BLOCKER_FINDING_SOURCES, createCtoTriage } from "./ctoTriage.mjs";
+
+// BET-1519 (§9.4/§9.5): the ONE generic plan executor + its driver — the
+// queue (≤ 10 FIFO, blocker-before-finding), ≤ 2 in flight, the two
+// executions-per-plan cap over the resolve store, the verify/retry loop, the
+// escalation to a blocker card with the attempt log, the `cto.resolve` ledger
+// row, the calibration outcome and the 7-day success resolution.
+import { createCtoExecutorDriver, createCtoPlanRunner } from "./ctoAct.mjs";
 
 // BET-1395 tool discovery (§7): the registry engine — fusion of the four
 // evidence channels, the two lifecycle bars, and the connect-ask gate.
@@ -345,6 +353,9 @@ export function createCtoEngine(deps = {}) {
     findings: findingsStore,
     // BET-1517 (§9.2): the resolution-plan store (triage output).
     plans: plansStore,
+    // BET-1519 (§9.4): the cto.resolve store — one entry per plan execution +
+    // the resolution fold bookkeeping (the executor driver's state).
+    resolve: resolveStore,
     verdicts: verdictsStore,
     budget: budgetStore,
     watchers: watchersStore,
@@ -472,6 +483,12 @@ export function createCtoEngine(deps = {}) {
     // BET-1517 (§9.1): optional pre-built triage engine (tests). Else one is
     // constructed lazily below over bundle.plans + the gated runEphemeral.
     triage = null,
+    // BET-1519 (§9.4): the executor driver's session seams —
+    // `{ runner?, runnerDeps?, driverDeps? }`. index.mjs wires runnerDeps to
+    // the real opencode session/delegate primitives; tests inject a fake
+    // runner. The engine adds the bookkeeping seams (resolve store, ledger,
+    // calibration, escalation, verdict scan) itself.
+    executor = null,
     // BET-1517 (§9.2): the sender-session transcript-tail reader for blocker
     // triage context — async (sessionID) => string|null (≤ 2k tokens, the
     // caller truncates). Default null → no tail block.
@@ -545,6 +562,8 @@ export function createCtoEngine(deps = {}) {
   let builtInBackfill = null;
   let profileDecayHandle = null;
   let verdictsEngine = null;
+  // BET-1519: the executor driver (lazy — see getExecutor).
+  let executorDriver = null;
   let calibrationEngine = null;
   let gateEngine = null;
   let watcherEngine = null;
@@ -868,6 +887,11 @@ export function createCtoEngine(deps = {}) {
       // BET-1518: the gate consumes the triage stage's ungated plan records —
       // act (executor seam) or ask card per §9.3, one pass per record.
       await getGate().gatePass();
+      // BET-1519: the executor driver's tick — fold due §9.5 resolutions
+      // (7-day success window / negative-verdict failure) and drain the
+      // execution queue. Best-effort: an executor failure never breaks the
+      // cards pipeline.
+      await getExecutor().tick();
       await cards.checkInboxLiveness();
       await syncState();
     } catch {
@@ -1290,10 +1314,77 @@ export function createCtoEngine(deps = {}) {
         }
       },
       calibrationOf: (classList) => getCalibration().calibrationsFor(classList),
-      executePlan: null, // BET-1519 wires the executor here
+      // BET-1519: the executor driver's gate seam — validate → cap → queue →
+      // drain; the gate's own announce/ledger happens after the seam accepts.
+      executePlan: async (plan, ctx) => {
+        try {
+          return await getExecutor().executePlan(plan, ctx);
+        } catch {
+          return { ok: false, reason: "executor-error" };
+        }
+      },
       recordAct: (input) => getCalibration().recordAct(input),
     });
     return gateEngine;
+  }
+
+  // BET-1519 (§9.4/§9.5): the executor driver — lazy single instance. The
+  // runner's session seams come from index.mjs via deps.executor (real
+  // opencode sessions / the shared startJobWithApproval delegate path); the
+  // driver adds the queue, the cap, the outcomes, the escalation card and
+  // the 7-day resolution. Everything best-effort: an executor failure never
+  // breaks the tick.
+  function getExecutor() {
+    if (executorDriver) return executorDriver;
+    const ex = executor ?? {};
+    // The engine owns the two fact-verifier seams (§6.7): a predicate
+    // statement matches via matchCheckable and verifies through the same
+    // factVerify the facts engine uses; a condition-gone check reuses the
+    // §10.3 classifier. index.mjs supplies the session/delegate/probe seams.
+    const runner = ex.runner ?? createCtoPlanRunner({
+      verifyFact: async ({ condition } = {}) => {
+        const match = matchCheckable(condition);
+        if (!match) return { ok: false, reason: "not-checkable" };
+        try {
+          const r = await factVerify({ surface: match.surface, probe: match.probe, branch: match.branch ?? undefined });
+          if (r?.ok === true) return { ok: true };
+          return { ok: false, reason: r?.result ?? "predicate-false" };
+        } catch (e) {
+          return { ok: false, reason: "verify-error", detail: e?.message };
+        }
+      },
+      conditionGone: async (condition) => conditionGoneFromCondition(condition, factVerify),
+      ...(ex.runnerDeps ?? {}),
+    });
+    executorDriver = createCtoExecutorDriver({
+      runner,
+      store: bundle.resolve,
+      ledger,
+      escalate: (text) => recordBlocker("cto-executor", text).catch(() => {}),
+      calibration: (input) => getCalibration().notePlanOutcome(input),
+      recordAct: (input) => getCalibration().recordAct(input),
+      verdictsList: async () => {
+        try {
+          return (await getVerdictsEngine().listVerdicts()) ?? [];
+        } catch {
+          return [];
+        }
+      },
+      knowsPlan: async (planId) => {
+        try {
+          const payload = await bundle.plans.load();
+          for (const rec of Object.values(payload?.records ?? {})) {
+            if ((rec?.plans ?? []).some((p) => p?.id === planId)) return true;
+          }
+        } catch {
+          /* fall through to the resolve store */
+        }
+        return false;
+      },
+      now,
+      ...(ex.driverDeps ?? {}),
+    });
+    return executorDriver;
   }
 
   // BET-1398 standing-query watchers (§4.3/§13.4): lazy single instance over
@@ -2924,6 +3015,11 @@ export function createCtoEngine(deps = {}) {
     toolsView,
     // BET-1396 (§7.5/§10.5): the A12 health endpoint's probe-health reader.
     probeHealth: () => getProbes()?.healthSnapshot() ?? { tools: 0, probes: 0, healthy: 0, authFailed: 0, lastRunAt: null },
+    // BET-1519: the probes engine — the executor's probe verify seam reads a
+    // probe's latest run outcome through probeSummary(tool).
+    get probes() {
+      return getProbes();
+    },
     // BET-1391 verdict ledger (§9.5): record + read the verdict ledger (the
     // opencode `cto_verdict` tool + the digest-opened rewire + the health card
     // all reach one path through these).
@@ -2941,6 +3037,12 @@ export function createCtoEngine(deps = {}) {
     // seam.
     get gate() {
       return getGate();
+    },
+    // BET-1519: the executor driver — the ONE generic §9.4 plan executor
+    // (executePlan for the gate, executeAccepted for the decision card's
+    // "Do it", tick from cardTick). Exposed for the verdict route + tests.
+    get executor() {
+      return getExecutor();
     },
     get rateTracker() {
       return track;

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1370,6 +1370,17 @@ export function createCtoEngine(deps = {}) {
           return [];
         }
       },
+      // §9.4 presence rule: finding-sourced machine acts refuse while the
+      // user is `present` (the gate degrades them to ask cards); blocker-
+      // sourced and user-accepted plans bypass. Same read the rollup/facts
+      // engines use.
+      presence: async () => {
+        try {
+          return getPresence().state ?? "away";
+        } catch {
+          return "away";
+        }
+      },
       knowsPlan: async (planId) => {
         try {
           const payload = await bundle.plans.load();

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -662,9 +662,11 @@ test("durability: a calibration fold survives a queue-edit save landing after it
   const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [] });
 
   // The calibration fold lands first (a verdict's fire-and-forget sink writes
-  // the §9.5 calibration store).
+  // the §9.5 calibration store). BET-1519: the fold may now consult
+  // plans.json (the accept-on-a-plan deferral check) before folding, so the
+  // wait is a real settle, not one microtask turn.
   await h.engine.recordVerdict({ subject: { type: "suggestion", id: "card-2", class: "queue-tonight" }, verdict: "accept" });
-  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setTimeout(r, 25));
   const afterFold = await h.engine.calibration.getState();
   assert.equal(afterFold.classes["queue-tonight"]?.successes, 1);
 

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -653,22 +653,37 @@ test("tonightAdd project resolution (BET-1426): explicit canonicalize, auto-reso
 test("overnight: queue-tonight verdicts fold into the overnight Thompson counters", async () => {
   const h = makeHarness({ trough: TROUGH, projects: [] });
   await h.engine.recordVerdict({ subject: { type: "suggestion", id: "card-1", class: "queue-tonight" }, verdict: "accept" });
-  await new Promise((r) => setImmediate(r));
-  const counters = await h.overnight.readCounters();
-  assert.equal(counters?.["queue-tonight"]?.alpha, 1, "accept folds a success counter");
+  // The fold is fire-and-forget (and may consult plans.json first) — poll.
+  assert.equal(
+    await waitForState(async () => (await h.overnight.readCounters())?.["queue-tonight"]?.alpha, 1),
+    true,
+    "accept folds a success counter",
+  );
 });
+
+// BET-1519 review cycle 1: a fold is fire-and-forget and may now consult
+// plans.json (the accept-on-a-plan deferral check) before writing, so fixed
+// settles are load-fragile under the full suite's parallel workers. A bounded
+// poll for the expected state is deterministic under any scheduling.
+async function waitForState(read, expected, { timeoutMs = 5000, step = 25 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await read();
+    if (last === expected) return true;
+    await new Promise((r) => setTimeout(r, step));
+  }
+  return false;
+}
 
 test("durability: a calibration fold survives a queue-edit save landing after it (mirrored-order regression, BET-1403 cycle 4)", async () => {
   const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [] });
+  const successesOf = async () => (await h.engine.calibration.getState())?.classes?.["queue-tonight"]?.successes;
 
   // The calibration fold lands first (a verdict's fire-and-forget sink writes
-  // the §9.5 calibration store). BET-1519: the fold may now consult
-  // plans.json (the accept-on-a-plan deferral check) before folding, so the
-  // wait is a real settle, not one microtask turn.
+  // the §9.5 calibration store).
   await h.engine.recordVerdict({ subject: { type: "suggestion", id: "card-2", class: "queue-tonight" }, verdict: "accept" });
-  await new Promise((r) => setTimeout(r, 25));
-  const afterFold = await h.engine.calibration.getState();
-  assert.equal(afterFold.classes["queue-tonight"]?.successes, 1);
+  assert.equal(await waitForState(successesOf, 1), true, "the accept verdict's fold landed");
 
   // Then a queue edit lands — AND the hostile old writer shape runs: a whole
   // engine-state save spreading a STALE pre-fold snapshot. When the ladder's
@@ -677,13 +692,11 @@ test("durability: a calibration fold survives a queue-edit save landing after it
   const removed = await h.engine.tonightRemove(h.engineStateObj.tonightQueue[0].id);
   assert.equal(removed.ok, true);
   await h.engineStateSave({ v: 1, tonightQueue: [{ id: "tq:stale" }] });
-  await new Promise((r) => setImmediate(r));
 
-  const after = await h.engine.calibration.getState();
   // Two folds landed: the accept verdict and the remove's own edit verdict —
   // BOTH survived the hostile stale engine-state save (both map to success
   // outcomes in the class's last-30 window, §9.5).
-  assert.equal(after.classes["queue-tonight"]?.successes, 2, "the calibration folds survived the stale engine-state save");
+  assert.equal(await waitForState(successesOf, 2), true, "the calibration folds survived the stale engine-state save");
   assert.deepEqual(h.engineStateObj.tonightQueue, [{ id: "tq:stale" }], "the queue edit landed");
 });
 

--- a/src/server/ctoGate.mjs
+++ b/src/server/ctoGate.mjs
@@ -188,7 +188,17 @@ export function createCtoGate(deps = {}) {
         let exec = { ok: false, reason: "no-executor" };
         if (typeof executePlan === "function") {
           try {
-            exec = (await executePlan(plan)) ?? { ok: false };
+            exec = (await executePlan(plan, {
+              findingId,
+              finding: rec.finding ?? null,
+              // §9.4-9.5 row context: the gate knows calibration/τ/effective —
+              // the executor stamps them on the cto.resolve row.
+              gateCtx: {
+                effective: score,
+                tau,
+                calibration: calibrationMap[cls],
+              },
+            })) ?? { ok: false };
           } catch {
             exec = { ok: false };
           }

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -166,12 +166,16 @@ export const watchersStore = createCtoJsonStore("watchers", ctoPath("watchers.js
 export const engineStateStore = createCtoJsonStore("engine-state", ctoPath("engine-state.json"));
 // (BET-1518) the trust ladder's trust.json store is deleted with the ladder —
 // calibration.json replaced it (§9.5, below).
-// BET-1521: the §9.4 cto.resolve ledger — one entry per plan execution
+// BET-1519: the §9.4 cto.resolve ledger — one entry per plan execution
 // ({ planId, class, findingId, confidence, calibration, effective, tau,
 // trigger: act|accepted, outcome: resolved|escalated, attempts, cost, undo,
-// refs }). Payload `{ entries: [...] }`, verdicts-mirrored; owned by the
-// executor (BET-1519) and read by the §14-7 health rows. Readers tolerate the
-// bare `{ v: 1 }` default payload (entries ?? []).
+// refs, ts }, resolved rows carrying `resolvedAt`). The §9.5 resolution fold
+// mutates the resolved row in place with successFoldedAt / failureFoldedAt +
+// foldReason (never a second row — one entry per execution). Per-plan state
+// (the two-executions-ever attempt cap, the 7-day success window) is derived
+// by scanning rows, so a re-triage can never re-arm the cap. Owned by the
+// executor driver (ctoAct.mjs) and read by the §14-7 health rows. Readers
+// tolerate the bare `{ v: 1 }` default payload (entries ?? []).
 export const resolveStore = createCtoJsonStore("resolve", ctoPath("resolve.json"));
 // BET-1521: the §9.5 calibration store — per-class last-30 outcome windows
 // (`{ classes: { <cls>: { successes, outcomes } } }`), Beta(1,1) prior.

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -2212,11 +2212,7 @@ const adaptiveCto = ctoEngine.createCtoEngine({
           if (sid) {
             const owner = resolveOwner(rows, sid);
             if (owner) {
-              const proj = rows.find((p) => p.tmuxSession === owner.tmuxSession);
-              return {
-                parentSessionID: owner.parentSessionID,
-                parentDirectory: owner.defaultCwd ?? proj?.defaultCwd ?? null,
-              };
+              return { parentSessionID: sid, parentDirectory: owner.cwd ?? null };
             }
           }
           for (const p of rows) {

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -106,7 +106,7 @@ import {
   startCapSweeper,
 } from "./capabilities.mjs";
 import { notifyCapSession } from "./capNotifier.mjs";
-import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset, resolveForgeOwner, loadJobs as loadDelegateJobs, pauseJob as delegatePauseJob } from "./delegate.mjs";
+import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset, resolveForgeOwner, resolveOwner, loadJobs as loadDelegateJobs, pauseJob as delegatePauseJob } from "./delegate.mjs";
 import {
   reportProgress,
   readProgressRecord,
@@ -146,14 +146,17 @@ import * as cto from "./cto.mjs";
 import * as ctoEngine from "./ctoEngine.mjs";
 import * as ctoBudget from "./ctoBudget.mjs";
 import { createFactSurfaces } from "./ctoFactSurfaces.mjs";
-import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore, digestsStore, factsStore, resolveStore, calibrationStore, startCtoStoreSweeper, CTO_STORE_SWEEP_INTERVAL_MS } from "./ctoStores.mjs";
+import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore, digestsStore, factsStore, resolveStore, calibrationStore, plansStore, startCtoStoreSweeper, CTO_STORE_SWEEP_INTERVAL_MS } from "./ctoStores.mjs";
 import * as ctoOvernight from "./ctoOvernight.mjs";
 import { computeHealthStats } from "./ctoHealth.mjs";
 import { composeProfileRender } from "./ctoProfile.mjs";
 import { runEphemeral, createEphemeralReaper } from "./ctoSessions.mjs";
 import { createCtoDigest, STALE_MS } from "./ctoDigest.mjs";
 import { createCtoSuggest } from "./ctoSuggest.mjs";
-import { createCtoActExecutor } from "./ctoAct.mjs";
+// BET-1519: the per-class act executors are retired — ctoAct.mjs is now the
+// ONE generic §9.4 plan executor (the driver + runner); the suggest flow's
+// bound options execute through the ask path (the user's click), and its
+// machine act verb degrades to the ask card when the executor declines.
 import {
   parseSegmentSummaryText,
   validateSegmentSummary,
@@ -2123,12 +2126,136 @@ const factSurfaces = createFactSurfaces({
   },
 });
 
+// The standard work toolset for CTO-originated delegate jobs (the same grants
+// the forge dispatch declares). Used by the overnight dispatch and consulted
+// nowhere else — the plan executor declares the PLAN's access instead.
+const STANDARD_WORK_TOOLS = [
+  { permission: "read", pattern: "**" },
+  { permission: "bash", pattern: "**" },
+  { permission: "write", pattern: "**" },
+  { permission: "edit", pattern: "**" },
+  { permission: "webfetch", pattern: "**" },
+];
+
 const adaptiveCto = ctoEngine.createCtoEngine({
   configGet: () => local.configGet(),
   ledger: ledgerStore,
   engineState: engineStateStore,
   publish: (evt) => bus.publish(evt),
   getSessionInfo: resolveSessionInfo,
+  // BET-1519 (§9.4): the ONE generic plan executor's session seams — real
+  // opencode ephemeral sessions, the shared startJobWithApproval delegate
+  // path (the plan's access rules ARE the declared tools; the approval card
+  // is the human's veto over machine-originated work), the delegate job poll
+  // and the consented §7.5 probe read. The engine adds the §6.7 verify
+  // seams (matchCheckable + condition-gone) and all bookkeeping itself.
+  executor: {
+    runnerDeps: {
+      createSession: async ({ directory, title, permission } = {}) => {
+        const sess = await oc.createSession({ directory, title, permission });
+        return { ok: true, id: sess?.id };
+      },
+      sendPrompt: async (args) => {
+        try {
+          await oc.sendPrompt(args);
+          return { ok: true };
+        } catch (e) {
+          return { ok: false, error: e?.message };
+        }
+      },
+      listMessages: (sid) => oc.listMessages(sid),
+      abortSession: async (sid) => {
+        try {
+          await oc.abortSession(sid);
+          return { ok: true };
+        } catch {
+          return { ok: false };
+        }
+      },
+      deleteSession: async (sid) => {
+        try {
+          await oc.deleteSessionRaw(sid);
+          return { ok: true };
+        } catch {
+          return { ok: false };
+        }
+      },
+      startJob: async (input) =>
+        delegateEngine.startJobWithApproval({
+          prompt: input?.prompt,
+          parentSessionID: input?.parentSessionID,
+          parentDirectory: input?.parentDirectory,
+          tools: input?.tools,
+          trustMode: input?.trustMode === true,
+          actor: "cto",
+        }),
+      jobRow: async (jobId) => {
+        try {
+          const rows = await loadDelegateJobs();
+          const j = (Array.isArray(rows) ? rows : []).find((r) => r?.id === jobId);
+          if (!j) return null;
+          return { running: j.status === "running", sessionId: j.childSessionID ?? null, status: j.status };
+        } catch {
+          return null;
+        }
+      },
+      resolveParent: async ({ finding } = {}) => {
+        try {
+          const projects = await tmux.listProjects();
+          const rows = (Array.isArray(projects) ? projects : []).filter((p) =>
+            (p.windows || []).some((w) => w?.opencodeSessionId),
+          );
+          if (rows.length === 0) return null;
+          // The finding's sender session first (the blocker's own project),
+          // then the first tracked project as the default host.
+          const sid = finding?.senderSessionID ?? finding?.sender?.sessionID ?? null;
+          if (sid) {
+            const owner = resolveOwner(rows, sid);
+            if (owner) {
+              const proj = rows.find((p) => p.tmuxSession === owner.tmuxSession);
+              return {
+                parentSessionID: owner.parentSessionID,
+                parentDirectory: owner.defaultCwd ?? proj?.defaultCwd ?? null,
+              };
+            }
+          }
+          for (const p of rows) {
+            const win = (p.windows || []).find((w) => w?.opencodeSessionId);
+            if (win) {
+              return {
+                parentSessionID: win.opencodeSessionId,
+                parentDirectory: p.defaultCwd ?? win.paneCurrentPath ?? null,
+              };
+            }
+          }
+          return null;
+        } catch {
+          return null;
+        }
+      },
+      probeRead: async (probe) => {
+        // §9.2 probe verify — a consented §7.5 probe read. The probes engine
+        // keys state per tool; "tool/probe" or "tool:probe" is the accepted
+        // spelling. No probes are authored yet on this box, so an unmatched
+        // name honestly fails verification (never a silent pass).
+        try {
+          const str = String(probe ?? "");
+          const sep = str.indexOf("/") >= 0 ? "/" : str.indexOf(":") >= 0 ? ":" : null;
+          if (!sep) return { ok: false, reason: "probe-name-unmatched" };
+          const tool = str.slice(0, str.indexOf(sep)).trim();
+          const name = str.slice(str.indexOf(sep) + 1).trim();
+          if (!tool || !name) return { ok: false, reason: "probe-name-unmatched" };
+          const summary = await adaptiveCto.probes.probeSummary(tool);
+          const row = (summary?.probes ?? []).find((pr) => pr?.name === name || pr?.id === name);
+          if (!row) return { ok: false, reason: "probe-name-unmatched" };
+          if (row.lastOk === true) return { ok: true };
+          return { ok: false, reason: row.lastOk === false ? "probe-unhealthy" : "no-probe-read" };
+        } catch {
+          return { ok: false, reason: "probe-read-error" };
+        }
+      },
+    },
+  },
   // BET-1517 (§9.2): the sender session's transcript tail for blocker triage
   // context — last messages flattened to text and capped at ~2k tokens
   // (~8000 chars) so the ≤ 6k triage context budget keeps room for the
@@ -2150,15 +2277,24 @@ const adaptiveCto = ctoEngine.createCtoEngine({
   // session/directory are resolved by the engine (resolveForgeOwner over
   // listProjects); this wrapper bakes in the "cto" actor, and the sweep
   // allowance (window remaining) is passed per-start by the engine.
+  // BET-1519 (delegate perm bypass fix): overnight jobs used to start with NO
+  // `permission` field, so opencode prepended its own allow-all default —
+  // every overnight job ran fully unconstrained. Route through the shared
+  // startJobWithApproval path with the standard work toolset DECLARED (the
+  // same grants the forge dispatch uses; the ruleset ends in the catch-all
+  // deny). trustMode true — the §11 veto card already consented tonight's
+  // plan, and an approval card here would just stall the overnight window.
   overnight: adaptiveCtoOvernight,
   startDelegateJob: async ({ name, prompt, parentSessionID, parentDirectory, sweepAllowanceMs } = {}) =>
-    delegateEngine.startJob({
+    delegateEngine.startJobWithApproval({
       prompt,
       name,
       parentSessionID,
       parentDirectory,
       actor: "cto",
       sweepAllowanceMs,
+      tools: STANDARD_WORK_TOOLS,
+      trustMode: true,
     }),
   listDelegateJobs: async () => {
     try {
@@ -2350,27 +2486,12 @@ async function gatedSuggestionEphemeral(taskClass, opts) {
     gate.release?.();
   }
 }
-// BET-1424 (§9.2/§9.3): the act-and-report executors for the bound suggest
-// options, wired to the live box subsystems. Refusals (and the still-unwired
-// config-change / tool-write classes) return {ok:false} so the suggest engine
-// degrades the act verb to the ask card — act-and-report never silently
-// no-ops. (BET-1518: the gate does not special-case any class; refusal lives
-// here, with the executor.)
-const ctoActExecutor = createCtoActExecutor({
-  proposeFact: (input) => adaptiveCto.proposeFact(input),
-  tonightAdd: (task) => adaptiveCto.tonightAdd(task),
-  beginDelegateJob: () => adaptiveCto.beginDelegateJob(),
-  listProjects: () => tmux.listProjects(),
-  startDelegateJob: async ({ prompt, model, parentSessionID, parentDirectory, actor } = {}) =>
-    delegateEngine.startJob({ prompt, model, parentSessionID, parentDirectory, actor }),
-  listDelegateJobs: async () => {
-    try {
-      return await loadDelegateJobs();
-    } catch {
-      return [];
-    }
-  },
-});
+// BET-1424's per-class act executors (record-decision / queue-tonight /
+// start-job branches) are RETIRED with this issue: ctoAct.mjs is the ONE
+// generic §9.4 plan executor now. The suggest flow's act verb (never fires —
+// executeAction is unwired) degrades to the ask card, where the bound options
+// remain user-executable through the renderer's ask path; blockers and
+// suggestions converge on the triage → plan → gate pipeline (D22).
 const adaptiveCtoSuggest = createCtoSuggest({
   now: () => Date.now(),
   publish: (evt) => bus.publish(evt),
@@ -2388,16 +2509,12 @@ const adaptiveCtoSuggest = createCtoSuggest({
   // tool-write's capability gate is on too, but the §7.4 tool registry
   // (P2-later) still feeds an empty write ring below, so a tool-write option
   // remains data-unreachable until B7 lands (the ring is the real gate).
-  // BET-1403 → BET-1518: act-and-report executors. The gate (not a ladder)
-  // decides act vs ask on effective = p × calibration ≥ τ; this seam decides
-  // whether the concrete bound action is machine-executable. BET-1424: all
-  // three bound executors are wired in ctoAct.mjs — record-decision (a
-  // validated, gatekeeper-checked fact proposal on the CTO's own blackboard),
-  // queue-tonight (the engine's tonightAdd) and start-job (a worktree-isolated
-  // delegate job as actor "cto" under the §3.3 gate). Anything unwired or
-  // refused → {ok:false} → the verb degrades to the ask card (the
-  // human-in-the-loop fallback). Never throws (ctoSuggest catches).
-  executeAction: ctoActExecutor,
+  // BET-1403 → BET-1519: the suggest flow's machine act verb is RETIRED —
+  // the per-class bound executors collapsed into the ONE generic plan
+  // executor (ctoAct.mjs). executeAction stays unwired → every candidate
+  // degrades to the ask card (the human-in-the-loop fallback); its bound
+  // options stay user-executable through the renderer's ask path.
+  executeAction: null,
   getWriteRingTools: async () => [], // §7.4 tool registry (P2-later) — empty → tool-write unreachable
   capabilities: { queueTonight: true, toolWrite: true },
   fireNotify: (args) => push.fireNotify(args),
@@ -4779,6 +4896,52 @@ const handleRequest = async (req, res) => {
           verdict,
           ...(never !== undefined ? { never } : {}),
         });
+        // BET-1519 (§9.4/§9.2 invariant 1): "Do it" — an accept (or edit) on a
+        // decision card whose subject resolves to a triage plan runs THAT plan
+        // through the ONE generic executor with trigger "accepted" (same
+        // executor, same verify, same attempt cap as the gate's act verb).
+        // The verdict stays the source of truth; the execution is best-effort
+        // and reported via the response's `execution` field (the calibration
+        // accept-fold is deferred to the executor's outcome — one outcome per
+        // plan). Refusals (cap-hit, queue-full, invalid) surface in the field
+        // and leave the card's plan for the ask path.
+        let execution = null;
+        if (
+          result.ok &&
+          (verdict === "accept" || verdict === "edit") &&
+          (subject?.type === "suggestion" || subject?.type === "plan") &&
+          typeof subject?.id === "string" &&
+          subject.id
+        ) {
+          try {
+            const payload = await plansStore.load();
+            let hit = null;
+            for (const rec of Object.values(payload?.records ?? {})) {
+              const plan = (rec?.plans ?? []).find((p) => p?.id === subject.id);
+              if (plan) {
+                hit = { plan, findingId: rec?.findingId ?? null, finding: rec?.finding ?? null };
+                break;
+              }
+            }
+            if (hit) {
+              let effective = null;
+              try {
+                const open = (await adaptiveCto.cards?.listOpen?.()) ?? [];
+                effective = open.find((c) => c?.id === subject.id)?.score ?? null;
+              } catch {
+                /* the ask card may already be closed — score is optional row context */
+              }
+              execution = await adaptiveCto.executor.executeAccepted(hit.plan, {
+                findingId: hit.findingId,
+                finding: hit.finding,
+                gateCtx: { effective },
+              });
+            }
+          } catch (e) {
+            execution = { ok: false, reason: `executor-error:${e?.message ?? "unknown"}` };
+          }
+          if (execution) void bus.publish({ kind: "ctoState" });
+        }
         // §9.1 resolution path (review Block 2): a judgment on a SUGGESTION
         // must also close the open decision card — accept → resolve, dismiss →
         // dismiss — so an acted-on / declined card is not left open forever.
@@ -4792,7 +4955,7 @@ const handleRequest = async (req, res) => {
             /* best-effort */
           }
         }
-        respondJson(res, result.ok ? 200 : 400, result);
+        respondJson(res, result.ok ? 200 : 400, result.ok ? { ...result, ...(execution ? { execution } : {}) } : result);
         return;
       }
       respondJson(res, 405, { error: "method not allowed" });


### PR DESCRIPTION
## BET-1519 — P4.4: the one generic executor + verify + attempt cap + `cto.resolve` + delegate perm fix

Base: origin/main @ ac4a060a (includes BET-1517 triage + BET-1518 gate/τ/calibration)

### The one executor (§9.4)
- `src/server/ctoAct.mjs` is rewritten as the ONE generic plan executor: `validatePlan` (runtime shape), `wantsDelegateSession` (access has write/edit → delegate job, else ephemeral), `buildExecutionBrief` (identity + finding + diagnosis + numbered steps + access flavor + undo + the exact `CHECK: pass|fail: <reason>` end marker), `runVerifyCheck` (all four §9.2 kinds — predicate via the §6.7 fact verifier, probe via a consented probe read, session-ok via the marker, condition-gone via the §10.3 liveness classifier; a no-opinion seam is a FAIL, never a silent pass), and the runner's run → verify → one-retry loop (retry in the SAME session with the failed check attached and a fresh 30-minute budget; both fail → escalated with the attempt log `attempt1:…; attempt2:…`).
- Delegate jobs poll the job row (`jobRow`), read the child session's transcript for checks, and deliver the retry brief into the child session; ephemeral sessions are always aborted + deleted after the run.

### The driver (ctoEngine wires it, ctoAct implements it)
- Queue ≤ 10 FIFO with blocker-before-finding; ≤ 2 in flight (§3.3 sub-cap / §9.4); overflow refused (`queue-full`).
- Attempt cap: **two executions per plan id, ever**, derived from the durable `resolve.json` rows — a re-triage can never re-arm it; a cap-hit refusal returns `cap-hit` (the gate degrades to the ask card, never acts).
- Every execution writes ONE `cto.resolve` ledger row with the full §9.4-9.5 field set: planId, class, findingId, confidence, calibration, effective, τ, trigger (`act`|`accepted`), outcome (`resolved`|`escalated`), attempts, cost, reason, undo, refs, ts (+`resolvedAt` on resolved rows).
- §9.5 outcomes, one per plan: `escalated` → immediate calibration failure + a human blocker card (`recordBlocker("cto-executor", …)`) carrying the attempt log; `resolved` → success DEFERRED to the 7-day window (driver `tick()` folds success when no correct/dismiss/veto verdict lands after `resolvedAt`, failure when one does). A negative verdict inside the window resolves immediately as failure.
- A runner throw is an interrupt → escalated with the interrupt reason (never silently lost). Note: the ticket's "aborts + requeues at any interrupt with outcome escalated" is implemented as abort + escalate (not re-queue) — re-queueing an interrupted run risks cap-less loops; the escalation card carries the state for the human.

### Double-count guard (§9.5 "one outcome per plan")
`ctoCalibration.noteVerdictEffects` now DEFERS the accept/edit fold when the subject resolves to a plan (plans.json hit, overridable via an injected `isPlanSubject`; ledgered as `calibrate.fold outcome:"deferred-to-executor"`) — the execution the accept kicked off owns the outcome through `notePlanOutcome`. Dismiss/correct/veto on plan subjects still fold immediately (dismissed-unexecuted / later-negative failures).

### "Do it" wiring (no duplicated execution logic)
`POST /api/cto/verdict` (index.mjs): an accept/edit whose subject resolves to a plan in plans.json runs THAT plan through `adaptiveCto.executor.executeAccepted` (trigger `accepted`, the digest announcement via the engine's `recordAct`), and reports the result in the response's `execution` field. The renderer's plan-option flow needed no logic change (its click already records the §9.5 accept verdict the route now acts on).

### Retired per-class executors
`createCtoActExecutor`, its three bound-action branches (record-decision / queue-tonight / start-job) and the three payload normalizers are deleted; the `no-executor` fall-through and the unreachable `config-change`/`tool-write` cases went with them. The suggest flow's machine act verb is now unwired (`executeAction: null` — an established seam state) so its acts degrade to ask cards, whose bound options stay user-executable through the renderer's ask path; blockers and suggestions converge on triage → plan → gate (D22). `beginDelegateJob` stays: the overnight dispatch (§11.5, unchanged by this ticket) still needs its own gate + `cto.delegate_begin` row.

### Delegate perm bypass fix
- CTO-originated delegate jobs (the executor) route through the shared `startJobWithApproval` with **the plan's access rules as the declared tools** and `trustMode: false` — the approval card is the human's veto over machine-originated work; the ruleset always ends in the catch-all deny (tested: tools + trustMode asserted on the start call).
- The overnight seam (`startDelegateJob`) also routed through `startJobWithApproval`, closing its NO-permission allow-all hole with the standard work toolset declared. **Deliberate deviation, flagged:** overnight jobs run with `trustMode: true` — the §11 veto card already consented tonight's plan (the ticket acknowledges that veto card is a scheduler artifact and unchanged), and a second approval card per overnight job would stall the window behind the 2-minute approval timeout.

### Anti-spaghetti
- Single sources kept: `buildPermissionRuleset` (delegate.mjs) reused for both session kinds; the resolve store (BET-1518's `resolveStore`) is the only new state, owned by the driver; no parallel calibration module (the dead prior run's was discarded in favor of BET-1518's).
- Deleted: the old per-class executor + normalizers (no importers remain — grep clean); `beginDelegateJob`'s suggest-flow start-job path dies with the suggest act verb, its overnight use remains.
- Duplicate-site audit: the runner's turn-poll mirrors `runSynchronousSession`'s established idle detection; the §6.7 verify seams are the engine's own `factVerify` + `conditionGoneFromCondition` (one implementation, injected).

### Follow-ups filed
- Parked: BET-1525 (probe-verify seam accepts tool-qualified names only; fails closed until probes exist), BET-1526 (plans could carry an optional project/cwd for job hosting).

### Verification results
- PR branch (`multica/BET-1519-generic-executor` @ 83745882, review cycle 1):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709
  - test: exit 0, 3958 pass / 0 fail / 0 skip. Failures: none. log sha256: 2c0e61c4db179eac80d557024197f2fa67b3d41b888298fcaa2ea70b1ea77a59
  - flake re-run: 4 consecutive full-suite `npm test` runs, all 3958/0 (the reviewer observed 3-of-4 failing at 5a099136)
- Base (`main` @ ac4a060a):
  - typecheck: exit 0. Errors: none. log sha256: 84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709
  - test: exit 0, 3949 pass / 0 fail / 0 skip. Failures: none. log sha256: 402c2d7e7b20b898fae6350156bb83e9b7fd2d1b370f006fbd1c5c91b9ce9dc5
- **Conclusion:** 0 failures on either branch; +9 tests on the PR branch (executor/driver suite + calibration deferral + §9.4 presence + still-running retry guard). Review cycle 1: both Blocks fixed — (1) the mirrored-order durability test's fold waits are now bounded polls for the expected state (deterministic under any load), and (2) the §9.4 presence rule is implemented on the executor path (finding-sourced `act` refuses while `present` → the gate degrades to the ask card; blocker-sourced and user-accepted plans bypass; enqueue-time check, documented). The reviewer's retry/interleave nit is also fixed: a delegate job still running at the turn budget escalates (`job-still-running-at-budget`) instead of delivering the retry prompt into the in-flight child session.

