### PR TITLE
BET-1520: route suggestions through the shared triage→gate→executor pipeline

### DIFF
--- a/src/server/ctoAct.test.mjs
+++ b/src/server/ctoAct.test.mjs
@@ -574,3 +574,49 @@ test("driver: executeAccepted announces the accepted execution through the act-a
   assert.equal(f.state.acts.length, 1);
   assert.deepEqual(f.state.acts[0].action, { type: "plan", payload: { planId: "pl1" } });
 });
+
+// ---------------------------------------------------------------------------
+// BET-1520 — the suggest finding's REAL pipeline shape obeys §3.4-3. The
+// finding the gate passes to the executor is the triage record's verbatim
+// copy of the pending-findings row (sourceFindingCopy), which preserves the
+// "suggest" source (pinned in ctoTriage.test.mjs). A suggest-sourced plan
+// must be presence-gated exactly like any other finding-sourced one, while
+// the inbox blocker's shape (source "inbox", noteKind "blocker") keeps the
+// §9.4 blocker exemption.
+// ---------------------------------------------------------------------------
+
+test("driver: §9.4 presence — a suggest-sourced plan defers to ask while present; an inbox blocker runs", async () => {
+  const f = fakeDriverDeps({ runnerResults: [] });
+  let presenceState = "present";
+  f.deps.presence = async () => presenceState;
+  const d = createCtoExecutorDriver(f.deps);
+  // The post-sourceFindingCopy shape of a suggest finding record.
+  const suggestFinding = {
+    source: "suggest",
+    sourceKind: "failure-recurrence",
+    sourceId: "rec:x",
+    ts: 1_000,
+    message: "Pipeline red on main",
+    title: "CTO finding: failure-recurrence",
+    refs: ["c1"],
+    pendingSince: 1_000,
+  };
+  const r1 = await d.executePlan(basePlan({ id: "pl-suggest" }), { finding: suggestFinding });
+  assert.equal(r1.ok, false, "a suggest-sourced machine act refuses while the user is present");
+  assert.equal(r1.reason, "presence-gated");
+  await settle(5);
+  assert.equal((await f.state.store.load()).entries.length, 0);
+  // The inbox blocker's real shape runs regardless of presence.
+  const r2 = await d.executePlan(basePlan({ id: "pl-inbox" }), {
+    finding: { source: "inbox", noteKind: "blocker", message: "deploy failed", refs: [] },
+  });
+  assert.equal(r2.ok, true);
+  await settle(10);
+  // Away → the same suggest plan runs.
+  presenceState = "away";
+  const r3 = await d.executePlan(basePlan({ id: "pl-suggest" }), { finding: suggestFinding });
+  assert.equal(r3.ok, true);
+  await settle(10);
+  const rows = (await f.state.store.load()).entries;
+  assert.deepEqual(rows.map((r) => r.planId).sort(), ["pl-inbox", "pl-suggest"]);
+});

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -86,6 +86,11 @@ export const CONNECT_SOURCE_KIND = "tool";
 // failure that degraded the digest. Keyed by `<tool>/<probe>`; the body
 // deep-links (in copy) to the secrets surface — the fix is a rotated key.
 export const PROBE_SOURCE_KIND = "probe";
+// Evidence-driven suggestion findings (BET-1520 / §9.1): digest-detected
+// failure recurrences, fact anomalies, watcher hits. NOT a blocker source —
+// they shed first in thrifty mode (§12.2) and defer to ask while present
+// (§9.4); the "suggest" source is what downstream reads to tell them apart.
+export const SUGGEST_FINDING_SOURCE = "suggest";
 
 // BET-1498: engine-state.json marker key for the one-time prune of the
 // pre-BET-1469 contentless open cards. Same idempotency contract as the
@@ -152,28 +157,33 @@ export function splitOrphanedShedCards(cards) {
 //
 // A blocker enters the pipeline on the next engine tick via the findings.json
 // queue (the §9.2-v2 bypass removed: the note used to ride into evidence only
-// at a rollup-close breakpoint). Three producers, one row shape:
+// at a rollup-close breakpoint). Four producers, one row shape:
 //   - an inbox blocker note, queued at note arrival (source "inbox")
 //   - a worker ask promoted past the 10-min threshold (source "ask")
 //   - a health escalation ingested from the watchdog (source "health")
+//   - an evidence-driven suggestion finding from the collectors
+//     (BET-1520, source "suggest": failure recurrences, fact anomalies,
+//     watcher hits)
 // Every row carries the normalized core the pipeline consumes downstream:
 //   {source, sourceKind, sourceId, ts, message, title, refs, pendingSince}
 // where `sourceId` is the stable card identity (the exact key the card
 // writer groups by), and producer-specific fields ride alongside (note
-// identity + sender for inbox; sessionID for asks; nothing extra for
-// health). The ENGINE's drain turns each row into a high-salience evidence
-// row on the A1 ledger — for inbox notes the exact row shape drainInbox
-// writes — and marks the source note read so the breakpoint drain never
-// double-folds it. Pure builders; these shapes are the producer↔consumer
-// contract.
+// identity + sender for inbox; sessionID for asks; the collector's reason +
+// project for suggest findings). The ENGINE's drain turns each row into a
+// high-salience evidence row on the A1 ledger — for inbox notes the exact
+// row shape drainInbox writes — and marks the source note read so the
+// breakpoint drain never double-folds it. Pure builders; these shapes are
+// the producer↔consumer contract.
 
 // The drain's ledger-kind mapping, in ONE pure place so the producers and
 // the engine's drain cannot drift: an ask folds as `ask.<sourceKind>`, a
 // health escalation as `health.blocker`, an inbox note as
-// `inbox.<noteKind>` (the shape drainInbox already wrote).
+// `inbox.<noteKind>` (the shape drainInbox already wrote), a suggestion
+// finding as `suggest.<sourceKind>` (BET-1520).
 export function findingLedgerKind(row) {
   if (row?.source === "ask") return `ask.${row?.sourceKind ?? "blocker"}`;
   if (row?.source === "health") return `health.blocker`;
+  if (row?.source === SUGGEST_FINDING_SOURCE) return `suggest.${row?.sourceKind ?? "finding"}`;
   return `inbox.${row?.noteKind ?? "blocker"}`;
 }
 
@@ -236,6 +246,34 @@ export function findingFromHealthGroup(group, { key, sourceId, ts = Date.now() }
     refs: [],
     pendingSince: Number.isFinite(group.minTs) ? group.minTs : undefined,
     tag: typeof key === "string" ? key : undefined,
+  };
+}
+
+// Source (4, BET-1520): an evidence-driven suggestion finding from the
+// ctoSuggest collectors — a digest-detected failure recurrence
+// (`failure-recurrence`), a fact anomaly (`fact-anomaly`) or a watcher hit
+// (`watcher-hit` / `watcher-hit-rate`). `f` is the collector's output shape
+// ({id, sourceKind, text, refs, ts?, reason?, project?}); `id` is the
+// collector's own stable content key (`rec:*`, `anom:*`, `wh:*`) and becomes
+// the row's `sourceId` — findingIdOf re-hashes it so a re-collected
+// identical finding keeps one finding id across passes (the usedKeys dedupe
+// still bounds enqueue to once per finding). `reason` (the anomaly collector's
+// why) and `project` (watcher hits capture it at hit time) ride alongside.
+export function findingFromSuggestion(f, { ts = Date.now() } = {}) {
+  if (!f || typeof f !== "object") return null;
+  const text = typeof f.text === "string" ? f.text.trim() : "";
+  if (!text) return null;
+  return {
+    source: SUGGEST_FINDING_SOURCE,
+    sourceKind: typeof f.sourceKind === "string" && f.sourceKind ? f.sourceKind : "finding",
+    sourceId: typeof f.id === "string" ? f.id : undefined,
+    ts,
+    message: text,
+    title: `CTO finding: ${typeof f.sourceKind === "string" && f.sourceKind ? f.sourceKind : "evidence"}`,
+    refs: Array.isArray(f.refs) ? f.refs : [],
+    pendingSince: Number.isFinite(f.ts) ? f.ts : ts,
+    reason: typeof f.reason === "string" ? f.reason : undefined,
+    project: typeof f.project === "string" && f.project ? f.project : undefined,
   };
 }
 
@@ -1255,7 +1293,7 @@ export function createCtoCards(deps = {}) {
   // the candidate's stable id (hash(findingId, class)) — a regeneration
   // updates the existing open card in place (title/why/options/evidence
   // refresh; created + carried-forward open-verdict count preserved), never
-  // duplicates. Option `action` types use the closed ACTION_TYPES enum; RPC is
+  // duplicates. An option's bound `action` executes through the ask path; RPC is
   // deliberately out of scope for the server — option execution is the
   // renderer's job (§9.1 "option buttons execute a bound action").
   async function upsertDecision({ id, title, why, options = [], refs = [], evidence = [], sourceKind, cls, score, capped = false, ts = now() } = {}) {

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -3006,6 +3006,11 @@ export function createCtoEngine(deps = {}) {
     // index.mjs's debug surface, same seam as drainInbox. `cardTick` rides
     // along (the pass that drains findings + runs the §10.3 liveness pass).
     drainFindings,
+    // BET-1520: the queue's producer seam — the fourth producer (the suggest
+    // engine's collectors) enqueues its evidence-driven findings through this
+    // one writer, so every producer shares ONE queue, ONE drain, ONE
+    // triage→gate→executor pipeline.
+    queueFinding: (row) => queueFindingRow(row),
     // BET-1517 (§9.1): the triage stage over the drain's rows — exposed for
     // tests + the gate ticket's seam (stored plans keyed by finding id).
     triageDrained,

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -27,6 +27,7 @@ import { inboxStore, sweepInbox, INBOX_TTL_MS } from "./ctoStores.mjs";
 import { createCtoInbound } from "./cto.mjs";
 import { WATCHER_HIT_KIND, WATCHER_HIT_SALIENCE, EVENT_PATTERN, RATE_THRESHOLD, USAGE_BURN } from "./ctoWatchers.mjs";
 import { findingIdOf } from "./ctoTriage.mjs";
+import { findingFromSuggestion } from "./ctoCards.mjs";
 
 const delay = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -1582,13 +1583,15 @@ test("triageDrained: thrifty keeps ALL §9.1 blocker sources (inbox/ask/health) 
     title: "Host health",
     refs: [],
   };
-  // The future evidence-driven finding (later ticket) — the ONLY class the
-  // shed rung may drop.
+  // BET-1520's evidence-driven finding (the suggest collectors) — the ONLY
+  // class the shed rung may drop.
   const EVIDENCE_ROW = {
-    source: "evidence",
+    source: "suggest",
     ts: clock.ms,
+    sourceKind: "failure-recurrence",
+    sourceId: "rec:x",
     message: "tests flaky",
-    title: "Flake",
+    title: "CTO finding: failure-recurrence",
     refs: [],
   };
   const { engine, stores } = makeFindingsEngine({
@@ -1659,4 +1662,94 @@ test("BET-1516: start() prunes the orphaned concurrentEphemeral health card (mar
   // Marker stamped — a rebuild is a no-op re-prune of a clean store.
   assert.equal((await stores.engineState.load()).shedCardPrune?.pruned, true);
   engine.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// BET-1520 — the fourth producer: the suggest collectors enqueue on the SAME
+// pending-findings queue, and ONE drain → triage → gate pipeline handles
+// every producer.
+// ---------------------------------------------------------------------------
+
+test("drainFindings maps a suggest finding to a suggest.<sourceKind> evidence row with no inbox side effects", async () => {
+  const clock = { ms: 5_000_000 };
+  const ledgerRows = [];
+  const { engine, stores } = makeFindingsEngine({ clock, ledgerRows, cards: {} });
+  // The row shape findingFromSuggestion produces (the collector's contract).
+  const row = findingFromSuggestion(
+    { id: "rec:x", sourceKind: "failure-recurrence", text: "Pipeline red on main", refs: ["c1"] },
+    { ts: clock.ms },
+  );
+  await stores.findings.save({ v: 1, findings: [row] });
+
+  const r = await engine.drainFindings();
+  assert.equal(r.drained, 1);
+  const evidence = ledgerRows.find((x) => x.kind === "suggest.failure-recurrence");
+  assert.ok(evidence, "the suggest finding folds as suggest.* — one kind per producer");
+  assert.equal(evidence.salience, "high");
+  assert.equal(evidence.message, "Pipeline red on main");
+  assert.deepEqual(evidence.refs, ["c1"]);
+  // No inbox note was involved — nothing to mark read, no inbox row.
+  assert.deepEqual((await stores.inbox.load()).entries, []);
+  assert.ok(!ledgerRows.some((x) => x.kind?.startsWith("inbox.")));
+});
+
+test("ONE pipeline: a suggest finding and an inbox blocker share ONE cardTick drain → triage → gate", async () => {
+  const clock = { ms: 6_000_000 };
+  const ledgerRows = [];
+  const modelCalls = [];
+  const { engine, stores } = makeFindingsEngine({
+    clock,
+    ledgerRows,
+    runEphemeral: async (args) => {
+      modelCalls.push(args);
+      return {
+        ok: true,
+        text: JSON.stringify({
+          plans: [
+            {
+              class: "job-redispatch",
+              diagnosis: "Plan from triage.",
+              steps: ["Do the thing"],
+              access: [],
+              verify: { kind: "condition-gone" },
+              undo: "none",
+              confidence: 0.7,
+              report: { one_liner: "Resolution plan", bullets: [] },
+            },
+          ],
+        }),
+      };
+    },
+  });
+  // Producer 1: the suggest collectors' enqueue (findingFromSuggestion).
+  const suggestRow = findingFromSuggestion(
+    { id: "rec:one", sourceKind: "failure-recurrence", text: "Pipeline red on main", refs: ["c1"] },
+    { ts: clock.ms },
+  );
+  // Producer 2: an inbox blocker note's enqueue.
+  const inboxR = inboxRow(clock.ms);
+  await stores.findings.save({ v: 1, findings: [suggestRow, inboxR] });
+
+  // ONE tick: drain → triage (one gated call per finding) → gate → executor.
+  await engine.cardTick();
+
+  // The queue is empty; both rows went through the SAME drain.
+  assert.deepEqual((await stores.findings.load()).findings, []);
+  // Two triage calls — one per producer's row, through the same caller.
+  assert.equal(modelCalls.length, 2);
+  // Both plan records landed, keyed by their producer-specific finding ids.
+  const records = (await stores.plans.load()).records;
+  assert.equal(Object.keys(records).length, 2);
+  assert.ok(records[findingIdOf(suggestRow)], "the suggest finding got a §9.2 plan record");
+  assert.ok(records[findingIdOf(inboxR)], "the inbox blocker got a §9.2 plan record");
+  assert.equal(records[findingIdOf(suggestRow)].finding.source, "suggest", "provenance survives to the plans store");
+  // Both evidence rows are the producer-specific kinds, in ONE ledger.
+  assert.ok(ledgerRows.some((x) => x.kind === "suggest.failure-recurrence"));
+  assert.ok(ledgerRows.some((x) => x.kind === "inbox.blocker"));
+  // The gate ran for both records on the SAME pass (fresh class → ask cards;
+  // every record got its gate.asked trail through the same gatePass loop).
+  const asked = ledgerRows.filter((x) => x.kind === "gate.asked");
+  assert.equal(asked.length, 2, "one gate decision per finding, same pass");
+  const cardsPayload = await stores.cards.load();
+  assert.equal(cardsPayload.cards.filter((c) => c.variant === "decision").length, 2, "both producers surface through the §9.3 ask card");
 });

--- a/src/server/ctoSuggest.mjs
+++ b/src/server/ctoSuggest.mjs
@@ -1,41 +1,40 @@
 // src/server/ctoSuggest.mjs
-// BET-1392 — the suggestion engine (spec §9.1) + the §14.3 silence audit.
+// BET-1392 — the suggestion-engine finding COLLECTOR (spec §9.1) + the §14.3
+// silence audit. BET-1520: the bespoke surface path is retired — findings no
+// longer generate candidates, worthiness scores, or decision cards here.
 //
 // Responsibilities:
-//   - Candidate generator: for each high-salience finding, ONE gated `suggest`
-//     model call MAY emit ≤3 candidates. Each candidate is stable-keyed
-//     `id = hash(findingId, class)` (regeneration upserts the card, never
-//     duplicates), carries the finding text + refs, and ≤3 options whose
-//     `action` type comes from a closed enum (`ACTION_TYPES`). The generator is
-//     told which option types are reachable by data so it cannot propose what
-//     the data forbids: `tool-write` only for tools holding the write ring
-//     (empty ring = branch unreachable), `queue-tonight` only at High tier.
-//   - Worthiness gate: a `worthiness` class call returns a 0..1 score; the
-//     candidate probability is `score × class prior × sender reliability`
-//     (§9.1 calibration). A per-class salience floor (`p_ask` from
-//     `defaultThresholds()`, flat engine-state override wins) sits BELOW the
-//     surface verbs: under it a candidate is SILENT-LOGGED (a ledger row
-//     {id, score, reason}) for the §14.3 silence audit. Above it, the §9.3
-//     gate (ctoGate.mjs, BET-1518) decides act vs ask:
-//     `effective = p × calibration(class)` (§9.5); `effective ≥ τ` acts
-//     through the executeAction seam (refusal → ask card, never a silent
-//     no-op), `effective < τ` surfaces the decision card. The v2 verb ladder
-//     (trust tiers, veto-window verb, cold-start pin, p_act) is deleted
-//     (D22 supersedes v2 §9.4 and §10.6-4); `notify` is a delivery property
-//     of ask (steep-decay kinds), not a verb.
+//   - Collectors: high-salience findings from the P2 evidence sources —
+//     digest-detected failure recurrences, fact anomalies, and watcher hits
+//     (BET-1398). Each collector returns a stable, content-derived `id`.
+//   - Enqueue (BET-1520): every collected finding is normalized into the
+//     pending-findings row shape (findingFromSuggestion in ctoCards.mjs) and
+//     queued through the injected `queueFinding` seam — the SAME producer
+//     queue inbox notes, promoted asks and health escalations ride. The
+//     engine's ONE pipeline takes over from there: drain → triage (§9.2,
+//     0–3 plans; MAY output none) → gate (§9.3 act/ask) → executor (§9.4/§9.5).
+//     The old in-module path — the suggest generator, worthiness probability,
+//     per-class salience floors, the verb decision, bound-action execution
+//     and direct decision-card emission — is deleted: the §9.2 triage call
+//     IS the "0–3 plans or none" step and the §9.3 gate's ask card is the
+//     only card surface. A plan-less finding is silent-logged by the gate
+//     (`suggest.silent`), so the §14.3 audit still counts the holds.
+//   - Dedupe (BET-1465, kept): a finding recurs on every pass for as long as
+//     its source digest/fact stays in the retained window (up to 30 digests);
+//     `es.suggest.usedKeys` marks findings already enqueued so the SAME
+//     finding does not re-pay a triage model call every pass. Keys are the
+//     collectors' content ids, bound at 200, persisted via patchEngineState.
 //   - Silence audit (§14.3): silent-log rows are re-readable; a held item
 //     takes a verdict (accept → the fact/going-forward branch, dismiss → the
 //     rejection counter) through the B3 verdict route.
 //
 // Pure logic + injected I/O in the style of ctoDigest.mjs / ctoEngine.mjs —
-// no live tmux/opencode/network in tests. The model, store, card, config,
-// facts and notify seams are all injectable (`runSuggest`, `runWorthiness`,
-// `cards`, `ledger`, `engineState`, `verdicts`, `digests`, `facts`,
-// `configGet`, `fireNotify`, `now`, `publish`).
+// no live tmux/opencode/network in tests. The store, ledger and queue seams
+// are all injectable (`queueFinding`, `ledger`, `engineState`, `digests`,
+// `facts`, `now`, `publish`).
 
 import { createHash } from "node:crypto";
 import {
-  appendLedgerBestEffort,
   ledgerStore,
   engineStateStore,
   patchEngineState,
@@ -43,38 +42,7 @@ import {
   factsStore,
 } from "./ctoStores.mjs";
 import { collectWatcherHitsFromLedger } from "./ctoWatchers.mjs";
-// BET-1518 (§9.3/§9.5): the gate replaces the verb ladder — act vs ask on
-// effective = p × calibration(class) vs τ; the suggest flow's candidate
-// confidence is its worthiness p.
-import { DEFAULT_TAU, evaluateGate } from "./ctoGate.mjs";
-
-export const SUGGEST_VERSION = 1;
-
-// The closed enum of bound-action option types (§9.1, §10.3).
-export const ACTION_TYPES = Object.freeze([
-  "config-change",
-  "queue-tonight",
-  "start-job",
-  "tool-write",
-  "record-decision",
-]);
-
-// Steep-decay source kinds that earn the `notify` (informational router call)
-// variant alongside the decision card. Deterministic rule, not a learned flag.
-// BET-1398: a watcher whose predicate was rate-threshold carries sourceKind
-// `watcher-hit-rate` and earns the notify variant (a burst-trip is a steep
-// signal); a plain `watcher-hit` (event-pattern / usage-burn) does not.
-export const NOTIFY_RECURRENCE_KINDS = Object.freeze(["failure-recurrence", "watcher-hit-rate"]);
-
-// §9.2 class priors — the per-class `p(want | class)` used in worthiness
-// calibration. Flat defaults; callers may override per class via config.
-export const DEFAULT_CLASS_PRIORS = Object.freeze({
-  "config-change": 0.5,
-  "queue-tonight": 0.35,
-  "start-job": 0.4,
-  "tool-write": 0.3,
-  "record-decision": 0.6,
-});
+import { findingFromSuggestion } from "./ctoCards.mjs";
 
 // BET-1465: bound `es.suggest.usedKeys` so it cannot become the next
 // unbounded engine-state store — the `ctoStores.mjs` sweep does not cover
@@ -83,136 +51,14 @@ export const DEFAULT_CLASS_PRIORS = Object.freeze({
 // blind bound is safe here.
 const USED_KEYS_CAP = 200;
 
-// §9.1 per-class salience floors (BET-1471 — implements the BET-1470
-// decision; do not re-litigate). `p_ask` is the worthiness bar a candidate
-// must clear before it may surface at all; below it the candidate is a
-// silent-log row for the §14.3 audit. With reliability at 1.0 a candidate's
-// p ceiling IS its class prior, so the floor derives from that ceiling:
-// `p_ask = 0.8 × ceiling`. The v2 `p_act` half of the pair is dead under the
-// gate (the act/ask split is `effective = p × calibration ≥ τ`, ctoGate.mjs)
-// but stays in the pair shape so the persisted engine-state override
-// (`suggest.thresholds {p_ask, p_act}`) round-trips; only `p_ask` is read.
-// The engine-state override, when present, applies globally to every class.
-export function defaultThresholds() {
-  return {
-    "record-decision": { p_ask: 0.48, p_act: 0.57 },
-    "config-change": { p_ask: 0.4, p_act: 0.48 },
-    "start-job": { p_ask: 0.32, p_act: 0.38 },
-    "queue-tonight": { p_ask: 0.28, p_act: 0.33 },
-    "tool-write": { p_ask: 0.24, p_act: 0.29 },
-  };
-}
-
-// Stable, collision-resistant candidate id: regeneration of the same
-// (findingId, class) yields the same id → the card upserts, never duplicates.
-export function stableSuggestionId(findingId, cls) {
-  return createHash("sha256")
-    .update(`${String(findingId)}\u0000${String(cls)}`)
-    .digest("hex")
-    .slice(0, 24);
-}
-
-// The pure `sha` used for finding ids derived from digest/fact signals.
-export function sha(input) {
-  return createHash("sha256").update(String(input)).digest("hex").slice(0, 24);
-}
-
-// §9.1/7.4 option filtering — the generator emits from the full enum, but the
-// DATA decides which branches are reachable: `tool-write` only for tools whose
-// registry entry holds the `write` ring (an empty list = the branch is
-// unreachable by data); `queue-tonight` only at High tier. Callers pass the
-// P2 `capabilities` so the tonight-queue (P3) and tool-registry (P2-later)
-// subsystems can be off while the pure rule stays faithful to the spec.
-export function filterOptionsByData(options, { writeToolIds = [], tier = "low", capabilities = {} } = {}) {
-  const writeRing = new Set(Array.isArray(writeToolIds) ? writeToolIds : []);
-  const allowQueueTonight = capabilities.queueTonight === true && String(tier).toLowerCase() === "high";
-  const allowToolWrite = capabilities.toolWrite === true;
-  return (Array.isArray(options) ? options : []).filter((o) => {
-    const t = o?.action?.type;
-    if (t === "tool-write") {
-      if (!allowToolWrite) return false;
-      const tool = o.action?.payload?.tool || o.tool;
-      if (!tool || !writeRing.has(tool)) return false;
-    } else if (t === "queue-tonight") {
-      if (!allowQueueTonight) return false;
-    }
-    return true;
-  });
-}
-
-// §9.1 worthiness calibration: p(want|E) = nano-model score × class prior ×
-// sender reliability, clamped to [0,1]. `score` is the model's 0..1 estimate.
-export function worthinessProbability(score, prior = 0.5, senderReliability = 0.5) {
-  const s = Number.isFinite(score) ? Math.min(1, Math.max(0, score)) : 0;
-  const p = Number.isFinite(prior) ? Math.max(0, prior) : 0;
-  const r = Number.isFinite(senderReliability) ? Math.min(1, Math.max(0, senderReliability)) : 0;
-  return Math.min(1, s * p * r);
-}
-
-// (BET-1518) `decideVerb` — the v2 verb ladder (per-class p_act, trust-tier
-// ceilings, veto-window verb, cold-start pin) — is deleted. The act/ask
-// split is the §9.3 gate (ctoGate.mjs: evaluateGate on effective = p ×
-// calibration vs τ); the salience floor above is the only threshold left.
-
-// ---------------------------------------------------------------------------
-// Generator output normalization (§9.1 schema)
-// ---------------------------------------------------------------------------
-
-export function validateOption(opt) {
-  if (!opt || typeof opt !== "object") return false;
-  if (typeof opt.label !== "string" || opt.label.trim().length === 0) return false;
-  const type = opt.action?.type;
-  if (!ACTION_TYPES.includes(type)) return false;
-  if (!opt.action.payload || typeof opt.action.payload !== "object") return false;
-  return true;
-}
-
-export function validateCandidate(c) {
-  if (!c || typeof c !== "object") return false;
-  if (!ACTION_TYPES.includes(c.class)) return false;
-  if (!c.finding || typeof c.finding !== "object" || typeof c.finding.text !== "string" || !c.finding.text.trim()) return false;
-  if (c.finding.refs !== undefined && (!Array.isArray(c.finding.refs) || !c.finding.refs.every((r) => typeof r === "string"))) return false;
-  if (!Array.isArray(c.options) || c.options.length === 0 || c.options.length > 3) return false;
-  return c.options.every(validateOption);
-}
-
-// Tolerant JSON extractor (a model may wrap the JSON in prose/fences).
-export function parseSuggestionText(text) {
-  if (typeof text !== "string") return null;
-  const start = text.indexOf("{");
-  const end = text.lastIndexOf("}");
-  if (start === -1 || end === -1 || end <= start) return null;
-  try {
-    const obj = JSON.parse(text.slice(start, end + 1));
-    return obj && typeof obj === "object" ? obj : null;
-  } catch {
-    return null;
-  }
-}
-
-// Normalize generated output into a validated, capped, id-bound candidate
-// list (≤3). `findingId` stamps each candidate's stable id.
-export function normalizeCandidates(parsed, findingId) {
-  const raw = Array.isArray(parsed?.candidates) ? parsed.candidates : [];
-  const valid = raw.filter(validateCandidate).slice(0, 3);
-  return valid.map((c) => ({
-    id: stableSuggestionId(findingId, c.class),
-    class: c.class,
-    finding: {
-      text: c.finding.text,
-      refs: Array.isArray(c.finding.refs) ? c.finding.refs : [],
-    },
-    options: c.options,
-  }));
-}
-
 // ---------------------------------------------------------------------------
 // P2 findings sources — digest-detected recurrences + fact anomalies
 // + watcher hits (BET-1398).
 // ---------------------------------------------------------------------------
 
 // A failure-tier digest item that recurs across digests is a high-salience
-// finding (steep decay → earns the notify variant).
+// finding (steep decay → historically earned the notify variant; the notify
+// delivery rides the §9.3 ask card since BET-1520).
 export function collectFailuresFromDigests(digests, { minRecurrence = 2 } = {}) {
   const groups = new Map();
   for (const d of digests || []) {
@@ -267,82 +113,30 @@ export function collectFindings(digests = [], facts = [], opts = {}) {
     ...collectFailuresFromDigests(digests, opts),
     ...collectAnomaliesFromFacts(facts, opts),
     // BET-1398 watcher hits as a candidate source: high-salience `watcher.hit`
-    // evidence rows. `sourceKind` is `watcher-hit`, or `watcher-hit-rate` for a
-    // rate-threshold watcher (which earns the steep-decay notify variant).
+    // evidence rows. `sourceKind` is `watcher-hit`, or `watcher-hit-rate` for
+    // a rate-threshold watcher (a burst-trip is a steep signal).
     ...collectWatcherHitsFromLedger(opts?.ledgerRows),
   ];
 }
 
-// ---------------------------------------------------------------------------
-// Prompt assembly
-// ---------------------------------------------------------------------------
-
-export function buildSuggestContext({ finding, writeToolIds = [], tier = "low", capabilities = {} } = {}) {
-  const opts = [];
-  opts.push("- `config-change`: change a box config value (halts if a value is sensitive)");
-  if (capabilities.queueTonight === true && String(tier).toLowerCase() === "high") {
-    opts.push("- `queue-tonight`: enqueue for tonight's overnight batch");
-  } else {
-    opts.push("- `queue-tonight`: NOT available at the current tier");
-  }
-  if (capabilities.toolWrite === true) {
-    opts.push(`- "tool-write": grant a tool a one-shot "write" ring action — eligible tools: ${writeToolIds.length ? writeToolIds.join(", ") : "(none — branch unreachable)"}`);
-  } else {
-    opts.push("- \"tool-write\": NOT available (no tool holds the write ring)");
-  }
-  opts.push("- `start-job`: launch a background delegate job");
-  opts.push("- `record-decision`: write a decision fact to the facts store");
-  return [
-    {
-      priority: "high",
-      text:
-        `You are the Adaptive CTO's suggestion generator. For the finding below, output at most 3 ` +
-        `candidate suggestions, or nothing if none are warranted. Output ONLY JSON of the form ` +
-        `{"candidates":[{"class":"<action-class>","finding":{"text":"<short restatement>","refs":["<ref>"]},` +
-        `"options":[{"label":"<short human button label>","action":{"type":"<action-type>","payload":{...}}}]}]}. ` +
-        `Each candidate's "class" must be an action-class and each option's action.type one of the available ` +
-        `action-types below. A candidate with zero viable options should simply be omitted. Keep finding.text ` +
-        `a faithful one-line restatement of the evidence, and refs to evidence ids. Currently-available action ` +
-        `types:\n${opts.join("\n")}`,
-    },
-    {
-      priority: "medium",
-      text: `Finding (${finding.sourceKind ?? "unknown"}):\n${finding.text || ""}${Array.isArray(finding.refs) && finding.refs.length ? `\nRefs: ${finding.refs.join(", ")}` : ""}`,
-    },
-  ];
+// Stable, collision-resistant candidate id: regeneration of the same
+// (findingId, class) yields the same id → the card upserts, never duplicates.
+// Used by the §9.2 plan id (ctoTriage) since BET-1517.
+export function stableSuggestionId(findingId, cls) {
+  return createHash("sha256")
+    .update(`${String(findingId)}\u0000${String(cls)}`)
+    .digest("hex")
+    .slice(0, 24);
 }
 
-export function buildWorthinessContext({ candidate, sourceKind } = {}) {
-  return [
-    {
-      priority: "high",
-      text:
-        `You are the gatekeeper deciding whether to surface one CTO suggestion to the user. ` +
-        `Rate how much the user would WANT this suggestion surfaced RIGHT NOW on a 0..1 scale. ` +
-        `Output ONLY a JSON number, e.g. 0.7. Consider relevance, urgency, and the cost of interrupting ` +
-        `the user. 0 = not worth surfacing; 1 = surface immediately.`,
-    },
-    {
-      priority: "medium",
-      text:
-        `Suggestion (class ${candidate.class}, source ${sourceKind ?? "unknown"}):\n` +
-        `${candidate.finding?.text || ""}\n` +
-        `Options: ${(candidate.options || []).map((o) => `[${o.action?.type}] ${o.label}`).join(" | ") || "none"}`,
-    },
-  ];
-}
-
-// Parse a worthiness model number (tolerant: "0.7", " 0.7", "score: 0.7").
-export function parseWorthinessScore(text) {
-  if (typeof text !== "string") return null;
-  const m = text.match(/(\d+(?:\.\d+)?)/);
-  if (!m) return null;
-  const n = Number(m[1]);
-  return Number.isFinite(n) ? n : null;
+// The pure `sha` used for finding ids derived from digest/fact signals
+// (collectors above) and finding ids derived from queue rows (ctoTriage).
+export function sha(input) {
+  return createHash("sha256").update(String(input)).digest("hex").slice(0, 24);
 }
 
 // ---------------------------------------------------------------------------
-// The suggestion engine — injected store/ledger/cards/model/config/now.
+// The finding-collector engine — injected store/ledger/queue/now.
 // ---------------------------------------------------------------------------
 
 export function createCtoSuggest(deps = {}) {
@@ -353,53 +147,13 @@ export function createCtoSuggest(deps = {}) {
     engineState = engineStateStore,
     digests = digestsStore,
     facts = factsStore,
-    configGet = async () => ({}),
-    cards = null, // ctoCards manager exposing upsertDecision (D20; may be null → decisions become silent-logs)
-    runSuggest = null, // gated runEphemeral for `suggest`; null → no generation
-    runWorthiness = null, // gated runEphemeral for `worthiness`; null → worthiness score 0.5
-    getWriteRingTools = async () => [], // §7.4 write ring (P2: empty → tool-write unreachable)
-    capabilities = { queueTonight: false, toolWrite: false }, // P2 subsystems off
-    fireNotify = async () => {}, // informational-tier router call (notify variant)
-    senderReliability = async () => 0.5, // async (finding) => [0,1]
-    classPriors = {}, // overrides for DEFAULT_CLASS_PRIORS
-    thresholds = null, // in-memory engine-state thresholds (lazy)
+    // BET-1520: the pending-findings queue writer — the engine's `queueFinding`
+    // seam (index.mjs wires it to the SAME queue the cards funnel uses).
+    // null → findings are collected but never queued, and are never marked
+    // used, so the first wired pass picks them up.
+    queueFinding = null,
     recordVerdict = null, // async ({subject, verdict, never}) => {ok} — B3 verdict route
-    executeAction = null, // BET-1403: async ({cls, action, candidate}) => {ok, ...} — act-and-report executors; refusal → ask card
-    // BET-1518 (§9.3/§9.5): the gate's two inputs. `calibrationOf` is async
-    // (cls) => (0,1] — index.mjs wires it to the engine's calibration
-    // instance; a missing/unreadable class → 0.5 (fresh). `tau` is the τ
-    // source (the ctoAutonomyThreshold Settings control, default 0.7).
-    calibrationOf = async () => 0.5, // async cls => (0,1]; index.mjs wires the calibration engine
-    tau = async () => DEFAULT_TAU, // async () => 0..1 — the ctoAutonomyThreshold setting
-    recordAct = null, // async ({cls, text, refs, action, score}) — act-and-report queue + ledger row
   } = deps;
-
-  const priors = { ...DEFAULT_CLASS_PRIORS, ...classPriors };
-
-  async function ledgerAppend(entry) {
-    return appendLedgerBestEffort(ledger, now(), entry);
-  }
-
-  // The decision card branch shares one upsert core (duplication-gate fix,
-  // was a 10-line intra-file clone): call the writer if wired, swallow a
-  // throw into null, and read the BET-1477 `ok !== false` / `isNew` /
-  // `changed` contract off the result.
-  async function upsertCardRes(upsert, card) {
-    let res = null;
-    if (cards && typeof upsert === "function") {
-      try {
-        res = await upsert({ ...card, ts: now() });
-      } catch {
-        res = null;
-      }
-    }
-    return {
-      res,
-      wrote: !!res && res.ok !== false,
-      isNew: res?.isNew === true,
-      changed: res?.changed === true,
-    };
-  }
 
   async function loadState() {
     let es = {};
@@ -409,20 +163,16 @@ export function createCtoSuggest(deps = {}) {
       es = {};
     }
     const st = (es.suggest && typeof es.suggest === "object") ? es.suggest : {};
-    // BET-1471: `suggest.thresholds` keeps its flat `{p_ask, p_act}` override
-    // shape and is returned raw — per-class salience floors are resolved per
-    // candidate inside processFinding, not baked in here.
-    const th = (st.thresholds && typeof st.thresholds === "object") ? st.thresholds : {};
-    const used = st.usedKeys || [];
-    return { es, st, thresholds: th, used };
+    const used = Array.isArray(st.usedKeys) ? st.usedKeys : [];
+    return { es, st, used };
   }
 
   // BET-1465 (defect 1): persist processed keys into `es.suggest.usedKeys` via
   // the same per-key read-modify-write path every other engine-state writer
   // uses (`patchEngineState`) — a snapshot-spread save here would silently
-  // revert whatever another writer (thresholds, trust migration, …) committed
-  // to `es.suggest` between our load and save. Best-effort: a failed write
-  // means the dedupe misses next pass, not that this pass's work is lost.
+  // revert whatever another writer (trust migration, …) committed to
+  // `es.suggest` between our load and save. Best-effort: a failed write means
+  // the dedupe misses next pass, not that this pass's work is lost.
   async function markUsed(keys) {
     const fresh = [...new Set((keys || []).filter((k) => typeof k === "string" && k))];
     if (!fresh.length) return;
@@ -435,13 +185,6 @@ export function createCtoSuggest(deps = {}) {
     } catch {
       /* best-effort */
     }
-  }
-
-  // BET-1471: the flat override only (in-memory dep + engine-state) —
-  // per-class salience floors are resolved per candidate in processFinding.
-  async function getThresholds() {
-    const { thresholds: th } = await loadState();
-    return { ...(thresholds || {}), ...th };
   }
 
   async function loadDigests({ count = 30 } = {}) {
@@ -494,263 +237,45 @@ export function createCtoSuggest(deps = {}) {
     return out;
   }
 
-  // Run the generator + worthiness gate for ONE finding and route the result.
-  async function processFinding(finding, { tier } = {}) {
-    if (!finding || !finding.id) return { finding: finding?.id, surfaced: 0, silent: 0 };
-
-    // BET-1465 (defect 1): a finding recurs on every pass for as long as its
-    // source digest/fact is retained (up to 30 digests) — without this gate
-    // the SAME finding re-pays the suggest + worthiness model calls, the
-    // ledger row, and (for steep-decay kinds) the notify push every 30
-    // minutes. `finding.id` is already the stable, content-derived identity
-    // the P2 collectors compute (collectFailuresFromDigests /
-    // collectAnomaliesFromFacts / collectWatcherHitsFromLedger) — reused
-    // as-is here, no new id scheme. Gating BEFORE the generator call (rather
-    // than only per-candidate) is what actually avoids "identical work
-    // already done": we cannot know a finding's candidate classes without
-    // calling `runSuggest`, so a candidate-level check alone would still
-    // re-pay that call every pass.
-    // BET-1465 review (nit): loadState() is the single engine-state read for
-    // this finding — its `thresholds` feeds the same merge getThresholds()
-    // does, so we don't pay a second engine-state load per finding per pass.
-    const { used, thresholds: stateThresholds } = await loadState();
-    if (used.includes(finding.id)) {
-      return { finding: finding.id, surfaced: 0, silent: 0 };
-    }
-
-    const th = { ...(thresholds || {}), ...stateThresholds };
-    const writeToolIds = await getWriteRingTools();
-    const reliability = await senderReliability(finding);
-
-    // BET-1465 review (Block 1): the §3.3 ephemeral gate refuses by RETURNING
-    // `{ok:false, gated:true}`, not by throwing — so a budget-closed pass (or
-    // a transient model error / unparseable response) must NOT be treated as
-    // "the generator ran and legitimately said zero candidates". Only mark a
-    // finding used once we've confirmed the generator actually completed and
-    // returned parseable output; a gated/failed/unparseable pass falls
-    // through untouched so the finding is reconsidered next pass, exactly as
-    // it was before this dedupe existed.
-    let candidates = [];
-    let generated = false;
-    if (runSuggest) {
-      try {
-        const res = await runSuggest({
-          taskClass: "suggest",
-          context: buildSuggestContext({ finding, writeToolIds, tier, capabilities }),
-          deps: { validate: (out) => normalizeCandidates(parseSuggestionText(out?.text), finding.id).length >= 0 },
-        });
-        if (res?.ok === false) {
-          // Ephemeral rate/budget gate refused — the generator never ran.
-          generated = false;
-        } else {
-          const parsed = parseSuggestionText(res?.text);
-          if (parsed === null) {
-            // Ran, but returned unparseable output — a transient quality
-            // failure, not a legitimate "no suggestion" answer.
-            generated = false;
-          } else {
-            candidates = normalizeCandidates(parsed, finding.id);
-            generated = true;
-          }
-        }
-      } catch {
-        generated = false;
-      }
-    }
-    if (!candidates.length) {
-      if (generated) {
-        await ledgerAppend({ kind: "suggest.generated", findingId: finding.id, sourceKind: finding.sourceKind, candidates: 0 });
-        await markUsed([finding.id]);
-      }
-      return { finding: finding.id, surfaced: 0, silent: 0 };
-    }
-
-    let surfaced = 0;
-    let silent = 0;
-    for (const c of candidates) {
-      const options = filterOptionsByData(c.options, { writeToolIds, tier, capabilities });
-      if (!options.length) {
-        // Every option was data-excluded → nothing to show; log the hold.
-        await ledgerAppend({ kind: "suggest.silent", id: c.id, class: c.class, score: 0, reason: "data-excluded", sourceKind: finding.sourceKind, text: c.finding.text });
-        silent += 1;
-        continue;
-      }
-      let score = 0.5;
-      if (runWorthiness) {
-        try {
-          const w = await runWorthiness({
-            taskClass: "worthiness",
-            context: buildWorthinessContext({ candidate: c, sourceKind: finding.sourceKind }),
-            deps: { validate: (out) => parseWorthinessScore(out?.text) != null },
-          });
-          score = parseWorthinessScore(w?.text) ?? 0.5;
-        } catch {
-          score = 0.5;
-        }
-      }
-      const p = worthinessProbability(score, priors[c.class], reliability);
-      // §9.1 salience floor: under the class's p_ask the candidate is a
-      // silent-log row (the §14.3 audit counts it). The per-class floor
-      // resolves here (BET-1471); `th` is the flat engine-state override
-      // that applies globally when present. p_act is dead under the gate.
-      const perClass = defaultThresholds()[c.class] || defaultThresholds()["config-change"];
-      const thMerged = { ...perClass, ...th };
-      const pAsk = Number.isFinite(thMerged.p_ask) ? thMerged.p_ask : perClass.p_ask;
-      if (p < pAsk) {
-        await ledgerAppend({ kind: "suggest.silent", id: c.id, class: c.class, score: p, reason: "below-p_ask", sourceKind: finding.sourceKind, text: c.finding.text });
-        silent += 1;
-        continue;
-      }
-
-      // BET-1518 (§9.3): the gate decides act vs ask on
-      // effective = p × calibration(class) ≥ τ. The candidate's worthiness p
-      // is its stated confidence; the class's calibration comes from the
-      // §9.5 estimator (0.5 fresh). notify is a delivery property of ask
-      // (steep-decay kinds), evaluated up front.
-      const notify = NOTIFY_RECURRENCE_KINDS.includes(finding.sourceKind);
-      let cal = 0.5;
-      try {
-        const cRaw = await calibrationOf(c.class);
-        cal = Number.isFinite(cRaw) ? Math.min(1, Math.max(0, cRaw)) : 0.5;
-      } catch {
-        cal = 0.5;
-      }
-      let tauNow = DEFAULT_TAU;
-      try {
-        const tRaw = await tau();
-        if (Number.isFinite(tRaw)) tauNow = Math.min(1, Math.max(0, tRaw));
-      } catch {
-        tauNow = DEFAULT_TAU;
-      }
-      const decision = evaluateGate({
-        plans: [{ id: c.id, class: c.class, confidence: p }],
-        tau: tauNow,
-        calibration: { [c.class]: cal },
-      });
-
-      const baseCard = {
-        id: c.id,
-        title: c.finding.text || "CTO suggestion",
-        why: `Suggested as "${c.class}": ${c.finding.text}`,
-        sourceKind: finding.sourceKind,
-        cls: c.class,
-        refs: c.finding.refs,
-        evidence: c.finding.refs,
-        options,
-        score: p,
-      };
-      // BET-1465 (defect 1, belt-and-braces): whether the card write that
-      // actually surfaced was a genuinely NEW card (`isNew`), not a re-upsert
-      // of one already on the board. Gates `fireNotify` below so a re-surfaced
-      // suggestion never re-pushes even if the (1) dedupe above somehow missed.
-      let cardIsNew = false;
-
-      // §9.2 act-and-report: the bound action of the primary option executes
-      // immediately; the ledger row + the digest announcement are written
-      // through recordAct. An unexecutable action (no executor wired,
-      // executor refused, no primary option) degrades to the ask card —
-      // never silently acts, never a veto-window (the veto-window verb is
-      // deleted with the ladder).
-      if (decision.verb === "act") {
-        const action = options[0]?.action ?? null;
-        let exec = { ok: false, reason: "no-executor" };
-        if (action && typeof executeAction === "function") {
-          try {
-            exec = (await executeAction({ cls: c.class, action, candidate: c })) ?? { ok: false };
-          } catch {
-            exec = { ok: false };
-          }
-        }
-        if (exec?.ok === true) {
-          if (typeof recordAct === "function") {
-            await recordAct({ cls: c.class, text: c.finding.text, refs: c.finding.refs, action, score: decision.effective }).catch(() => {});
-          }
-          await ledgerAppend({ kind: "suggest.acted", cardId: c.id, class: c.class, actionType: action?.type, score: p, sourceKind: finding.sourceKind });
-          surfaced += 1;
-          continue;
-        }
-        // fall through to the decision card
-      }
-
-      // ask verb (or degraded act) → write (or upsert) the decision card.
-      // BET-1477: `ok !== false` is the "card path worked" test — a
-      // byte-identical regeneration of an unchanged decision card is
-      // "already surfaced, still current" (surfaced, no new ledger row, no
-      // re-push), NOT a `suggest.silent` no-card-path hold. Only a missing
-      // writer, a thrown write, or an explicit `ok: false` is a hold.
-      {
-        const up = await upsertCardRes(cards?.upsertDecision, { ...baseCard, variant: "decision" });
-        cardIsNew = up.isNew;
-        if (up.wrote) {
-          if (up.changed) {
-            await ledgerAppend({ kind: "suggest.presented", cardId: c.id, class: c.class, variant: "decision", score: p, sourceKind: finding.sourceKind });
-          }
-          surfaced += 1;
-        } else {
-          // No card machinery (or it failed) → hold instead of acting.
-          await ledgerAppend({ kind: "suggest.silent", id: c.id, class: c.class, score: p, reason: "no-card-path", sourceKind: finding.sourceKind, text: c.finding.text });
-          silent += 1;
-          continue;
-        }
-      }
-
-      // notify variant: informational-tier router call when the decay rule
-      // matches AND a decision card was actually surfaced. Also require
-      // `cardIsNew` (belt-and-braces, defect 1): a re-surfaced suggestion
-      // (upsert of an existing card) must never re-push, even if it somehow
-      // reached here despite the (1) dedupe gate above.
-      if (notify === true && cardIsNew) {
-        try {
-          await fireNotify({
-            title: "CTO suggestion",
-            message: `Consider "${c.class}": ${c.finding.text}`,
-            urgent: false,
-            // BET-1465 (defect 2, review fix): every session-less AI `notify`
-            // call previously collided on the SAME "notify-global" tag and
-            // silently overwrote its predecessor in the notification shade.
-            // `sessionID` is NOT a private tag input — it travels to the
-            // phone and the native app deep-links a tap to that session, so
-            // synthesizing one here (as the first cut of this fix did) opens
-            // a tap onto a session that doesn't exist. `tag` is the caller
-            // override push.mjs now exposes for exactly this case; sessionID
-            // stays unset, so a tap just opens the app, as it always did for
-            // a session-less notify.
-            tag: `cto-suggest:${c.id}`,
-          });
-        } catch {
-          /* best-effort */
-        }
-      }
-    }
-    // BET-1465 review (Question 1): only `finding.id` is ever read back by the
-    // dedupe gate above — per-candidate keys were write-only and, at ~2
-    // candidates/finding, were eating the 200-entry cap ~3x faster than the
-    // cap implies. Persist only what's actually consulted.
-    await markUsed([finding.id]);
-    return { finding: finding.id, surfaced, silent };
-  }
-
-  // The full pass: collect findings from P2 sources, then process each.
-  // Returns `{findings, surfaced, silent}` for diagnostics/tests.
+  // The full pass: collect findings from the P2 sources, dedupe against
+  // usedKeys, and enqueue each fresh finding on the pending-findings queue
+  // (BET-1520). Returns `{findings, enqueued}` for diagnostics/tests.
   async function runPass({ nowMs = now() } = {}) {
-    const cfg = await configGet();
-    const tier = String(cfg?.ctoTier ?? "low").toLowerCase();
     const [digestsArr, factsArr, ledgerRows] = await Promise.all([loadDigests(), loadFacts(), loadLedgerRows()]);
     const findings = collectFindings(digestsArr, factsArr, { nowMs, ledgerRows });
-    let surfaced = 0;
-    let silent = 0;
+    const { used } = await loadState();
+    const usedSet = new Set(used);
+    let enqueued = 0;
+    const enqueuedKeys = [];
     for (const f of findings) {
-      const r = await processFinding(f, { tier });
-      surfaced += r.surfaced;
-      silent += r.silent;
+      if (!f || typeof f.id !== "string" || !f.id || usedSet.has(f.id)) continue;
+      const row = findingFromSuggestion(f, { ts: nowMs });
+      if (!row) continue;
+      if (typeof queueFinding !== "function") break;
+      try {
+        await queueFinding(row);
+      } catch {
+        // The enqueue failed — do NOT mark this finding used; the next pass
+        // retries it. The rest of the findings still attempt their enqueue.
+        continue;
+      }
+      enqueued += 1;
+      enqueuedKeys.push(f.id);
     }
-    await publish({ kind: "suggestState", payload: { findings: findings.length, surfaced, silent, ts: nowMs } });
-    return { findings: findings.length, surfaced, silent };
+    // Mark used only after the enqueues that actually happened (the same
+    // confirm-then-commit order the old flow used for its model calls): a
+    // wrongly-consumed key loses the finding until its source leaves the
+    // retained window, a missed stamp costs one redundant triage call.
+    await markUsed(enqueuedKeys);
+    await publish({ kind: "suggestState", payload: { findings: findings.length, enqueued, ts: nowMs } });
+    return { findings: findings.length, enqueued };
   }
 
   // ---- §14.3 silence audit ----
   // The held (silent-log) rows the monthly digest's "I held back N items —
-  // review?" aside links to. Reverse-chron, with an optional cursor.
+  // review?" aside links to. Reverse-chron, with an optional cursor. Since
+  // BET-1520 the rows are written by the gate (plan-less / no-card-path
+  // holds) — this stays the single read surface.
   async function listHeld({ before, limit = 100 } = {}) {
     let rows = [];
     try {
@@ -790,12 +315,7 @@ export function createCtoSuggest(deps = {}) {
 
   return {
     runPass,
-    processFinding,
     listHeld,
     verdictHeld,
-    getThresholds,
-    // exposed for tests / diagnostics
-    _priors: priors,
-    _filterOptionsByData: filterOptionsByData,
   };
 }

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -174,13 +174,22 @@ function makeSug({
   };
 }
 
-test("runPass: collected findings enqueue on the pending-findings queue in the row contract shape", async () => {
+// Shared fixture: the same failure text in two retained digests → one
+// failure-recurrence finding collected on every pass. Returns the raw list
+// (for collectors assertions) and the store dep wired to serve it.
+function recurringDigests() {
   const digestList = [
     { generated: 1, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c1"] }] },
     { generated: 2, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c2"] }] },
   ];
+  const digests = { list: async () => ["d1", "d2"], load: async (id) => (id === "d1" ? digestList[0] : digestList[1]) };
+  return { digestList, digests };
+}
+
+test("runPass: collected findings enqueue on the pending-findings queue in the row contract shape", async () => {
+  const { digests } = recurringDigests();
   const h = makeSug({
-    digests: { list: async () => ["d1", "d2"], load: async (id) => (id === "d1" ? digestList[0] : digestList[1]) },
+    digests,
     facts: {
       list: async () => ["p1"],
       load: async () => ({ facts: [{ id: "f1", kind: "anomaly", statement: "Deploys spike on Tuesdays", refs: ["file:1"] }] }),
@@ -209,12 +218,9 @@ test("runPass: collected findings enqueue on the pending-findings queue in the r
 });
 
 test("dedupe: a second runPass over the same retained sources enqueues nothing (BET-1465 kept)", async () => {
-  const digestList = [
-    { generated: 1, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c1"] }] },
-    { generated: 2, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c2"] }] },
-  ];
+  const { digests } = recurringDigests();
   const h = makeSug({
-    digests: { list: async () => ["d1", "d2"], load: async (id) => (id === "d1" ? digestList[0] : digestList[1]) },
+    digests,
     queueFinding: () => {},
   });
   const r1 = await h.sug.runPass({ nowMs: h.clock.ms });
@@ -335,7 +341,11 @@ test("verdictHeld: routes judgment to the B3 verdict route", async () => {
   assert.equal(verdictEntries[0].verdict, "dismiss");
 });
 
-test("verdictHeld stamps the held row's class onto the subject (§9.5 attribution)", async () => {
+// Shared verdict-harness scaffold: a fixed ledger carrying one silent-log
+// row and a minimal wired engine. `recordVerdict` truthy → the B3 route is
+// wired to record into the returned `recorded` array; null → the unwired
+// route under test.
+function verdictHarness(recordVerdict) {
   const recorded = [];
   const rows = [{ id: "held-9", kind: "suggest.silent", class: "tool-write", ts: 1 }];
   const sug = createCtoSuggest({
@@ -343,11 +353,20 @@ test("verdictHeld stamps the held row's class onto the subject (§9.5 attributio
     engineState: { load: async () => ({ v: 1 }), save: async () => {} },
     now: () => 1_000,
     publish: () => {},
-    recordVerdict: async ({ subject, verdict }) => {
-      recorded.push({ subject, verdict });
-      return { ok: true };
-    },
+    ...(recordVerdict
+      ? {
+          recordVerdict: async (input) => {
+            recorded.push(input);
+            return { ok: true };
+          },
+        }
+      : { recordVerdict: null }),
   });
+  return { sug, recorded };
+}
+
+test("verdictHeld stamps the held row's class onto the subject (§9.5 attribution)", async () => {
+  const { sug, recorded } = verdictHarness(true);
   await sug.verdictHeld({ id: "held-9", verdict: "accept" });
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0].subject.class, "tool-write");
@@ -358,14 +377,7 @@ test("verdictHeld stamps the held row's class onto the subject (§9.5 attributio
 // fold anywhere), so an unwired verdict route degrades instead.
 test("verdictHeld without a verdict route degrades — no direct-store append", async () => {
   await verdictsStore.save({ entries: [] });
-  const rows = [{ id: "held-9", kind: "suggest.silent", class: "tool-write", ts: 1 }];
-  const sug = createCtoSuggest({
-    ledger: { append: async () => true, read: async () => rows },
-    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
-    now: () => 1_000,
-    publish: () => {},
-    recordVerdict: null, // unwired route
-  });
+  const { sug } = verdictHarness(null); // unwired route
   const r = await sug.verdictHeld({ id: "held-9", verdict: "accept" });
   assert.equal(r.ok, false);
   assert.match(r.error ?? "", /no-verdict-route/);

--- a/src/server/ctoSuggest.test.mjs
+++ b/src/server/ctoSuggest.test.mjs
@@ -1,35 +1,25 @@
-// BET-1490: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
+// BET-1520: shared fail-fast guard — must stay the first import (see ctoTestGuard.mjs).
 import "./ctoTestGuard.mjs";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { createCtoCards } from "./ctoCards.mjs";
-import { patchStore, verdictsStore } from "./ctoStores.mjs";
+import { verdictsStore } from "./ctoStores.mjs";
 import {
-  ACTION_TYPES,
-  DEFAULT_CLASS_PRIORS,
-  buildSuggestContext,
-  buildWorthinessContext,
   collectAnomaliesFromFacts,
   collectFailuresFromDigests,
   collectFindings,
   createCtoSuggest,
-  defaultThresholds,
-  filterOptionsByData,
-  normalizeCandidates,
-  parseSuggestionText,
-  parseWorthinessScore,
   stableSuggestionId,
-  worthinessProbability,
+  sha,
 } from "./ctoSuggest.mjs";
-import { evaluateGate } from "./ctoGate.mjs";
-// BET-1518: the deleted verb-ladder symbols must be gone — a stale import of
-// decideVerb/VERDICT_MIN below (or anywhere) would break this file's module
-// contract check (see the deleted-symbols test at the bottom).
+import { findingFromSuggestion, findingLedgerKind } from "./ctoCards.mjs";
+import { findingIdOf } from "./ctoTriage.mjs";
+// BET-1520: the deleted surface-path symbols must be gone from the module
+// (see the deleted-symbols test at the bottom).
 const suggestModule = await import("./ctoSuggest.mjs");
 
 // ---------------------------------------------------------------------------
-// Id stability (§9.1)
+// Id stability (§9.1 — the derivation ctoTriage's plan ids re-use)
 // ---------------------------------------------------------------------------
 
 test("stableSuggestionId: same (findingId,class) is stable; different inputs differ", () => {
@@ -40,111 +30,7 @@ test("stableSuggestionId: same (findingId,class) is stable; different inputs dif
 });
 
 // ---------------------------------------------------------------------------
-// Option filtering by data (§9.1 + §7.4) — enum exclusion
-// ---------------------------------------------------------------------------
-
-test("filterOptionsByData: empty write ring always excludes tool-write even with capability on", () => {
-  const opts = [
-    { label: "run", action: { type: "start-job", payload: {} } },
-    { label: "write", action: { type: "tool-write", payload: { tool: "edit" } } },
-  ];
-  const out = filterOptionsByData(opts, { writeToolIds: [], tier: "high", capabilities: { toolWrite: true, queueTonight: true } });
-  assert.deepEqual(out.map((o) => o.label), ["run"]);
-});
-
-test("filterOptionsByData: tool-write on the write ring passes; tool off-ring excluded", () => {
-  const opts = [
-    { label: "write-a", action: { type: "tool-write", payload: { tool: "edit" } } },
-    { label: "write-b", action: { type: "tool-write", payload: { tool: "bash" } } },
-  ];
-  const out = filterOptionsByData(opts, { writeToolIds: ["edit"], tier: "high", capabilities: { toolWrite: true } });
-  assert.deepEqual(out.map((o) => o.label), ["write-a"]);
-});
-
-test("filterOptionsByData: Low/Medium tier excludes queue-tonight; High + capability allows it", () => {
-  const oq = { label: "tonight", action: { type: "queue-tonight", payload: {} } };
-  assert.deepEqual(filterOptionsByData([oq], { tier: "low", capabilities: { queueTonight: true } }).length, 0);
-  assert.deepEqual(filterOptionsByData([oq], { tier: "medium", capabilities: { queueTonight: true } }).length, 0);
-  // capability off (P2 default) — excluded even at High tier
-  assert.deepEqual(filterOptionsByData([oq], { tier: "high", capabilities: { queueTonight: false } }).length, 0);
-  // capability on AND High → allowed
-  assert.equal(filterOptionsByData([oq], { tier: "high", capabilities: { queueTonight: true } }).length, 1);
-});
-
-test("filterOptionsByData: P2 default capabilities exclude both queue-tonight and tool-write", () => {
-  const opts = [
-    { label: "cfg", action: { type: "config-change", payload: {} } },
-    { label: "tonight", action: { type: "queue-tonight", payload: {} } },
-    { label: "write", action: { type: "tool-write", payload: { tool: "edit" } } },
-  ];
-  const out = filterOptionsByData(opts, { writeToolIds: [], tier: "medium", capabilities: {} });
-  assert.deepEqual(out.map((o) => o.label), ["cfg"]);
-});
-
-// ---------------------------------------------------------------------------
-// Worthiness calibration (§9.1)
-// ---------------------------------------------------------------------------
-
-test("worthinessProbability: score × prior × reliability, clamped", () => {
-  assert.equal(worthinessProbability(0.5, 0.5, 0.5), 0.125);
-  assert.equal(worthinessProbability(1, 1, 1), 1);
-  assert.equal(worthinessProbability(2, 1, 1), 1); // clamp high
-  assert.equal(worthinessProbability(0, 1, 1), 0);
-  // invalid/non-finite score treated as 0
-  assert.equal(worthinessProbability(NaN, 1, 1), 0);
-  assert.equal(worthinessProbability(0.5, 0.5, 2), 0.25); // reliability clamped to 1
-  // defaults
-  assert.equal(worthinessProbability(0.5), 0.5 * 0.5 * 0.5);
-});
-
-test("default priors cover the closed enum", () => {
-  for (const t of ACTION_TYPES) {
-    assert.ok(typeof DEFAULT_CLASS_PRIORS[t] === "number", `missing prior for ${t}`);
-  }
-});
-
-// ---------------------------------------------------------------------------
-// Salience floors (BET-1471) — the ONLY thresholds left under the gate.
-// The verb ladder itself (decideVerb, tiers, cold-start, p_act) is deleted
-// (BET-1518); the act/ask split is evaluateGate on effective = p ×
-// calibration ≥ τ (ctoGate.test.mjs covers the gate math).
-// ---------------------------------------------------------------------------
-
-// BET-1471: the shipped per-class table — each floor derives from the class's
-// prior ceiling (p_ask = 0.8 × ceiling). Pinned as exact literals so a prior
-// change without a floor change cannot sneak the arithmetic dead-zone back
-// in. The p_act half of the pair is dead but kept in the shape so the
-// persisted engine-state override round-trips.
-test("defaultThresholds: per-class floors match the BET-1470 decision table", () => {
-  const th = defaultThresholds();
-  for (const t of ACTION_TYPES) {
-    assert.ok(th[t] && typeof th[t] === "object", `missing thresholds for ${t}`);
-  }
-  assert.deepEqual(th["record-decision"], { p_ask: 0.48, p_act: 0.57 });
-  assert.deepEqual(th["config-change"], { p_ask: 0.4, p_act: 0.48 });
-  assert.deepEqual(th["start-job"], { p_ask: 0.32, p_act: 0.38 });
-  assert.deepEqual(th["queue-tonight"], { p_ask: 0.28, p_act: 0.33 });
-  assert.deepEqual(th["tool-write"], { p_ask: 0.24, p_act: 0.29 });
-  // Every floor stays inside its class's p ceiling (= its prior): a candidate
-  // at the ceiling clears the ask bar.
-  for (const t of ACTION_TYPES) {
-    const ceiling = DEFAULT_CLASS_PRIORS[t];
-    assert.ok(th[t].p_ask <= ceiling, `${t}: p_ask must not exceed the prior ceiling`);
-  }
-});
-
-// BET-1518 regression: the deleted ladder symbols must be gone from the
-// module surface (no VERDICT_MIN re-export, no decideVerb, no countVerdicts).
-test("deleted symbols: no decideVerb, no VERDICT_MIN, no countVerdicts on the module", () => {
-  assert.equal("decideVerb" in suggestModule, false);
-  assert.equal("VERDICT_MIN" in suggestModule, false);
-  const eng = createCtoSuggest({});
-  assert.equal(typeof eng.countVerdicts, "undefined");
-  assert.equal("_trust" in eng, false);
-});
-
-// ---------------------------------------------------------------------------
-// Findings collection (P2 sources)
+// Findings collection (P2 sources) — unchanged by BET-1520
 // ---------------------------------------------------------------------------
 
 test("collectFailuresFromDigests: recurring failure becomes a finding; single = not", () => {
@@ -178,242 +64,256 @@ test("collectAnomaliesFromFacts: anomaly/kind, low-confidence, and superseded fa
   assert.ok(findings.some((f) => f.text === "Old priority"));
 });
 
-// ---------------------------------------------------------------------------
-// Generator output normalization (§9.1 schema)
-// ---------------------------------------------------------------------------
-
-test("normalizeCandidates: validates schema, binds stable id, caps at 3", () => {
-  const text = JSON.stringify({
-    candidates: [
-      { class: "start-job", finding: { text: "Retry the build", refs: ["c1"] }, options: [{ label: "Run", action: { type: "start-job", payload: { prompt: "x" } } }] },
-      { class: "bad-class", finding: { text: "ignored" }, options: [{ label: "x", action: { type: "start-job", payload: {} } }] },
-      { class: "config-change", finding: { text: "Bump cap", refs: ["c2"] }, options: [{ label: "Apply", action: { type: "config-change", payload: { patch: {} } } }] },
-      { class: "record-decision", finding: { text: "fourth", refs: [] }, options: [{ label: "4", action: { type: "record-decision", payload: {} } }] },
-      { class: "tool-write", finding: { text: "five", refs: [] }, options: [{ label: "5", action: { type: "tool-write", payload: { tool: "edit" } } }] },
-    ],
-  });
-  const out = normalizeCandidates(parseSuggestionText(text), "rec:abc");
-  assert.equal(out.length, 3); // capped, invalid class dropped
-  assert.equal(out[0].id, stableSuggestionId("rec:abc", "start-job"));
-  assert.ok(out.every((c) => ACTION_TYPES.includes(c.class)));
-  assert.ok(out.every((c) => c.options.length >= 1 && c.options.length <= 3));
-});
-
-test("parseSuggestionText: extracts JSON from prose fences", () => {
-  const out = parseSuggestionText("Here you go:\n```json\n{\"candidates\":[]}\n```");
-  assert.deepEqual(out, { candidates: [] });
-  assert.equal(parseSuggestionText("not json"), null);
-  assert.equal(parseWorthinessScore("0.7"), 0.7);
-  assert.equal(parseWorthinessScore("score: 0.35"), 0.35);
-  assert.equal(parseWorthinessScore("nan"), null);
+test("collectFindings: combines digest + fact sources", () => {
+  const digests = [
+    { items: [{ tier: "failure", text: "F" }, { tier: "failure", text: "F" }] },
+  ];
+  const facts = [{ id: "f", kind: "anomaly", statement: "A" }];
+  const out = collectFindings(digests, facts, { nowMs: Date.now() });
+  assert.equal(out.length, 2);
 });
 
 // ---------------------------------------------------------------------------
-// The pipeline (createCtoSuggest) — injected stores + gated model seams
-//
-// ONE harness builder (`makeSug`) parameterizes the full createCtoSuggest()
-// config over memory-backed stores; each test overrides only the seams it
-// exercises. This is the file-wide generalization of BET-1465's local
-// makeDedupeSug pattern (BET-1474): the duplication gate re-scans the WHOLE
-// changed file, so every repeated config block must live in this builder.
+// The row contract (BET-1520): collector output → pending-findings row
 // ---------------------------------------------------------------------------
 
-// One-candidate generator payload for a class — the shape the gated `suggest`
-// model call returns for a single finding. The "Go" label is arbitrary; no
-// assertion reads it.
-function oneCandidateSuggestText(cls, text, refs = []) {
-  return JSON.stringify({
-    candidates: [{ class: cls, finding: { text, refs }, options: [{ label: "Go", action: { type: cls, payload: {} } }] }],
-  });
-}
+test("findingFromSuggestion: normalized core + producer-specific fields; garbage → null", () => {
+  const ts = 1_000_000;
+  const row = findingFromSuggestion(
+    { id: "rec:abc", sourceKind: "failure-recurrence", text: "Pipeline red on main", refs: ["c1"] },
+    { ts },
+  );
+  assert.equal(row.source, "suggest");
+  assert.equal(row.sourceKind, "failure-recurrence");
+  assert.equal(row.sourceId, "rec:abc", "the collector's stable id is the row's sourceId");
+  assert.equal(row.ts, ts);
+  assert.equal(row.message, "Pipeline red on main");
+  assert.equal(row.title, "CTO finding: failure-recurrence");
+  assert.deepEqual(row.refs, ["c1"]);
+  assert.equal(row.pendingSince, ts);
+  assert.equal(row.reason, undefined);
+  assert.equal(row.project, undefined);
+  // an anomaly's reason and a watcher's project ride alongside
+  const withReason = findingFromSuggestion({ id: "anom:x", sourceKind: "fact-anomaly", text: "s", refs: [], reason: "low-confidence fact (0.3)" });
+  assert.equal(withReason.reason, "low-confidence fact (0.3)");
+  const withProject = findingFromSuggestion({ id: "wh:y", sourceKind: "watcher-hit", text: "s", refs: [], project: "MantaUI" });
+  assert.equal(withProject.project, "MantaUI");
+  assert.equal(findingFromSuggestion(null), null);
+  assert.equal(findingFromSuggestion({ id: "rec:1", sourceKind: "watcher-hit", text: "   " }), null, "no text → no row");
+});
 
-// The shared harness: memory-backed ledger / verdicts / engine-state /
-// calibration / board stores + a parameterized createCtoSuggest(). Defaults
-// encode the common warm wiring (medium tier, reliability 1.0, a card writer
-// that accepts and records every write, fresh calibration 0.5 and τ 0.7 —
-// under which a max-p candidate still ASKS, never acts). `build` assembles
-// a SECOND engine over the same stores for multi-instance tests.
+test("a suggest row's finding id is content-stable across re-collections (usedKeys + plan upserts converge)", () => {
+  const f = { id: "rec:abc", sourceKind: "failure-recurrence", text: "Pipeline red on main", refs: ["c1"] };
+  const id1 = findingIdOf(findingFromSuggestion(f, { ts: 1 }));
+  const id2 = findingIdOf(findingFromSuggestion(f, { ts: 2 })); // re-collected next pass
+  assert.equal(id1, id2);
+  assert.match(id1, /^find:suggest:[0-9a-f]{24}$/);
+  // different findings → different ids
+  const other = findingIdOf(findingFromSuggestion({ ...f, id: "rec:other" }, { ts: 3 }));
+  assert.notEqual(id1, other);
+});
+
+test("findingLedgerKind: suggest rows fold as suggest.<sourceKind>", () => {
+  assert.equal(findingLedgerKind(findingFromSuggestion({ id: "rec:a", sourceKind: "failure-recurrence", text: "x" })), "suggest.failure-recurrence");
+  assert.equal(findingLedgerKind(findingFromSuggestion({ id: "wh:b", sourceKind: "watcher-hit-rate", text: "x" })), "suggest.watcher-hit-rate");
+  assert.equal(findingLedgerKind({ source: "suggest" }), "suggest.finding", "missing kind falls back, never mislabels as inbox");
+});
+
+// ---------------------------------------------------------------------------
+// The engine (createCtoSuggest): collect → dedupe → enqueue (BET-1520)
+// ---------------------------------------------------------------------------
+
+// The shared harness: memory-backed ledger / engine-state stores + a
+// parameterized createCtoSuggest(). Each test overrides only the seams it
+// exercises.
 function makeSug({
-  thresholds = null, // flat {p_ask, p_act} → the es.suggest.thresholds override
-  engineState = null, // full initial engine state (wins over thresholds)
-  calibration = null, // number | async (cls) => (0,1] — the class's §9.5 calibration
-  tau = null, // number | async () => 0..1 — the gate's τ (default 0.7)
+  engineState = null, // full initial engine state
   digests: digestsDep = { list: async () => [], load: async () => null },
-  configGet = async () => ({ ctoTier: "medium" }),
-  capabilities = null,
-  cards: cardsDep = null, // cards dep override; default records into the board
-  vetoSink = null, // array → the cards dep also exposes a recording upsertVeto (overnight tests only)
-  buildCards = null, // ({boardStore, ledger, engineState, now}) => cards manager
-  runSuggest = async () => ({ text: JSON.stringify({ candidates: [] }) }),
-  runWorthiness = async () => ({ text: "0.9" }),
-  senderReliability = async () => 1.0,
-  classPriors = null,
-  executeAction = null,
+  facts: factsDep = { list: async () => [], load: async () => null },
+  collectInput = null, // [digestsArr, factsArr] override → skips store reads for collector inputs
+  queueFinding = null,
   recordVerdict = null, // default: the B3 route, recorded into verdictEntries
-  fireNotify = null, // default: recorded into notified[]
 } = {}) {
   const clock = { ms: 1_000_000 };
   const ledgerRows = [];
   const verdictEntries = [];
-  const notified = [];
-  const acts = [];
-  let board = { v: 1, cards: [] };
-  const initialEs = engineState ?? (thresholds ? { v: 1, suggest: { thresholds } } : { v: 1 });
-  let es = initialEs;
+  const queued = [];
+  let es = engineState ?? { v: 1 };
 
   const ledger = { append: async (r) => ledgerRows.push(r), read: async () => ledgerRows };
-  const verdicts = { load: async () => ({ entries: verdictEntries }), save: async () => {} };
   const engineStateDep = { load: async () => es, save: async (p) => { es = p; } };
-  const boardStore = { load: async () => board, save: async (p) => { board = p; } };
 
-  const defaultCards = {
-    upsertDecision: async (c) => {
-      board.cards.push(c);
-      return { changed: true, isNew: true };
-    },
-  };
-  if (vetoSink) {
-    defaultCards.upsertVeto = async (c) => {
-      vetoSink.push(c);
-      return { changed: true, isNew: true };
-    };
-  }
-  const cardsManager = buildCards
-    ? buildCards({ boardStore, ledger, engineState: engineStateDep, now: () => clock.ms })
-    : cardsDep ?? defaultCards;
-
-  function assemble(extra = {}) {
-    return createCtoSuggest({
-      now: () => clock.ms,
-      publish: () => {},
-      ledger,
-      verdicts,
-      engineState: engineStateDep,
-      digests: digestsDep,
-      facts: { list: async () => [], load: async () => null },
-      configGet,
-      ...(capabilities ? { capabilities } : {}),
-      cards: cardsManager,
-      runSuggest,
-      runWorthiness,
-      senderReliability,
-      ...(classPriors ? { classPriors } : {}),
-      ...(executeAction ? { executeAction } : {}),
-      calibrationOf:
-        calibration == null
-          ? async () => 0.5
-          : typeof calibration === "function"
-            ? calibration
-            : async () => calibration,
-      tau:
-        tau == null
-          ? async () => 0.7
-          : typeof tau === "function"
-            ? tau
-            : async () => tau,
-      recordAct: async (input) => {
-        acts.push(input);
-        return { ok: true };
-      },
-      recordVerdict:
-        recordVerdict ??
-        (async ({ subject, verdict, never }) => {
-          verdictEntries.push({ ts: clock.ms, subject, verdict, ...(never ? { never: true } : {}) });
-          return { ok: true };
-        }),
-      fireNotify: fireNotify ?? (async (args) => { notified.push(args); }),
-      ...extra,
-    });
-  }
+  const sug = createCtoSuggest({
+    now: () => clock.ms,
+    publish: () => {},
+    ledger,
+    engineState: engineStateDep,
+    digests: digestsDep,
+    facts: factsDep,
+    ...(queueFinding
+      ? {
+          queueFinding: async (row) => {
+            await queueFinding(row); // may throw — a failed enqueue is never recorded
+            queued.push(row);
+          },
+        }
+      : {}),
+    ...(recordVerdict ? { recordVerdict } : {}),
+  });
 
   return {
-    sug: assemble(),
-    build: assemble, // a second engine over the SAME stores
+    sug,
     clock,
     ledgerRows,
     verdictEntries,
-    notified,
-    acts,
-    get cardPayload() {
-      return board;
-    },
+    queued,
     getEs: () => es,
     resetEs() {
-      es = initialEs; // simulates usedKeys-cap churn / engine-state reset
+      es = engineState ?? { v: 1 };
     },
   };
 }
 
-test("pipeline: silent-log when below p_ask (no card, ledger row, no notify)", async () => {
+test("runPass: collected findings enqueue on the pending-findings queue in the row contract shape", async () => {
+  const digestList = [
+    { generated: 1, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c1"] }] },
+    { generated: 2, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c2"] }] },
+  ];
   const h = makeSug({
-    thresholds: { p_ask: 0.5, p_act: 0.95 },
-    // low worthiness score → p = 0.2 * prior * reliability < p_ask=0.5
-    runSuggest: async () => ({ text: oneCandidateSuggestText("start-job", "a") }),
-    runWorthiness: async () => ({ text: "0.2" }),
+    digests: { list: async () => ["d1", "d2"], load: async (id) => (id === "d1" ? digestList[0] : digestList[1]) },
+    facts: {
+      list: async () => ["p1"],
+      load: async () => ({ facts: [{ id: "f1", kind: "anomaly", statement: "Deploys spike on Tuesdays", refs: ["file:1"] }] }),
+    },
+    queueFinding: () => {},
   });
-  const r = await h.sug.processFinding({ id: "rec:abc", sourceKind: "fact-anomaly", text: "a", refs: [] }, { tier: "medium" });
-  assert.equal(r.surfaced, 0);
-  assert.equal(r.silent, 1);
-  assert.equal(h.cardPayload.cards.length, 0);
-  assert.ok(h.ledgerRows.some((x) => x.kind === "suggest.silent" && x.id === stableSuggestionId("rec:abc", "start-job")));
-  assert.equal(h.notified.length, 0);
+  const r = await h.sug.runPass({ nowMs: h.clock.ms });
+  assert.equal(r.findings, 2);
+  assert.equal(r.enqueued, 2);
+  assert.equal(h.queued.length, 2);
+  const rec = h.queued.find((row) => row.sourceKind === "failure-recurrence");
+  assert.equal(rec.source, "suggest");
+  assert.equal(rec.sourceId, "rec:" + sha("Pipeline red on main"));
+  assert.equal(rec.message, "Pipeline red on main");
+  assert.deepEqual(rec.refs.sort(), ["c1", "c2"]);
+  const anom = h.queued.find((row) => row.sourceKind === "fact-anomaly");
+  assert.equal(anom.sourceId, "anom:" + sha("f1|Deploys spike on Tuesdays"));
+  assert.equal(anom.reason, "anomaly-kind fact");
+  // finding ids derive cleanly from the queued rows (the pipeline's join key)
+  assert.match(findingIdOf(rec), /^find:suggest:[0-9a-f]{24}$/);
+  // every enqueued key is marked used
+  const used = h.getEs().suggest?.usedKeys ?? [];
+  assert.equal(used.length, 2);
+  assert.ok(used.includes(rec.sourceId));
+  assert.ok(used.includes(anom.sourceId));
 });
 
-test("pipeline: decision card surfaced + notify on failure-recurrence; option executors excluded by P2 data", async () => {
+test("dedupe: a second runPass over the same retained sources enqueues nothing (BET-1465 kept)", async () => {
+  const digestList = [
+    { generated: 1, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c1"] }] },
+    { generated: 2, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c2"] }] },
+  ];
   const h = makeSug({
-    thresholds: { p_ask: 0.2, p_act: 0.95 },
-    runSuggest: async () => ({
-      text: JSON.stringify({
-        candidates: [
-          {
-            class: "start-job",
-            finding: { text: "Restart the stuck build", refs: ["c1"] },
-            options: [
-              { label: "Kick build", action: { type: "start-job", payload: { prompt: "retry" } } },
-              { label: "Tonight", action: { type: "queue-tonight", payload: {} } },
-              { label: "Write", action: { type: "tool-write", payload: { tool: "edit" } } },
-            ],
-          },
-        ],
-      }),
-    }),
-    runWorthiness: async () => ({ text: "1.0" }),
+    digests: { list: async () => ["d1", "d2"], load: async (id) => (id === "d1" ? digestList[0] : digestList[1]) },
+    queueFinding: () => {},
   });
-
-  // failure-recurrence finding → notify
-  const r = await h.sug.processFinding(
-    { id: "rec:x", sourceKind: "failure-recurrence", text: "build", refs: ["c1"] },
-    { tier: "medium" },
-  );
-  assert.equal(r.surfaced, 1);
-  assert.equal(h.notified.length, 1); // steep-decay notify variant fired
-  const card = h.cardPayload.cards[0];
-  assert.ok(card);
-  assert.equal(card.variant, "decision");
-  // P2 data excluded queue-tonight + tool-write (empty write ring / capability off)
-  const labels = card.options.map((o) => o.action.type);
-  assert.deepEqual(labels, ["start-job"]);
+  const r1 = await h.sug.runPass({ nowMs: h.clock.ms });
+  assert.equal(r1.enqueued, 1);
+  h.clock.ms += 30 * 60_000; // the next 30-minute pass over the SAME retained digests
+  const r2 = await h.sug.runPass({ nowMs: h.clock.ms });
+  assert.equal(r2.findings, 1, "the finding is still collected (source retained)");
+  assert.equal(r2.enqueued, 0, "but never re-enqueued — no second triage model call");
+  assert.equal(h.queued.length, 1);
+  assert.equal(h.ledgerRows.length, 0, "the collector writes no ledger rows — evidence rides the drain");
 });
 
-test("pipeline: a fresh class never acts (calibration 0.5 × p < τ) — the gate caps everything at ask", async () => {
-  // BET-1518: with a fresh class (calibration 0.5) and the default τ 0.7,
-  // even a max-worthiness candidate's effective (1.0 × 0.5 = 0.5) stays below
-  // the bar — the cold-start behavior emerges from the estimator, no pin.
+test("enqueue-failure: the failed finding is NOT marked used — the next pass retries it; siblings still enqueue", async () => {
+  let badCalls = 0;
+  const facts = [
+    { id: "f-ok", kind: "anomaly", statement: "Ok statement" },
+    { id: "f-bad", kind: "anomaly", statement: "Bad statement" },
+  ];
   const h = makeSug({
-    thresholds: { p_ask: 0.2, p_act: 0.3 },
-    configGet: async () => ({ ctoTier: "high" }),
-    runSuggest: async () => ({ text: oneCandidateSuggestText("start-job", "cold") }),
-    runWorthiness: async () => ({ text: "1.0" }), // score → p high
+    facts: { list: async () => ["p"], load: async () => ({ facts }) },
+    queueFinding: (row) => {
+      if (row.message === "Bad statement") {
+        badCalls += 1;
+        if (badCalls === 1) throw new Error("store down"); // fails once, recovers
+      }
+    },
   });
-  const r = await h.sug.processFinding({ id: "rec:cold", sourceKind: "fact-anomaly", text: "cold", refs: [] }, { tier: "high" });
-  assert.equal(r.surfaced, 1); // asks -> decision card, not an act
-  assert.equal(h.cardPayload.cards[0].variant, "decision");
+  const r1 = await h.sug.runPass({ nowMs: h.clock.ms });
+  assert.equal(r1.enqueued, 1, "only the healthy enqueue landed");
+  const used = h.getEs().suggest?.usedKeys ?? [];
+  assert.equal(used.length, 1);
+  assert.equal(used[0], "anom:" + sha("f-ok|Ok statement"), "only the healthy finding is consumed");
+
+  const r2 = await h.sug.runPass({ nowMs: h.clock.ms + 1 });
+  assert.equal(r2.enqueued, 1, "the failed finding is reconsidered next pass");
+  assert.equal(h.queued.filter((row) => row.message === "Bad statement").length, 1, "recorded only on the successful retry");
 });
 
-test("listHeld: returns silent-log ledger rows", async () => {
+test("unwired queue seam: findings collect, nothing enqueues, nothing marked used (retried later)", async () => {
+  const h = makeSug({
+    facts: { list: async () => ["p"], load: async () => ({ facts: [{ id: "f", kind: "anomaly", statement: "S" }] }) },
+  });
+  const r = await h.sug.runPass({ nowMs: h.clock.ms });
+  assert.equal(r.findings, 1);
+  assert.equal(r.enqueued, 0);
+  assert.equal((h.getEs().suggest?.usedKeys ?? []).length, 0, "no consumed key for an unqueued finding");
+  // once wired, the same stores pick the finding up
+  const wired = createCtoSuggest({
+    now: () => h.clock.ms,
+    publish: () => {},
+    ledger: { append: async () => {}, read: async () => [] },
+    engineState: { load: () => h.getEs(), save: async () => {} },
+    digests: { list: async () => [], load: async () => null },
+    facts: { list: async () => ["p"], load: async () => ({ facts: [{ id: "f", kind: "anomaly", statement: "S" }] }) },
+    queueFinding: async () => {},
+  });
+  const r2 = await wired.runPass({ nowMs: h.clock.ms });
+  assert.equal(r2.enqueued, 1);
+});
+
+test("usedKeys cap: exactly-at-cap holds every entry; the 201st key evicts the OLDEST and preserves the MRU tail", async () => {
+  const mk = (i) => ({ id: `f${i}`, kind: "anomaly", statement: `Statement ${i}` });
+  const keyOf = (i) => "anom:" + sha(`f${i}|Statement ${i}`); // the collector's content id
+  // 198 seeded keys + 2 enqueued in one pass = exactly 200: NO eviction.
+  const h = makeSug({
+    engineState: { v: 1, suggest: { usedKeys: Array.from({ length: 198 }, (_, i) => `old-${i}`) } },
+    facts: { list: async () => ["p"], load: async () => ({ facts: [mk(200), mk(201)] }) },
+    queueFinding: () => {},
+  });
+  await h.sug.runPass({ nowMs: h.clock.ms });
+  let used = h.getEs().suggest.usedKeys;
+  assert.equal(used.length, 200, "the cap holds: length never exceeds 200");
+  assert.equal(used[0], "old-0", "nothing evicted while filling to exactly the cap");
+  assert.equal(used[199], keyOf(201), "the newest key sits at the tail");
+
+  // One past the cap: the 201st distinct key evicts exactly one entry — the
+  // OLDEST (front), not the newest. Trailing-slice FIFO is the chosen rule.
+  const h2 = makeSug({
+    engineState: { v: 1, suggest: { usedKeys: Array.from({ length: 200 }, (_, i) => `old-${i}`) } },
+    facts: { list: async () => ["p"], load: async () => ({ facts: [mk(201)] }) },
+    queueFinding: () => {},
+  });
+  await h2.sug.runPass({ nowMs: h.clock.ms });
+  used = h2.getEs().suggest.usedKeys;
+  assert.equal(used.length, 200);
+  assert.ok(!used.includes("old-0"), "the 201st key evicts the OLDEST entry");
+  assert.ok(used.includes(keyOf(201)), "the newest key is kept, not dropped");
+  assert.equal(used[0], "old-1", "the second-oldest survives at the front");
+  assert.deepEqual(used.slice(-2), ["old-199", keyOf(201)], "MRU preserved at the tail");
+});
+
+// ---------------------------------------------------------------------------
+// §14.3 silence audit — unchanged read surface (rows are written by the gate)
+// ---------------------------------------------------------------------------
+
+test("listHeld: returns the gate's silent-log ledger rows", async () => {
   const h = makeSug();
   h.ledgerRows.push({ kind: "suggest.silent", id: "a", score: 0.1, ts: 10 });
-  h.ledgerRows.push({ kind: "suggest.presented", cardId: "b", ts: 9 });
+  h.ledgerRows.push({ kind: "gate.asked", cardId: "b", ts: 9 });
   h.ledgerRows.push({ kind: "suggest.silent", id: "c", score: 0.2, ts: 11 });
   const held = await h.sug.listHeld();
   assert.equal(held.length, 2);
@@ -421,12 +321,36 @@ test("listHeld: returns silent-log ledger rows", async () => {
 });
 
 test("verdictHeld: routes judgment to the B3 verdict route", async () => {
-  const h = makeSug();
+  const verdictEntries = [];
+  const h = makeSug({
+    recordVerdict: async ({ subject, verdict, never }) => {
+      verdictEntries.push({ subject, verdict, ...(never ? { never: true } : {}) });
+      return { ok: true };
+    },
+  });
   const r = await h.sug.verdictHeld({ id: "rec:abc", verdict: "dismiss" });
   assert.equal(r.ok, true);
-  assert.equal(h.verdictEntries.length, 1);
-  assert.equal(h.verdictEntries[0].subject.type, "suggestion");
-  assert.equal(h.verdictEntries[0].verdict, "dismiss");
+  assert.equal(verdictEntries.length, 1);
+  assert.equal(verdictEntries[0].subject.type, "suggestion");
+  assert.equal(verdictEntries[0].verdict, "dismiss");
+});
+
+test("verdictHeld stamps the held row's class onto the subject (§9.5 attribution)", async () => {
+  const recorded = [];
+  const rows = [{ id: "held-9", kind: "suggest.silent", class: "tool-write", ts: 1 }];
+  const sug = createCtoSuggest({
+    ledger: { append: async () => true, read: async () => rows },
+    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
+    now: () => 1_000,
+    publish: () => {},
+    recordVerdict: async ({ subject, verdict }) => {
+      recorded.push({ subject, verdict });
+      return { ok: true };
+    },
+  });
+  await sug.verdictHeld({ id: "held-9", verdict: "accept" });
+  assert.equal(recorded.length, 1);
+  assert.equal(recorded[0].subject.class, "tool-write");
 });
 
 // BET-1518 — the direct-store fallback is deleted: a fallback-appended
@@ -438,10 +362,8 @@ test("verdictHeld without a verdict route degrades — no direct-store append", 
   const sug = createCtoSuggest({
     ledger: { append: async () => true, read: async () => rows },
     engineState: { load: async () => ({ v: 1 }), save: async () => {} },
-    verdicts: verdictsStore,
     now: () => 1_000,
     publish: () => {},
-    configGet: async () => ({}),
     recordVerdict: null, // unwired route
   });
   const r = await sug.verdictHeld({ id: "held-9", verdict: "accept" });
@@ -451,420 +373,37 @@ test("verdictHeld without a verdict route degrades — no direct-store append", 
   assert.equal((after.entries ?? []).length, 0, "no direct-store append behind the route's back");
 });
 
-test("verdictHeld stamps the held row's class onto the subject (§9.5 attribution)", async () => {
-  const h = makeSug({
-    runSuggest: async () => ({ text: oneCandidateSuggestText("start-job", "a") }),
-    runWorthiness: async () => ({ text: "0.1" }), // p below p_ask → silent-log (a HELD row)
-  });
-  await h.sug.processFinding(
-    { id: "rec:h1", sourceKind: "fact-anomaly", text: "a", refs: [] },
-    { tier: "medium" }
-  );
-  const sid = stableSuggestionId("rec:h1", "start-job");
-  const recorded = [];
-  const sug2 = h.build({
-    recordVerdict: async ({ subject, verdict }) => {
-      recorded.push({ subject, verdict });
-      return { ok: true };
-    },
-  });
-  await sug2.verdictHeld({ id: sid, verdict: "accept" });
-  assert.equal(recorded.length, 1);
-  assert.equal(recorded[0].subject.class, "start-job");
-});
-
-test("collectFindings: combines digest + fact sources", () => {
-  const digests = [
-    { items: [{ tier: "failure", text: "F" }, { tier: "failure", text: "F" }] },
-  ];
-  const facts = [{ id: "f", kind: "anomaly", statement: "A" }];
-  const out = collectFindings(digests, facts, { nowMs: Date.now() });
-  assert.equal(out.length, 2);
-});
-
 // ---------------------------------------------------------------------------
-// §9.1 review Block 1 — decision-card reachability under PRODUCTION wiring
+// BET-1520 regression: the deleted surface-path symbols are gone. Findings
+// surface ONLY through the shared triage → gate pipeline now.
 // ---------------------------------------------------------------------------
 
-test("production wiring can surface a decision card: reliability 1.0 × prior 0.6 ≥ p_ask 0.48", async () => {
-  // Mirror the SHIPPED index.mjs constants: reliability 1.0 (trusted internal
-  // sender), default class priors (max 0.6 record-decision), no engine-state
-  // override → the BET-1471 per-class thresholds (record-decision p_ask 0.48
-  // = 0.8 × the 0.6 ceiling), Medium tier — the harness defaults ARE that
-  // wiring; only the generator + worthiness seams are per-test.
-  const h = makeSug({
-    runSuggest: async () => ({ text: oneCandidateSuggestText("record-decision", "Adopt pact") }),
-    runWorthiness: async () => ({ text: "1.0" }), // max-worthiness candidate
-  });
-  const r = await h.sug.processFinding({ id: "rec:r", sourceKind: "fact-anomaly", text: "r", refs: [] }, { tier: "medium" });
-  // p = 1.0 × 0.6 × 1.0 = 0.6 ≥ p_ask 0.48 → surfaces; the gate asks (fresh
-  // class 0.5 → effective 0.3 < τ 0.7), never silent-log.
-  assert.equal(r.surfaced, 1);
-  assert.equal(h.cardPayload.cards.length, 1);
-  assert.equal(h.cardPayload.cards[0].variant, "decision");
-});
-
-// BET-1471 regression: queue-tonight's ceiling (prior 0.35) sat below the old
-// global p_ask 0.4, so the class was silent-log at ANY score. Its per-class
-// bar (0.28 = 0.8 × 0.35) makes a max-worthiness candidate surface.
-test("queue-tonight is no longer a dead class: score-1.0 candidate surfaces a card", async () => {
-  const h = makeSug({
-    configGet: async () => ({ ctoTier: "high" }),
-    capabilities: { queueTonight: true, toolWrite: true }, // SHIPPED values in index.mjs
-    runSuggest: async () => ({ text: oneCandidateSuggestText("queue-tonight", "Queue the maintenance window") }),
-    runWorthiness: async () => ({ text: "1.0" }), // max-worthiness candidate
-  });
-  const r = await h.sug.processFinding({ id: "rec:q", sourceKind: "fact-anomaly", text: "q", refs: [] }, { tier: "high" });
-  // p = 1.0 × 0.35 × 1.0 = 0.35 ≥ p_ask 0.28 → decision card. Under the old
-  // global bar (0.4) this exact candidate was silent-log at every score.
-  assert.equal(r.surfaced, 1);
-  assert.equal(r.silent, 0);
-  assert.equal(h.cardPayload.cards.length, 1);
-  assert.equal(h.cardPayload.cards[0].variant, "decision");
-  assert.ok(h.ledgerRows.every((x) => x.kind !== "suggest.silent"));
-});
-
-// BET-1518 reachability: for each class, p at the ceiling reaches the act
-// verb through a fully-calibrated class (calibration → 1.0 over its outcome
-// window), surfaces the ask card on a fresh class, and stays silent below
-// the class's p_ask floor. No tiers, no eligibility map — the class list is
-// the §9.2 enum itself, and the τ dial is lowered to 0.3 (the default 0.7
-// exceeds the low-prior classes' ceilings by design: they ask until the user
-// turns the dial down).
-test("act verb is arithmetically reachable through calibration, not tiers", () => {
-  const classes = { "record-decision": 0.6, "queue-tonight": 0.35, "start-job": 0.4 };
-  for (const [cls, ceiling] of Object.entries(classes)) {
-    // τ dialed to the class's ceiling: a calibrated class reaches the act verb
-    const acted = evaluateGate({ plans: [{ id: "p", class: cls, confidence: ceiling }], tau: ceiling, calibration: { [cls]: 1.0 } });
-    assert.equal(acted.verb, "act", `${cls}: p at the ceiling with full calibration must reach the act verb`);
-    // the same p on a fresh class → ask card (0.5 × ceiling < ceiling)
-    const asked = evaluateGate({ plans: [{ id: "p", class: cls, confidence: ceiling }], tau: ceiling, calibration: { [cls]: 0.5 } });
-    assert.equal(asked.verb, "ask", `${cls}: p at the ceiling on a fresh class must surface the ask card`);
-    // just below the class's p_ask floor → silent-log (handled in processFinding)
-    const pAsk = defaultThresholds()[cls].p_ask;
-    assert.ok(pAsk > 0 && pAsk < ceiling, `${cls}: the floor sits inside the class's ceiling`);
-  }
-});
-
-// ---------------------------------------------------------------------------
-// BET-1518 — the gate in the pipeline (§9.3/§9.5): act vs ask on
-// effective = p × calibration ≥ τ; refusal degrades to the ask card; notify
-// is a delivery property of ask.
-// ---------------------------------------------------------------------------
-
-test("pipeline: ask verb surfaces the decision card with the effective score (never a veto card)", async () => {
-  // Fresh calibration (0.5) × p 1.0 = 0.5 < τ 0.7 → ask. The veto-window
-  // verb is deleted: even with a veto writer on the harness, no veto card
-  // may be written.
-  const vetoCards = [];
-  const h = makeSug({
-    vetoSink: vetoCards,
-    runSuggest: async () => ({ text: oneCandidateSuggestText("record-decision", "a") }),
-  });
-  const r = await h.sug.processFinding({ id: "rec:vd", sourceKind: "fact-anomaly", text: "a", refs: [] }, { tier: "medium" });
-  assert.equal(r.surfaced, 1);
-  assert.equal(h.cardPayload.cards.length, 1);
-  assert.equal(h.cardPayload.cards[0].variant, "decision");
-  assert.equal(vetoCards.length, 0);
-  assert.ok(h.ledgerRows.some((x) => x.kind === "suggest.presented" && x.variant === "decision"));
-});
-
-test("pipeline: calibrated class + p ≥ τ acts, ledgers, and queues the digest report", async () => {
-  const executed = [];
-  const h = makeSug({
-    calibration: async (cls) => (cls === "record-decision" ? 1.0 : 0.5),
-    tau: 0.7,
-    executeAction: async ({ cls, action }) => {
-      executed.push({ cls, action });
-      return { ok: true };
-    },
-    runSuggest: async () => ({ text: oneCandidateSuggestText("record-decision", "Adopt pact", ["msg:1"]) }),
-    runWorthiness: async () => ({ text: "1.0" }), // p = 1.0 × 1.0 (prior override) ≥ τ → act
-    classPriors: { "record-decision": 1.0 },
-  });
-  const r = await h.sug.processFinding({ id: "rec:aa", sourceKind: "fact-anomaly", text: "a", refs: [] }, { tier: "medium" });
-  assert.equal(r.surfaced, 1);
-  assert.equal(executed.length, 1);
-  assert.equal(executed[0].action.type, "record-decision");
-  assert.equal(h.cardPayload.cards.length, 0); // no card — it acted
-  assert.ok(h.ledgerRows.some((x) => x.kind === "suggest.acted" && x.class === "record-decision"));
-  // The mandatory report (§9.2 invariant 1) is queued for the next digest.
-  assert.equal(h.acts.length, 1);
-  assert.equal(h.acts[0].cls, "record-decision");
-});
-
-test("pipeline: act-refused action degrades to the ask card (never silently acts, never a veto card)", async () => {
-  const h = makeSug({
-    calibration: async (cls) => (cls === "start-job" ? 1.0 : 0.5),
-    runSuggest: async () => ({ text: oneCandidateSuggestText("start-job", "a") }),
-    runWorthiness: async () => ({ text: "1.0" }),
-    classPriors: { "start-job": 1.0 },
-    // executeAction stays unwired for this class → refuse
-  });
-  const r = await h.sug.processFinding({ id: "rec:de", sourceKind: "fact-anomaly", text: "a", refs: [] }, { tier: "medium" });
-  assert.equal(r.surfaced, 1);
-  assert.equal(h.cardPayload.cards.length, 1); // degraded to the ask card
-  assert.equal(h.cardPayload.cards[0].variant, "decision");
-  assert.equal(h.ledgerRows.filter((x) => x.kind === "suggest.acted").length, 0);
-  assert.equal(h.acts.length, 0);
-});
-
-test("pipeline: below the class's p_ask stays silent even when calibration would act", async () => {
-  const executed = [];
-  const h = makeSug({
-    calibration: 1.0,
-    runSuggest: async () => ({ text: oneCandidateSuggestText("config-change", "a") }),
-    runWorthiness: async () => ({ text: "0.35" }), // p = 0.35 < config-change p_ask 0.4
-    classPriors: { "config-change": 1.0 },
-    executeAction: async () => { executed.push(1); return { ok: true }; },
-  });
-  const r = await h.sug.processFinding({ id: "rec:cc", sourceKind: "fact-anomaly", text: "a", refs: [] }, { tier: "medium" });
-  assert.equal(r.surfaced, 0);
-  assert.equal(r.silent, 1);
-  assert.equal(executed.length, 0);
-  assert.equal(h.cardPayload.cards.length, 0);
-});
-
-test("pipeline: no special-casing — a config-change plan acts through the same gate", async () => {
-  const executed = [];
-  const h = makeSug({
-    calibration: 1.0,
-    tau: 0.5,
-    executeAction: async ({ cls, action }) => {
-      executed.push({ cls, action });
-      return { ok: true };
-    },
-    runSuggest: async () => ({ text: oneCandidateSuggestText("config-change", "a") }),
-    runWorthiness: async () => ({ text: "1.0" }),
-    classPriors: { "config-change": 1.0 },
-  });
-  const r = await h.sug.processFinding({ id: "rec:noSpecial", sourceKind: "fact-anomaly", text: "a", refs: [] }, { tier: "medium" });
-  assert.equal(r.surfaced, 1);
-  assert.equal(executed.length, 1);
-  assert.equal(executed[0].cls, "config-change");
-});
-
-// ---------------------------------------------------------------------------
-// BET-1465 — usedKeys dedupe (defect 1) + distinct notify tag (defect 2)
-// ---------------------------------------------------------------------------
-
-test("dedupe: a second runPass over the same findings makes no new model calls, ledger rows, or notifies", async () => {
-  let suggestCalls = 0;
-  let worthinessCalls = 0;
-  const digestList = [
-    { generated: 1, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c1"] }] },
-    { generated: 2, items: [{ tier: "failure", text: "Pipeline red on main", refs: ["c2"] }] },
-  ];
-  const h = makeSug({
-    thresholds: { p_ask: 0.2, p_act: 0.95 },
-    digests: { list: async () => ["d1", "d2"], load: async (id) => (id === "d1" ? digestList[0] : digestList[1]) },
-    runSuggest: async () => {
-      suggestCalls += 1;
-      return { text: oneCandidateSuggestText("start-job", "Restart the stuck build", ["c1"]) };
-    },
-    runWorthiness: async () => {
-      worthinessCalls += 1;
-      return { text: "0.9" };
-    },
-  });
-
-  const r1 = await h.sug.runPass({ nowMs: h.clock.ms });
-  assert.equal(r1.findings, 1);
-  assert.equal(r1.surfaced, 1);
-  assert.equal(suggestCalls, 1);
-  assert.equal(worthinessCalls, 1);
-  assert.equal(h.ledgerRows.length, 1);
-  assert.equal(h.notified.length, 1); // failure-recurrence → notify
-
-  h.clock.ms += 30 * 60_000; // simulate the next 30-minute pass over the SAME retained digests
-  const r2 = await h.sug.runPass({ nowMs: h.clock.ms });
-  assert.equal(r2.findings, 1); // the finding is still collected (source retained)
-  assert.equal(r2.surfaced, 0);
-  assert.equal(r2.silent, 0);
-  assert.equal(suggestCalls, 1, "no new suggest model call");
-  assert.equal(worthinessCalls, 1, "no new worthiness model call");
-  assert.equal(h.ledgerRows.length, 1, "no new ledger row");
-  assert.equal(h.notified.length, 1, "no new fireNotify");
-});
-
-test("usedKeys cap: exactly-at-cap holds every entry; the 201st evicts the OLDEST and preserves the MRU tail", async () => {
-  // Seed one short of the cap, then fill to exactly 200 through the real
-  // processFinding → markUsed append path.
-  const h = makeSug({
-    engineState: { v: 1, suggest: { usedKeys: Array.from({ length: 199 }, (_, i) => `old-${i}`) } },
-  });
-  const process = (id) =>
-    h.sug.processFinding({ id, sourceKind: "fact-anomaly", text: "x", refs: [] }, { tier: "medium" });
-
-  // At-cap state: the 200th distinct key lands with NO eviction.
-  await process("rec:fill");
-  let used = h.getEs().suggest.usedKeys;
-  assert.equal(used.length, 200);
-  assert.equal(used[0], "old-0", "nothing evicted while filling to exactly the cap");
-  assert.equal(used[199], "rec:fill", "the newest key sits at the tail");
-
-  // One past the cap: the 201st distinct key evicts exactly one entry —
-  // the OLDEST (front), not the newest being dropped. Trailing-slice FIFO
-  // is the chosen rule (documented idiom shared with ctoBudget.mjs).
-  await process("rec:over");
-  used = h.getEs().suggest.usedKeys;
-  assert.equal(used.length, 200, "the cap holds: length never exceeds 200");
-  assert.ok(!used.includes("old-0"), "the 201st key evicts the OLDEST entry");
-  assert.ok(used.includes("rec:over"), "the newest key is kept, not dropped");
-
-  // The surviving keys are exactly the expected ones, in order —
-  // old-1..old-198 (198 entries) plus the two appends at the tail (MRU preserved).
-  assert.deepEqual(used, [
-    ...Array.from({ length: 198 }, (_, i) => `old-${i + 1}`),
-    "rec:fill",
-    "rec:over",
-  ]);
-});
-
-test("notify: fireNotify carries a distinct, non-global tag per candidate WITHOUT synthesizing a sessionID (defect 2, review fix)", async () => {
-  const notified = [];
-  const fireNotify = async (args) => notified.push(args);
-  const a = makeSug({ runSuggest: async () => ({ text: oneCandidateSuggestText("start-job", "A") }), fireNotify });
-  const b = makeSug({ runSuggest: async () => ({ text: oneCandidateSuggestText("start-job", "B") }), fireNotify });
-  await a.sug.processFinding({ id: "rec:a", sourceKind: "failure-recurrence", text: "A", refs: [] }, { tier: "medium" });
-  await b.sug.processFinding({ id: "rec:b", sourceKind: "failure-recurrence", text: "B", refs: [] }, { tier: "medium" });
-  assert.equal(notified.length, 2);
-  // push.mjs's `tag` override (added for this fix) is the caller-supplied
-  // identifier — a present, per-candidate tag is what keeps two unrelated
-  // CTO suggestions (and every other session-less AI `notify` call) from
-  // colliding on the shared "notify-global" tag. `sessionID` is a real,
-  // load-bearing field that deep-links a phone tap — it must stay unset here,
-  // never synthesized just to influence the tag (that was the reviewer Block).
-  assert.ok(notified[0].tag, "tag must be present — omission degrades to the shared notify-global tag");
-  assert.ok(notified[1].tag);
-  assert.notEqual(notified[0].tag, notified[1].tag);
-  assert.doesNotMatch(String(notified[0].tag), /^global$/);
-  assert.equal(notified[0].sessionID, undefined);
-  assert.equal(notified[1].sessionID, undefined);
-});
-
-test("fireNotify is gated on the card write's isNew: a re-upserted (not new) card never re-pushes", async () => {
-  const h = makeSug({
-    cards: { upsertDecision: async () => ({ changed: true, isNew: false }) }, // upsert of a card already on the board
-    runSuggest: async () => ({ text: oneCandidateSuggestText("start-job", "again") }),
-  });
-  const r = await h.sug.processFinding({ id: "rec:re", sourceKind: "failure-recurrence", text: "again", refs: [] }, { tier: "medium" });
-  assert.equal(r.surfaced, 1); // the card write still counts as surfaced
-  assert.equal(h.notified.length, 0); // but never re-pushes a not-new card
-});
-
-// ---------------------------------------------------------------------------
-// BET-1465 review, Block 1 — a gated or failed generation must NOT
-// permanently mark the finding used. The §3.3 ephemeral gate refuses by
-// RETURNING {ok:false}, not by throwing, so a budget-closed pass looked
-// exactly like "the generator ran and said zero candidates" before this fix.
-// ---------------------------------------------------------------------------
-
-test("a gated generation ({ok:false}) does not mark the finding used — it's reconsidered next pass", async () => {
-  let calls = 0;
-  const h = makeSug({
-    thresholds: { p_ask: 0.2, p_act: 0.95 },
-    runSuggest: async () => {
-      calls += 1;
-      // §3.3 ephemeral gate refusal shape (index.mjs gatedSuggestionEphemeral)
-      return calls === 1 ? { ok: false, gated: true, error: "budget-closed" } : { text: oneCandidateSuggestText("start-job", "recovered") };
-    },
-  });
-  const finding = { id: "rec:gated", sourceKind: "failure-recurrence", text: "x", refs: [] };
-  const r1 = await h.sug.processFinding(finding, { tier: "medium" });
-  assert.equal(r1.surfaced, 0);
-  assert.equal(r1.silent, 0);
-  assert.ok(!(h.getEs().suggest?.usedKeys || []).includes("rec:gated"), "gated pass must not mark used");
-
-  const r2 = await h.sug.processFinding(finding, { tier: "medium" });
-  assert.equal(calls, 2, "the generator ran again next pass — not permanently suppressed");
-  assert.equal(r2.surfaced, 1, "the finding is reconsidered and surfaces once budget frees up");
-});
-
-test("a throwing / unparseable generation does not mark the finding used", async () => {
-  const throwing = makeSug({
-    runSuggest: async () => {
-      throw new Error("model timeout");
-    },
-  });
-  await throwing.sug.processFinding({ id: "rec:throws", sourceKind: "fact-anomaly", text: "x", refs: [] }, { tier: "medium" });
-  assert.ok(!(throwing.getEs().suggest?.usedKeys || []).includes("rec:throws"));
-
-  const garbage = makeSug({ runSuggest: async () => ({ text: "not json at all" }) });
-  await garbage.sug.processFinding({ id: "rec:garbage", sourceKind: "fact-anomaly", text: "x", refs: [] }, { tier: "medium" });
-  assert.ok(!(garbage.getEs().suggest?.usedKeys || []).includes("rec:garbage"));
-});
-
-test("a generator that legitimately returns zero candidates (valid empty JSON) IS marked used", async () => {
-  const h = makeSug(); // the default generator returns valid empty JSON
-  await h.sug.processFinding({ id: "rec:empty", sourceKind: "fact-anomaly", text: "x", refs: [] }, { tier: "medium" });
-  assert.ok((h.getEs().suggest?.usedKeys || []).includes("rec:empty"));
-});
-
-// ---------------------------------------------------------------------------
-// BET-1477 — a byte-identical regeneration of an unchanged candidate is
-// "already surfaced, still current" (surfaced), never a suggest.silent
-// no-card-path hold, and never a veto→decision verb downgrade.
-//
-// These tests pin the whole chain through the REAL card manager
-// (createCtoCards over the harness's fake stores) — the BET-1463
-// byte-identical no-op return in ctoCards.mjs AND the BET-1477 branch in
-// ctoSuggest.mjs, not just a fake writer's return shape.
-// ---------------------------------------------------------------------------
-
-function makeRegenSug(extra = {}) {
-  return makeSug({
-    thresholds: { p_ask: 0.2, p_act: 0.95 },
-    runWorthiness: async () => ({ text: "0.6" }),
-    buildCards: ({ boardStore, ledger, engineState, now }) =>
-      createCtoCards({ cardStore: boardStore, ledger, engineState, now }),
-    ...extra,
-  });
-}
-
-test("BET-1477: a byte-identical decision regeneration counts as surfaced, not silent (no-card-path)", async () => {
-  const h = makeRegenSug({
-    runSuggest: async () => ({ text: oneCandidateSuggestText("config-change", "Tighten the cache TTL", ["c1"]) }),
-  });
-  const finding = { id: "rec:regen-d", sourceKind: "fact-anomaly", text: "Tighten the cache TTL", refs: ["c1"] };
-
-  const r1 = await h.sug.processFinding(finding, { tier: "medium" });
-  assert.equal(r1.surfaced, 1);
-  assert.equal(r1.silent, 0);
-  const firstWriteAt = h.cardPayload.cards[0].updatedAt;
-  const presentedRows = h.ledgerRows.filter((r) => r.kind === "suggest.presented").length;
-
-  // Next pass: the dedupe marker was evicted (cap churn / engine-state
-  // reset), the generator regenerates the SAME candidate — the card content
-  // is byte-identical, only the write timestamp differs (excluded from
-  // cardContentEqual). This must count as surfaced, not as a no-card-path
-  // hold.
-  h.clock.ms += 30 * 60_000;
-  h.resetEs();
-  const r2 = await h.sug.processFinding(finding, { tier: "medium" });
-  assert.equal(r2.surfaced, 1, "unchanged card is already on the board and current → surfaced");
-  assert.equal(r2.silent, 0);
-  assert.ok(!h.ledgerRows.some((r) => r.kind === "suggest.silent" && r.reason === "no-card-path"), "no suggest.silent(no-card-path) miscount");
-  assert.equal(h.ledgerRows.filter((r) => r.kind === "suggest.presented").length, presentedRows, "no second presented row — no ledger noise");
-  assert.equal(h.cardPayload.cards.filter((c) => c.state === "open").length, 1, "never duplicated");
-  assert.equal(h.cardPayload.cards[0].updatedAt, firstWriteAt, "byte-identical no-op did not rewrite the card");
-});
-
-test("BET-1477: a thrown, missing, or explicitly-refused (ok:false) decision-card write still holds as suggest.silent(no-card-path)", async () => {
-  for (const [label, cardsDep] of [
-    ["throw", { upsertDecision: async () => { throw new Error("card store boom"); } }],
-    ["missing-method", {}],
-    ["ok:false", { upsertDecision: async () => ({ ok: false, changed: false, isNew: false }) }],
+test("deleted symbols: no generator/worthiness/verb surface on the module or engine", async () => {
+  for (const sym of [
+    "worthinessProbability",
+    "DEFAULT_CLASS_PRIORS",
+    "defaultThresholds",
+    "parseWorthinessScore",
+    "buildSuggestContext",
+    "buildWorthinessContext",
+    "parseSuggestionText",
+    "normalizeCandidates",
+    "validateCandidate",
+    "validateOption",
+    "filterOptionsByData",
+    "NOTIFY_RECURRENCE_KINDS",
+    "ACTION_TYPES",
+    "SUGGEST_VERSION",
+    "processFinding",
   ]) {
-    const h = makeSug({
-      thresholds: { p_ask: 0.2, p_act: 0.95 },
-      cards: cardsDep,
-      runSuggest: async () => ({ text: oneCandidateSuggestText("config-change", "x") }),
-      runWorthiness: async () => ({ text: "0.6" }),
-    });
-    const r = await h.sug.processFinding({ id: `rec:fail-${label}`, sourceKind: "fact-anomaly", text: "x", refs: [] }, { tier: "medium" });
-    assert.equal(r.surfaced, 0, `${label}: no surfaced count without a card`);
-    assert.equal(r.silent, 1, `${label}: held instead`);
-    assert.ok(h.ledgerRows.some((x) => x.kind === "suggest.silent" && x.reason === "no-card-path"), `${label}: the hold reason is preserved`);
+    assert.equal(sym in suggestModule, false, `${sym} must be deleted from ctoSuggest.mjs`);
+  }
+  // ... and the surviving engine surface is the new one.
+  const eng = suggestModule.createCtoSuggest({});
+  assert.equal(typeof eng.runPass, "function");
+  assert.equal(typeof eng.listHeld, "function");
+  assert.equal(typeof eng.verdictHeld, "function");
+  for (const sym of ["processFinding", "getThresholds", "_priors", "_filterOptionsByData"]) {
+    assert.equal(sym in eng, false, `${sym} must be deleted from the engine surface`);
   }
 });

--- a/src/server/ctoTriage.mjs
+++ b/src/server/ctoTriage.mjs
@@ -30,7 +30,9 @@ import {
 import { sha, stableSuggestionId } from "./ctoSuggest.mjs";
 // The producer→ledger-kind mapping shared with the engine's drain (one pure
 // place, so the triage prompt's kind label cannot drift from the evidence row).
-import { findingLedgerKind } from "./ctoCards.mjs";
+// SUGGEST_FINDING_SOURCE: the fourth producer's row discriminator (BET-1520) —
+// findingIdOf keys on it and sourceFindingCopy passes it through verbatim.
+import { findingLedgerKind, SUGGEST_FINDING_SOURCE } from "./ctoCards.mjs";
 
 export const TRIAGE_VERSION = 1;
 
@@ -76,7 +78,10 @@ export const PLAN_RECORDS_CAP = 100;
  * re-report of the same condition (content-keyed, not noteId-keyed — a
  * restated blocker is the same finding per §9.2's regenerations-UPDATE rule).
  * Inbox rows are content-keyed like the inbox card's group key (tag, title,
- * message, liveness condition); ask rows key on their stable sourceId.
+ * message, liveness condition); ask rows key on their stable sourceId;
+ * suggest rows (BET-1520) key on the collector's own stable content id
+ * (sourceId: `rec:*` / `anom:*` / `wh:*`) — a re-collected identical finding
+ * keeps one finding id, so plan upserts converge.
  * Returns null for garbage input.
  */
 export function findingIdOf(finding) {
@@ -85,6 +90,10 @@ export function findingIdOf(finding) {
   if (finding.source === "ask") {
     const sourceId = typeof finding.sourceId === "string" ? finding.sourceId : "";
     return `find:ask:${sha(`${finding.sourceKind ?? ""}\u0000${sourceId}\u0000${message}`)}`;
+  }
+  if (finding.source === SUGGEST_FINDING_SOURCE) {
+    const sourceId = typeof finding.sourceId === "string" ? finding.sourceId : "";
+    return `find:suggest:${sha(`${finding.sourceKind ?? ""}\u0000${sourceId}\u0000${message}`)}`;
   }
   const tag = typeof finding.tag === "string" ? finding.tag : "";
   const title = typeof finding.title === "string" ? finding.title : "";
@@ -330,10 +339,16 @@ export function buildTriageContext(finding, ctx = {}) {
 }
 
 // Verbatim source fields worth carrying into the plans store (the gate/card
-// render from these; content stays untrusted data).
+// render from these; content stays untrusted data). The `suggest` source
+// passes through verbatim — it must reach the executor as non-blocker so the
+// §9.4 presence rule gates it, and it keeps the plans store's provenance honest.
 function sourceFindingCopy(finding) {
+  const source = finding?.source;
   return {
-    source: BLOCKER_FINDING_SOURCES.has(finding?.source) ? finding.source : "inbox",
+    source:
+      BLOCKER_FINDING_SOURCES.has(source) || source === SUGGEST_FINDING_SOURCE
+        ? source
+        : "inbox",
     sourceKind: typeof finding?.sourceKind === "string" ? finding.sourceKind : undefined,
     noteKind: typeof finding?.noteKind === "string" ? finding.noteKind : undefined,
     sourceId: typeof finding?.sourceId === "string" ? finding.sourceId : undefined,

--- a/src/server/ctoTriage.test.mjs
+++ b/src/server/ctoTriage.test.mjs
@@ -227,6 +227,11 @@ test("buildTriageContext kind label spans all §9.1 producers (shared findingLed
     "health.blocker",
     "health escalations are not mislabeled as inbox rows",
   );
+  assert.equal(
+    labelOf({ source: "suggest", sourceKind: "failure-recurrence", sourceId: "rec:x", message: "m" }),
+    "suggest.failure-recurrence",
+    "BET-1520: the fourth producer's kind label spans the suggest source",
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -296,6 +301,12 @@ test("triageFinding: every §9.1 source stamps its true source on the stored rec
   });
   await triage.triageFinding({ source: "ask", sourceKind: "permission", sourceId: "perm_1", message: "m" }, {});
   await triage.triageFinding({ source: "health", sourceKind: "health", sourceId: "h1", message: "watchdog tripped" }, {});
+  // BET-1520: the fourth producer's source passes through verbatim — it must
+  // reach the executor as NON-blocker so the §9.4 presence rule gates it.
+  await triage.triageFinding(
+    { source: "suggest", sourceKind: "failure-recurrence", sourceId: "rec:x", message: "Pipeline red on main" },
+    {},
+  );
   const records = (await plans.load()).records;
   assert.equal(records[findingIdOf({ source: "ask", sourceKind: "permission", sourceId: "perm_1", message: "m" })].finding.source, "ask");
   assert.equal(
@@ -303,6 +314,10 @@ test("triageFinding: every §9.1 source stamps its true source on the stored rec
     "health",
     "health rows are not mis-stamped as inbox",
   );
+  const rec = records[findingIdOf({ source: "suggest", sourceKind: "failure-recurrence", sourceId: "rec:x", message: "Pipeline red on main" })];
+  assert.equal(rec.finding.source, "suggest", "suggest rows are not mis-stamped as inbox");
+  assert.equal(rec.finding.sourceKind, "failure-recurrence");
+  assert.equal(rec.finding.message, "Pipeline red on main");
 });
 
 test("triageFinding: gated/error model call persists NOTHING (the finding is already in evidence)", async () => {

--- a/src/server/ctoWatchers.test.mjs
+++ b/src/server/ctoWatchers.test.mjs
@@ -37,7 +37,7 @@ import {
   createStandingQueryEngine,
 } from "./ctoWatchers.mjs";
 import { RETENTION_MS } from "./ctoStores.mjs";
-import { NOTIFY_RECURRENCE_KINDS, collectFindings } from "./ctoSuggest.mjs";
+import { collectFindings } from "./ctoSuggest.mjs";
 
 function makeEngineDeps(overrides = {}) {
   const state = { watchers: [] };
@@ -414,9 +414,20 @@ test("an evidence event's project rides the hit into the ledger (BET-1428)", asy
   assert.equal(hit.project, "/repo", "the hosting project is captured at hit time");
 });
 
-test("the steep-decay notify rule set gained watcher-hit-rate", () => {
-  assert.ok(NOTIFY_RECURRENCE_KINDS.includes("watcher-hit-rate"));
-  assert.ok(NOTIFY_RECURRENCE_KINDS.includes("failure-recurrence"));
+// BET-1520: the steep-decay notify enum is retired with the suggest flow's
+// bespoke surface path — what survives is the sourceKind mapping.
+test("the collector maps a rate-threshold watcher hit to the watcher-hit-rate sourceKind", async () => {
+  const ledgerRows = [
+    { kind: "watcher.hit", salience: "high", watcherId: "w-rate", predicateKind: RATE_THRESHOLD, text: "burst trip", ts: 1 },
+  ];
+  const findings = collectFindings([], [], { ledgerRows });
+  assert.ok(findings.some((f) => f.sourceKind === "watcher-hit-rate" && f.text.includes("burst trip")));
+  const plain = collectFindings([], [], {
+    ledgerRows: [
+      { kind: "watcher.hit", salience: "high", watcherId: "w-plain", predicateKind: EVENT_PATTERN, text: "theme match", ts: 2 },
+    ],
+  });
+  assert.ok(plain.some((f) => f.sourceKind === "watcher-hit" && f.text.includes("theme match")));
 });
 
 test("collectFindings wires watcher hits into the candidate source input set", () => {

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -2459,14 +2459,10 @@ let adaptiveCtoDigest = null;
   adaptiveCtoDigest.start();
 }
 
-// BET-1392 suggestion engine (A10, §9.1 + §14.3): the worthiness-gated
-// suggestion pipeline. P2 sources = digest-detected recurrences + fact
-// anomalies (watcher hits arrive in a later issue). Runs only at Medium/High
-// tier (§12.1 — Low tier is "no suggestions"). Model spend goes through the
-// §3.3 ephemeral rate gate (gatedSuggestionEphemeral), the SAME as
-// digest-compose; worthiness is nano tier, the generator mid tier.
-// Notifications, when the steep-decay rule matches, go through the
-// informational router (fireNotify).
+// §3.3 ephemeral rate gate for the engine's mid-tier model classes — the
+// digest compose, the tool-registry scans and (since BET-1520) nothing in
+// the suggest flow, whose findings enqueue without a model call of their own
+// (the spend rides the shared triage/gate classes).
 async function gatedSuggestionEphemeral(taskClass, opts) {
   const gate = await adaptiveCto.beginEphemeral();
   if (!gate?.ok) return { ok: false, gated: true, error: gate?.error };
@@ -2483,58 +2479,29 @@ async function gatedSuggestionEphemeral(taskClass, opts) {
   }
 }
 // BET-1424's per-class act executors (record-decision / queue-tonight /
-// start-job branches) are RETIRED with this issue: ctoAct.mjs is the ONE
-// generic §9.4 plan executor now. The suggest flow's act verb (never fires —
-// executeAction is unwired) degrades to the ask card, where the bound options
-// remain user-executable through the renderer's ask path; blockers and
-// suggestions converge on the triage → plan → gate pipeline (D22).
+// start-job branches) are RETIRED (BET-1519), and BET-1520 retires the
+// suggest flow's own generator/worthiness/verb machinery with them:
+// ctoAct.mjs is the ONE generic §9.4 plan executor, and collected findings
+// surface only through the shared triage → plan → gate pipeline (D22).
 const adaptiveCtoSuggest = createCtoSuggest({
   now: () => Date.now(),
   publish: (evt) => bus.publish(evt),
   ledger: ledgerStore,
   engineState: engineStateStore,
-  verdicts: verdictsStore,
   digests: digestsStore,
   facts: factsStore,
-  configGet: () => local.configGet(),
-  cards: adaptiveCto.cards,
   // B3 verdict route shared with the opencode `cto_verdict` tool + the engine.
   recordVerdict: (input) => adaptiveCto.recordVerdict(input),
-  // BET-1419: the overnight queue (BET-1402 core + engine wiring in this
-  // issue) is live — queue-tonight options are now emittable at High tier.
-  // tool-write's capability gate is on too, but the §7.4 tool registry
-  // (P2-later) still feeds an empty write ring below, so a tool-write option
-  // remains data-unreachable until B7 lands (the ring is the real gate).
-  // BET-1403 → BET-1519: the suggest flow's machine act verb is RETIRED —
-  // the per-class bound executors collapsed into the ONE generic plan
-  // executor (ctoAct.mjs). executeAction stays unwired → every candidate
-  // degrades to the ask card (the human-in-the-loop fallback); its bound
-  // options stay user-executable through the renderer's ask path.
-  executeAction: null,
-  getWriteRingTools: async () => [], // §7.4 tool registry (P2-later) — empty → tool-write unreachable
-  capabilities: { queueTonight: true, toolWrite: true },
-  fireNotify: (args) => push.fireNotify(args),
-  // §9.1 sender reliability. Findings here come from the box's OWN engine
-  // (digest-detected recurrences, fact anomalies), not an external sender —
-  // a trusted internal source, so reliability approaches 1.0. With it pinned
-  // to 1.0 a candidate's p ceiling IS its class prior, and the BET-1471
-  // per-class salience floors hang off that same ceiling (p_ask = 0.8 ×
-  // prior): a score-1.0 candidate clears the floor for EVERY class
-  // (p = prior ≥ 0.8 × prior) and proceeds to the gate. Under the old global
-  // pair the ask verb could never fire for the quiet classes (§9.1 review
-  // Block 1; BET-1470). The act/ask split is the gate's effective ≥ τ, not a
-  // p_act threshold (BET-1518).
-  senderReliability: async () => 1.0,
-  // BET-1518 (§9.3/§9.5): the gate's two inputs, wired to the engine's ONE
-  // calibration instance (the same instance the verdict sink folds into, so
-  // every attribution lands in one window set), and the live τ setting
-  // (the ctoAutonomyThreshold control, default 0.7). The act branch books
-  // its digest announcement through the same engine (§9.2 invariant 1).
-  calibrationOf: async (cls) => adaptiveCto.calibration.calibration(cls),
-  tau: async () => local.configGet()?.ctoAutonomyThreshold,
-  recordAct: (input) => adaptiveCto.calibration.recordAct(input),
-  runSuggest: (opts) => gatedSuggestionEphemeral("suggest", opts),
-  runWorthiness: (opts) => gatedSuggestionEphemeral("worthiness", opts),
+  // BET-1520: collected findings enqueue on the pending-findings queue — the
+  // SAME queue inbox notes / promoted asks / health escalations ride — and
+  // flow through the ONE triage → gate → executor pipeline. The old
+  // in-module surface path (suggest generator → worthiness probability →
+  // verb → decision card / bound-action execution) is deleted; the §9.2
+  // triage call and the §9.3 gate's ask card replace it. `executeAction`
+  // stays unwired by design: candidate options execute through the ask path
+  // (the user's click), and its machine act verb degrades to the ask card
+  // when the executor declines.
+  queueFinding: (row) => adaptiveCto.queueFinding(row),
 });
 // Poller: run the suggestion pass periodically, only when suggestions are
 // enabled (Medium/High tier + ctoEnabled).

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -272,7 +272,7 @@ export type CtoCard = {
   repeatCount?: number;
   // BET-1392 decision cards (§9.1) — present only when variant === "decision".
   // `why` is the one-paragraph rationale; `options` are the bound-action
-  // buttons (closed ACTION_TYPES enum); `evidence` feeds the "evidence ▸"
+  // buttons the ask path executes; `evidence` feeds the "evidence ▸"
   // expander; `cls` is the gating action-class; `score`/`capped` surface the
   // worthiness probability + cold-start cap for the health stat.
   why?: string;


### PR DESCRIPTION
## BET-1520 — Route suggestions through the same triage→gate→executor path

Spec: docs/adaptive-cto-spec.md §9.1 (pipeline), §9.2 (triage), §9.5 (executor), §15 P4 item 5, §3.4 rule 3, §9.3.
Base: origin/main @ 9c74fc6e

### What changed

The suggest engine keeps its three P2 collectors (digest-detected failure recurrences, fact anomalies, watcher hits) and now **enqueues every collected finding on the pending-findings queue** — the same queue inbox notes, promoted asks and health escalations ride. From there the ONE engine pipeline takes over: drain → triage (§9.2, 0–3 plans; MAY output none) → gate (§9.3 act/ask) → executor (§9.4/§9.5). Net −751 lines.

**The bespoke surface path is deleted** (per the issue's DELETE list):
- the suggest generator (`runSuggest` seam, `buildSuggestContext`, `parseSuggestionText`, `normalizeCandidates`, `validateCandidate`/`validateOption`, `ACTION_TYPES`, `filterOptionsByData`)
- the worthiness step — decision: **drop entirely** (the removal-favoring option). `worthinessProbability`, `DEFAULT_CLASS_PRIORS`, `defaultThresholds`, `parseWorthinessScore`, `buildWorthinessContext`, the `runWorthiness` seam, and the `suggest.thresholds` engine-state merge are gone. Rationale: the §9.2 triage call IS the "0–3 plans or none" model step — a plan-less finding silent-logs (`suggest.silent`, still written by the gate, §14.3 audit unchanged), so a separate nano-worthiness pre-filter bought nothing but a second model call per finding. No salience floor is carried over (recurrence/anomaly strength is implicit in the finding text the triage call sees).
- `processFinding`'s verb/action machinery: bound-action execution, direct decision-card emission, the veto-window/notify branches (`NOTIFY_RECURRENCE_KINDS`, `fireNotify` dep), `senderReliability`/`classPriors`/`thresholds`/`calibrationOf`/`tau`/`recordAct`/`executeAction`/`cards`/`configGet` deps.

**Kept because it still has a distinct role:**
- the three collectors verbatim (with their stable content ids)
- the BET-1465 `es.suggest.usedKeys` dedupe — now gating *enqueue* instead of generation, so a recurring finding does not re-pay a triage model call every 30-min pass. Enqueue-then-mark ordering preserved (a failed enqueue retries next pass; a consumed key never loses a finding). Cap stays 200, trailing-slice FIFO.
- `listHeld`/`verdictHeld` (§14.3 silence audit read surface) unchanged; rows now written by the gate.

### Plumbing
- `ctoCards.mjs`: `SUGGEST_FINDING_SOURCE = "suggest"`, `findingFromSuggestion` (the fourth producer's row builder, alongside the other three), `findingLedgerKind` maps suggest rows to `suggest.<sourceKind>`.
- `ctoTriage.mjs`: `findingIdOf` gains the `find:suggest:*` derivation (keyed on the collector's stable `sourceId` — re-collected identical findings keep one finding id, so plan upserts converge); `sourceFindingCopy` passes the suggest source through verbatim so the plans store's provenance is honest and the executor sees a non-blocker.
- `ctoEngine.mjs`: exposes the `queueFinding` seam (public, next to `drainFindings`); the drain loop itself was already source-agnostic — one `cardTick` = drain → triage → gate → executor for ALL producers.
- `index.mjs`: rewires `createCtoSuggest` to the new dep set; `queueFinding: (row) => adaptiveCto.queueFinding(row)`.

### Tests (all via the sandboxed memory-store harness, `ctoTestGuard` first import)
- `ctoSuggest.test.mjs` rewritten: row-contract enqueue for the collector kinds, content-stable suggest finding ids, dedupe/retry/unwired-seam, usedKeys cap (no-eviction-at-cap + oldest-eviction + MRU tail), silence audit, and a **deleted-symbols module-contract regression** (15 symbols asserted gone).
- `ctoEngine.test.mjs`: the fourth producer's drain (`suggest.failure-recurrence` evidence row, no inbox side effects); **ONE-pipeline test** — one `cardTick` triages AND gates a suggest finding and an inbox blocker through the same drain/triage/gate calls (2 model calls, 2 plan records, 2 `gate.asked` rows, 2 ask cards); the thrifty-shed placeholder now uses the real suggest source.
- `ctoAct.test.mjs`: the post-`sourceFindingCopy` suggest shape obeys §3.4-3 (presence-gated while present) while the inbox blocker keeps the exemption.
- `ctoTriage.test.mjs` / `ctoWatchers.test.mjs`: suggest source stamping + kind-label span; retired notify-enum assertions became sourceKind mapping assertions.

### Cross-cutting notes
- **Informational push for finding asks is no longer fired** — the old steep-decay `fireNotify` variant lived in the deleted branch. §9.3 makes notify a delivery property of ask; blocker asks still push via the funnel. Filed follow-up: **BET-1527** (parked, spec-§10-amendment territory).
- `es.suggest.thresholds` persisted engine-state overrides are now inert (nothing reads them); left in place deliberately — inert data, no code path, not worth a migration.
- Legacy decision cards already on boards render through the unchanged ask path (options carry `action.type === "plan"`; renderer untouched).
